### PR TITLE
fix(orchestrator): build ConnectionURL from options in connector install

### DIFF
--- a/platform/orchestrator/connector_marketplace_handlers_test.go
+++ b/platform/orchestrator/connector_marketplace_handlers_test.go
@@ -741,7 +741,7 @@ func TestBuildConnectionURL_Postgres(t *testing.T) {
 			want: "postgres://admin:secret123@db.example.com:5432/mydb?sslmode=disable",
 		},
 		{
-			name: "with ssl_mode",
+			name: "with ssl_mode (underscore)",
 			options: map[string]interface{}{
 				"host":     "secure.db.com",
 				"port":     float64(5432),
@@ -753,6 +753,20 @@ func TestBuildConnectionURL_Postgres(t *testing.T) {
 				"password": "pass",
 			},
 			want: "postgres://user:pass@secure.db.com:5432/proddb?sslmode=require",
+		},
+		{
+			name: "with sslmode (no underscore)",
+			options: map[string]interface{}{
+				"host":     "secure.db.com",
+				"port":     float64(5432),
+				"database": "proddb",
+				"sslmode":  "verify-full",
+			},
+			credentials: map[string]string{
+				"username": "user",
+				"password": "pass",
+			},
+			want: "postgres://user:pass@secure.db.com:5432/proddb?sslmode=verify-full",
 		},
 		{
 			name: "explicit connection_url takes precedence",
@@ -777,6 +791,52 @@ func TestBuildConnectionURL_Postgres(t *testing.T) {
 				"password": "pass",
 			},
 			want: "postgres://user:pass@localhost:5432/test?sslmode=disable",
+		},
+		{
+			name: "special characters in password - URL encoded",
+			options: map[string]interface{}{
+				"host":     "db.example.com",
+				"port":     float64(5432),
+				"database": "mydb",
+			},
+			credentials: map[string]string{
+				"username": "admin",
+				"password": "p@ss:word/123#test",
+			},
+			want: "postgres://admin:p%40ss%3Aword%2F123%23test@db.example.com:5432/mydb?sslmode=disable",
+		},
+		{
+			name: "special characters in username",
+			options: map[string]interface{}{
+				"host":     "db.example.com",
+				"database": "mydb",
+			},
+			credentials: map[string]string{
+				"username": "user@domain.com",
+				"password": "pass",
+			},
+			want: "postgres://user%40domain.com:pass@db.example.com:5432/mydb?sslmode=disable",
+		},
+		{
+			name: "nil credentials map",
+			options: map[string]interface{}{
+				"host":     "db.example.com",
+				"database": "mydb",
+			},
+			credentials: nil,
+			want:        "postgres://db.example.com:5432/mydb?sslmode=disable",
+		},
+		{
+			name:        "nil options map",
+			options:     nil,
+			credentials: map[string]string{"username": "user", "password": "pass"},
+			want:        "postgres://user:pass@localhost:5432/?sslmode=disable",
+		},
+		{
+			name:        "both nil",
+			options:     nil,
+			credentials: nil,
+			want:        "postgres://localhost:5432/?sslmode=disable",
 		},
 	}
 
@@ -818,6 +878,24 @@ func TestBuildConnectionURL_Redis(t *testing.T) {
 			credentials: map[string]string{},
 			want:        "redis://localhost:6379/0",
 		},
+		{
+			name: "special characters in password",
+			options: map[string]interface{}{
+				"host": "redis.example.com",
+				"port": float64(6379),
+				"db":   float64(0),
+			},
+			credentials: map[string]string{
+				"password": "p@ss:word/123",
+			},
+			want: "redis://:p%40ss%3Aword%2F123@redis.example.com:6379/0",
+		},
+		{
+			name:        "nil credentials",
+			options:     map[string]interface{}{"host": "localhost"},
+			credentials: nil,
+			want:        "redis://localhost:6379/0",
+		},
 	}
 
 	for _, tt := range tests {
@@ -832,90 +910,365 @@ func TestBuildConnectionURL_Redis(t *testing.T) {
 
 // Test buildConnectionURL for MySQL
 func TestBuildConnectionURL_MySQL(t *testing.T) {
-	options := map[string]interface{}{
-		"host":     "mysql.example.com",
-		"port":     float64(3306),
-		"database": "app",
-	}
-	credentials := map[string]string{
-		"username": "root",
-		"password": "secret",
+	tests := []struct {
+		name        string
+		options     map[string]interface{}
+		credentials map[string]string
+		want        string
+	}{
+		{
+			name: "full credentials",
+			options: map[string]interface{}{
+				"host":     "mysql.example.com",
+				"port":     float64(3306),
+				"database": "app",
+			},
+			credentials: map[string]string{
+				"username": "root",
+				"password": "secret",
+			},
+			want: "root:secret@tcp(mysql.example.com:3306)/app",
+		},
+		{
+			name: "special characters in password",
+			options: map[string]interface{}{
+				"host":     "mysql.example.com",
+				"port":     float64(3306),
+				"database": "app",
+			},
+			credentials: map[string]string{
+				"username": "root",
+				"password": "p@ss:word/123",
+			},
+			want: "root:p%40ss%3Aword%2F123@tcp(mysql.example.com:3306)/app",
+		},
+		{
+			name: "username only",
+			options: map[string]interface{}{
+				"host":     "mysql.example.com",
+				"database": "app",
+			},
+			credentials: map[string]string{
+				"username": "root",
+			},
+			want: "root@tcp(mysql.example.com:3306)/app",
+		},
+		{
+			name: "no credentials",
+			options: map[string]interface{}{
+				"host":     "mysql.example.com",
+				"database": "app",
+			},
+			credentials: nil,
+			want:        "tcp(mysql.example.com:3306)/app",
+		},
 	}
 
-	got := buildConnectionURL("mysql", options, credentials)
-	want := "root:secret@tcp(mysql.example.com:3306)/app"
-
-	if got != want {
-		t.Errorf("buildConnectionURL(mysql) = %q, want %q", got, want)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildConnectionURL("mysql", tt.options, tt.credentials)
+			if got != tt.want {
+				t.Errorf("buildConnectionURL() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 
 // Test buildConnectionURL for MongoDB
 func TestBuildConnectionURL_MongoDB(t *testing.T) {
-	options := map[string]interface{}{
-		"host":     "mongo.example.com",
-		"port":     float64(27017),
-		"database": "docs",
-	}
-	credentials := map[string]string{
-		"username": "mongouser",
-		"password": "mongopass",
+	tests := []struct {
+		name        string
+		options     map[string]interface{}
+		credentials map[string]string
+		want        string
+	}{
+		{
+			name: "full credentials",
+			options: map[string]interface{}{
+				"host":     "mongo.example.com",
+				"port":     float64(27017),
+				"database": "docs",
+			},
+			credentials: map[string]string{
+				"username": "mongouser",
+				"password": "mongopass",
+			},
+			want: "mongodb://mongouser:mongopass@mongo.example.com:27017/docs",
+		},
+		{
+			name: "with authSource",
+			options: map[string]interface{}{
+				"host":        "mongo.example.com",
+				"port":        float64(27017),
+				"database":    "docs",
+				"auth_source": "admin",
+			},
+			credentials: map[string]string{
+				"username": "mongouser",
+				"password": "mongopass",
+			},
+			want: "mongodb://mongouser:mongopass@mongo.example.com:27017/docs?authSource=admin",
+		},
+		{
+			name: "special characters in password",
+			options: map[string]interface{}{
+				"host":     "mongo.example.com",
+				"port":     float64(27017),
+				"database": "docs",
+			},
+			credentials: map[string]string{
+				"username": "mongouser",
+				"password": "p@ss:word/123",
+			},
+			want: "mongodb://mongouser:p%40ss%3Aword%2F123@mongo.example.com:27017/docs",
+		},
+		{
+			name: "nil credentials",
+			options: map[string]interface{}{
+				"host":     "mongo.example.com",
+				"database": "docs",
+			},
+			credentials: nil,
+			want:        "mongodb://mongo.example.com:27017/docs",
+		},
 	}
 
-	got := buildConnectionURL("mongodb", options, credentials)
-	want := "mongodb://mongouser:mongopass@mongo.example.com:27017/docs"
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildConnectionURL("mongodb", tt.options, tt.credentials)
+			if got != tt.want {
+				t.Errorf("buildConnectionURL() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
 
-	if got != want {
-		t.Errorf("buildConnectionURL(mongodb) = %q, want %q", got, want)
+// Test buildConnectionURL for Cassandra
+func TestBuildConnectionURL_Cassandra(t *testing.T) {
+	tests := []struct {
+		name        string
+		options     map[string]interface{}
+		credentials map[string]string
+		want        string
+	}{
+		{
+			name: "full credentials",
+			options: map[string]interface{}{
+				"host":     "cassandra.example.com",
+				"port":     float64(9042),
+				"keyspace": "mykeyspace",
+			},
+			credentials: map[string]string{
+				"username": "cassuser",
+				"password": "casspass",
+			},
+			want: "cassandra://cassuser:casspass@cassandra.example.com:9042/mykeyspace",
+		},
+		{
+			name: "using database as keyspace fallback",
+			options: map[string]interface{}{
+				"host":     "cassandra.example.com",
+				"port":     float64(9042),
+				"database": "fallbackkeyspace",
+			},
+			credentials: map[string]string{
+				"username": "cassuser",
+				"password": "casspass",
+			},
+			want: "cassandra://cassuser:casspass@cassandra.example.com:9042/fallbackkeyspace",
+		},
+		{
+			name: "special characters in password",
+			options: map[string]interface{}{
+				"host":     "cassandra.example.com",
+				"keyspace": "mykeyspace",
+			},
+			credentials: map[string]string{
+				"username": "cassuser",
+				"password": "p@ss:word/123",
+			},
+			want: "cassandra://cassuser:p%40ss%3Aword%2F123@cassandra.example.com:9042/mykeyspace",
+		},
+		{
+			name: "no credentials",
+			options: map[string]interface{}{
+				"host":     "cassandra.example.com",
+				"keyspace": "mykeyspace",
+			},
+			credentials: nil,
+			want:        "cassandra://cassandra.example.com:9042/mykeyspace",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildConnectionURL("cassandra", tt.options, tt.credentials)
+			if got != tt.want {
+				t.Errorf("buildConnectionURL() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 
 // Test buildConnectionURL for HTTP connector
 func TestBuildConnectionURL_HTTP(t *testing.T) {
-	options := map[string]interface{}{
-		"base_url": "https://api.example.com/v1",
+	tests := []struct {
+		name        string
+		options     map[string]interface{}
+		credentials map[string]string
+		want        string
+	}{
+		{
+			name: "with base_url",
+			options: map[string]interface{}{
+				"base_url": "https://api.example.com/v1",
+			},
+			credentials: nil,
+			want:        "https://api.example.com/v1",
+		},
+		{
+			name:        "without base_url returns empty",
+			options:     map[string]interface{}{},
+			credentials: nil,
+			want:        "",
+		},
+		{
+			name:        "nil options returns empty",
+			options:     nil,
+			credentials: nil,
+			want:        "",
+		},
 	}
 
-	got := buildConnectionURL("http", options, nil)
-	want := "https://api.example.com/v1"
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildConnectionURL("http", tt.options, tt.credentials)
+			if got != tt.want {
+				t.Errorf("buildConnectionURL() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// Test buildConnectionURL for unknown connector type
+func TestBuildConnectionURL_UnknownType(t *testing.T) {
+	options := map[string]interface{}{
+		"base_url": "https://custom.example.com",
+	}
+	got := buildConnectionURL("unknown", options, nil)
+	want := "https://custom.example.com"
 
 	if got != want {
-		t.Errorf("buildConnectionURL(http) = %q, want %q", got, want)
+		t.Errorf("buildConnectionURL(unknown) = %q, want %q", got, want)
+	}
+
+	// Without base_url, should return empty
+	got = buildConnectionURL("unknown", map[string]interface{}{}, nil)
+	if got != "" {
+		t.Errorf("buildConnectionURL(unknown) without base_url = %q, want empty", got)
 	}
 }
 
 // Test helper functions
 func TestGetStringOption(t *testing.T) {
-	options := map[string]interface{}{
-		"host":   "example.com",
-		"number": 123,
+	tests := []struct {
+		name       string
+		options    map[string]interface{}
+		key        string
+		defaultVal string
+		want       string
+	}{
+		{
+			name:       "existing key",
+			options:    map[string]interface{}{"host": "example.com"},
+			key:        "host",
+			defaultVal: "default",
+			want:       "example.com",
+		},
+		{
+			name:       "missing key",
+			options:    map[string]interface{}{"host": "example.com"},
+			key:        "missing",
+			defaultVal: "default",
+			want:       "default",
+		},
+		{
+			name:       "nil options",
+			options:    nil,
+			key:        "host",
+			defaultVal: "default",
+			want:       "default",
+		},
+		{
+			name:       "wrong type returns default",
+			options:    map[string]interface{}{"port": 5432},
+			key:        "port",
+			defaultVal: "default",
+			want:       "default",
+		},
 	}
 
-	if got := getStringOption(options, "host", "default"); got != "example.com" {
-		t.Errorf("getStringOption(host) = %q, want %q", got, "example.com")
-	}
-
-	if got := getStringOption(options, "missing", "default"); got != "default" {
-		t.Errorf("getStringOption(missing) = %q, want %q", got, "default")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getStringOption(tt.options, tt.key, tt.defaultVal)
+			if got != tt.want {
+				t.Errorf("getStringOption() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 
 func TestGetIntOption(t *testing.T) {
-	options := map[string]interface{}{
-		"float_port": float64(5432),
-		"int_port":   3306,
-		"string":     "not a number",
+	tests := []struct {
+		name       string
+		options    map[string]interface{}
+		key        string
+		defaultVal int
+		want       int
+	}{
+		{
+			name:       "float64 value (JSON)",
+			options:    map[string]interface{}{"port": float64(5432)},
+			key:        "port",
+			defaultVal: 0,
+			want:       5432,
+		},
+		{
+			name:       "int value",
+			options:    map[string]interface{}{"port": 3306},
+			key:        "port",
+			defaultVal: 0,
+			want:       3306,
+		},
+		{
+			name:       "missing key",
+			options:    map[string]interface{}{},
+			key:        "port",
+			defaultVal: 9999,
+			want:       9999,
+		},
+		{
+			name:       "nil options",
+			options:    nil,
+			key:        "port",
+			defaultVal: 9999,
+			want:       9999,
+		},
+		{
+			name:       "wrong type returns default",
+			options:    map[string]interface{}{"port": "not a number"},
+			key:        "port",
+			defaultVal: 9999,
+			want:       9999,
+		},
 	}
 
-	if got := getIntOption(options, "float_port", 0); got != 5432 {
-		t.Errorf("getIntOption(float_port) = %d, want %d", got, 5432)
-	}
-
-	if got := getIntOption(options, "int_port", 0); got != 3306 {
-		t.Errorf("getIntOption(int_port) = %d, want %d", got, 3306)
-	}
-
-	if got := getIntOption(options, "missing", 9999); got != 9999 {
-		t.Errorf("getIntOption(missing) = %d, want %d", got, 9999)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getIntOption(tt.options, tt.key, tt.defaultVal)
+			if got != tt.want {
+				t.Errorf("getIntOption() = %d, want %d", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
The `installConnectorHandler` was creating `ConnectorConfig` without setting `ConnectionURL`, causing database connectors to default to localhost (`[::1]:5432`).

## Problem
When calling `POST /api/v1/connectors/postgresql/install` with host/port/database options, the connector would fail with:
```
dial tcp [::1]:5432: connect: connection refused
```

This happened because:
1. Handler creates `base.ConnectorConfig` with `Options` and `Credentials` maps
2. Handler never sets `ConnectionURL` field
3. PostgresConnector.Connect() reads `config.ConnectionURL` which is empty
4. Empty URL defaults to localhost IPv6

## Solution
Added `buildConnectionURL()` function that constructs the proper DSN from options and credentials for each connector type:
- **postgres**: `postgres://user:pass@host:port/db?sslmode=disable`
- **mysql**: `user:pass@tcp(host:port)/db`
- **mongodb**: `mongodb://user:pass@host:port/db`
- **redis**: `redis://:pass@host:port/db`
- **cassandra**: `cassandra://user:pass@host:port/keyspace`
- **http**: Uses `base_url` from options

## Code Review Fixes (Second Commit)

All issues identified in code review have been addressed:

### 🔴 Critical: URL Encoding for Special Characters
- Passwords with `@`, `:`, `/`, `!` etc. now properly URL-encoded
- Uses `url.UserPassword()` for PostgreSQL, MongoDB, Redis, Cassandra
- Uses `url.QueryEscape()` for MySQL DSN format
- Example: `p@ss:word/123` → encoded correctly in URLs

### 🟡 Medium: Nil Map Safety
- `getStringOption()` and `getIntOption()` now handle nil options map
- `buildConnectionURL()` handles nil credentials map
- No panic risk when maps are nil

### 🟢 Minor: SSL Mode Key Support
- PostgreSQL now accepts both `ssl_mode` and `sslmode`
- Checks `ssl_mode` first, falls back to `sslmode`

### 🟢 Minor: Cassandra Connector Support
- Added `buildCassandraURL()` function
- Supports `keyspace` option with fallback to `database`
- Format: `cassandra://user:pass@host:port/keyspace`

### 🟢 Minor: MongoDB authSource Support
- Added `auth_source` option for MongoDB
- Appends `?authSource=admin` when specified

## Changes
- `platform/orchestrator/connector_marketplace_handlers.go`:
  - Add `net/url` import for proper URL encoding
  - Add `buildConnectionURL()` with proper credential encoding
  - Add dedicated builders: `buildPostgresURL`, `buildMySQLURL`, `buildMongoDBURL`, `buildRedisURL`, `buildCassandraURL`
  - Add nil-safe `getStringOption()` and `getIntOption()` helpers
  - Update `installConnectorHandler` to set `ConnectionURL`
- `platform/orchestrator/connector_marketplace_handlers_test.go`:
  - Add comprehensive tests (37 test cases total)
  - Test special characters in passwords
  - Test nil map handling
  - Test SSL mode key variants
  - Test MongoDB authSource
  - Test Cassandra keyspace fallback

## Test plan
- [x] Unit tests pass for all connector types (37 test cases)
- [x] PostgreSQL connector install succeeds with host=postgres, port=5432
- [x] Connector health check returns healthy with active connection
- [x] Special characters in credentials work correctly

## Tested locally
```bash
curl -s "http://localhost:8081/api/v1/connectors/postgresql/install" -X POST \
  -H "Content-Type: application/json" \
  -d '{"name":"local-postgres","tenant_id":"test","options":{"host":"postgres","port":5432,"database":"axonflow"},"credentials":{"username":"axonflow","password":"localdev123"}}'

# Response: {"success":true,"message":"Connector installed successfully",...}

curl -s "http://localhost:8081/api/v1/connectors/postgresql/health"
# Response: {"healthy":true,"latency":593708,"details":{"open_connections":"1"},...}
```