### PR TITLE
chore: add PR template and CODEOWNERS for contributor onboarding

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,22 @@
+# CODEOWNERS - Auto-assign reviewers for pull requests
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owners for everything
+* @saurabhjain1592
+
+# Platform components
+/platform/agent/ @saurabhjain1592
+/platform/orchestrator/ @saurabhjain1592
+/platform/connectors/ @saurabhjain1592
+/platform/shared/ @saurabhjain1592
+
+# SDKs
+/sdk/ @saurabhjain1592
+
+# Documentation
+/docs/ @saurabhjain1592
+*.md @saurabhjain1592
+
+# CI/CD and infrastructure
+/.github/ @saurabhjain1592
+/migrations/ @saurabhjain1592

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,39 @@
+## Description
+
+<!-- Brief description of the changes -->
+
+## Type of Change
+
+- [ ] `feat`: New feature
+- [ ] `fix`: Bug fix
+- [ ] `docs`: Documentation update
+- [ ] `refactor`: Code refactoring
+- [ ] `test`: Adding or updating tests
+- [ ] `chore`: Build, CI/CD, or dependency updates
+
+## What Changed
+
+**Problem:**
+<!-- What problem does this PR solve? Link to issue if applicable -->
+
+**Solution:**
+<!-- How does this PR solve the problem? -->
+
+## How to Test
+
+```bash
+# Steps to test locally
+go test ./...
+```
+
+## Checklist
+
+- [ ] Code follows project style guidelines
+- [ ] Tests added/updated for new functionality
+- [ ] All tests pass locally (`go test ./...`)
+- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
+- [ ] No sensitive data (secrets, API keys) in code
+
+## Related Issues
+
+Closes #


### PR DESCRIPTION
## Summary
- Add simplified PR template for community contributors
- Add CODEOWNERS to auto-assign reviewers

## Files Added
- `.github/pull_request_template.md` - Streamlined PR checklist
- `.github/CODEOWNERS` - Auto-assigns @saurabhjain1592 to all PRs

## Test Plan
- [x] Files created and valid syntax