### PR TITLE
docs: replace internal mechanics with customer-facing features

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,9 +173,9 @@ AxonFlow is available in two editions:
 | **Advanced Features** | | |
 | Multi-Agent Planning (MAP) | ✅ YAML configs | ✅ Full |
 | Policy templates library | Basic | Full (EU AI Act, HIPAA, PCI-DSS) |
-| License validation | ❌ | ✅ |
-| AWS Marketplace integration | ❌ | ✅ |
-| Node enforcement & metering | ❌ | ✅ |
+| Customer dashboard UI | ❌ | ✅ |
+| Usage analytics & reporting | ❌ | ✅ |
+| Multi-provider LLM routing | ❌ | ✅ |
 | **Deployment** | | |
 | Docker Compose (local) | ✅ | ✅ |
 | AWS ECS/Fargate | Manual | One-click CloudFormation |


### PR DESCRIPTION
## Summary

Replace internal business mechanics with actual customer benefits in the OSS vs Enterprise comparison table.

**Before (internal mechanics - not customer value):**
- License validation
- AWS Marketplace integration  
- Node enforcement & metering

**After (customer benefits):**
- Customer dashboard UI
- Usage analytics & reporting
- Multi-provider LLM routing

These internal mechanics are documented in `technical-docs/` for engineering reference:
- `NODE_ENFORCEMENT_ARCHITECTURE.md`
- `LICENSE_ARCHITECTURE.md`
- `USAGE_METERING_ARCHITECTURE.md`
- `AWS_MARKETPLACE_METERING.md`

## Test Plan

- [x] Verify table renders correctly in GitHub README preview
- [x] No functional code changes