### PR TITLE
docs: fix visual workflow builder claim in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,8 +178,8 @@ const response = await axonflow.protect({
 The NewRelic of AI — prevent failures before they happen with real-time governance:
 
 ### 🔄 **Agentic Workflow Orchestration**
-- Visualise and deploy multi-step AI workflows across internal systems
-- Visual editor + code-first config (YAML/JSON/DSL)
+- Deploy multi-step AI workflows across internal systems
+- Code-first config (YAML/JSON/DSL) with programmatic API
 - Decision logic, retries, approvals, fallbacks
 - Multi-agent flows (LLM + human-in-the-loop)
 - Versioned rollouts & rollback support


### PR DESCRIPTION
## Summary
- Remove 'Visual editor' claim (feature is in roadmap as TODO, not implemented)
- Change 'Visualise and deploy' to 'Deploy' to be accurate
- Keep code-first config reference as that is implemented

## Context
Part of documentation accuracy audit before OSS launch. The README claimed visual workflow builder exists but it's listed in the roadmap as a Phase 1 TODO item.

## Test plan
- [ ] README renders correctly
- [ ] No broken links