### PR TITLE
docs: add Community section to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -591,4 +591,10 @@ Contributors are recognized in:
 - Release notes for significant contributions
 - GitHub contributor graph
 
+## Community
+
+Join our growing community of developers building AI governance solutions:
+- [GitHub Discussions](https://github.com/getaxonflow/axonflow/discussions) - Ask questions and share ideas
+- [Issue Tracker](https://github.com/getaxonflow/axonflow/issues) - Report bugs and request features
+
 Thank you for contributing to AxonFlow!


### PR DESCRIPTION
## Summary

Adds a Community section to the CONTRIBUTING.md file with links to:
- GitHub Discussions for asking questions and sharing ideas
- Issue Tracker for reporting bugs and requesting features

This helps new contributors find the right places to engage with the community.

## Test Plan
- [x] Links are valid
- [x] Section placement makes sense (before the closing thank you)