### PR TITLE
fix: enable Proxy Mode and add SSN detection policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,12 +75,13 @@ curl http://localhost:8081/health
 ```
 ╔═══════════════════════════════════════════════════════════════╗
 ║               AxonFlow Interactive Demo                       ║
+║          Real-time AI Governance in Action                    ║
 ╚═══════════════════════════════════════════════════════════════╝
 
-Demo 1: PII Detection & Blocking
+Demo 1: SQL Injection Blocking
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-Sending: "Process payment for John Smith, SSN 123-45-6789"
-🛡️  BLOCKED - PII Detected (SSN pattern blocked in real-time)
+Sending: "SELECT * FROM users WHERE id=1 UNION SELECT password FROM admin"
+🛡️  BLOCKED - SQL Injection Detected
 
 Demo 2: Safe Query (Allowed)
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -89,15 +90,15 @@ Sending: "What is the weather forecast for tomorrow?"
 
 Demo 3: Credit Card Detection
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-Sending: "Charge my card 4111-1111-1111-1111"
-🛡️  BLOCKED - Credit Card Detected
+Sending: "Charge my card 4111-1111-1111-1111 for the order"
+🛡️  POLICY TRIGGERED - Credit Card Detected
 
 Demo 4: Sub-10ms Policy Evaluation
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-⚡ Average latency: 4ms (Sub-10ms inline governance!)
+⚡ Average latency: 3ms (Sub-10ms inline governance achieved!)
 ```
 
-**That's AxonFlow** - blocking sensitive data in real-time, under 10ms.
+**That's AxonFlow** - blocking malicious queries and detecting sensitive data in real-time, under 10ms.
 
 ### Want More? Try These Examples
 
@@ -115,15 +116,15 @@ Want to try from code? Here's the Python equivalent of the demo:
 # pip install requests
 import requests
 
-# Test PII detection using the Gateway Mode pre-check endpoint
+# Test SQL injection detection using the Gateway Mode pre-check endpoint
 response = requests.post("http://localhost:8080/api/policy/pre-check", json={
     "client_id": "demo",
     "user_token": "demo-user",
-    "query": "My SSN is 123-45-6789",
+    "query": "SELECT * FROM users WHERE id=1 UNION SELECT password FROM admin",
     "context": {"user_role": "agent"}
 })
 
-print(response.json())  # Shows approved: false for PII violation
+print(response.json())  # Shows approved: false, block_reason: "SQL injection detected"
 ```
 
 ---

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,6 +101,9 @@ services:
 
       # Redis (optional)
       REDIS_URL: redis://redis:6379
+
+      # Orchestrator URL (required for Proxy Mode to forward requests)
+      ORCHESTRATOR_URL: http://axonflow-orchestrator:8081
     ports:
       - "8080:8080"
     depends_on:

--- a/migrations/core/010_policy_tables.sql
+++ b/migrations/core/010_policy_tables.sql
@@ -258,7 +258,9 @@ INSERT INTO static_policies (policy_id, name, category, pattern, severity, descr
 ('sql_injection_union', 'SQL Injection - UNION Attack', 'sql_injection', 'union\s+select', 'critical', 'UNION-based SQL injection attempt', 'block', 'global'),
 ('sql_injection_or', 'SQL Injection - OR Condition', 'sql_injection', '(\bor\b|\band\b).*[''"]?\s*[=<>].*[''"]?\s*(or|and)\s*[''"]?\s*[=<>]', 'critical', 'Boolean-based SQL injection attempt', 'block', 'global'),
 ('drop_table_prevention', 'DROP TABLE Prevention', 'dangerous_queries', 'drop\s+table', 'critical', 'DROP TABLE operations are not allowed', 'block', 'global'),
-('truncate_prevention', 'TRUNCATE Prevention', 'dangerous_queries', 'truncate\s+table', 'critical', 'TRUNCATE operations are not allowed', 'block', 'global')
+('truncate_prevention', 'TRUNCATE Prevention', 'dangerous_queries', 'truncate\s+table', 'critical', 'TRUNCATE operations are not allowed', 'block', 'global'),
+-- PII Detection policy (credit card detection is in 014_eu_ai_act_templates.sql as eu_gdpr_credit_card_detection)
+('pii_ssn_detection', 'SSN Detection', 'pii_detection', '\b\d{3}[-\s]?\d{2}[-\s]?\d{4}\b', 'high', 'US Social Security Number pattern detected', 'redact', 'global')
 ON CONFLICT (policy_id) DO NOTHING;
 
 -- Insert essential default dynamic policies


### PR DESCRIPTION
## Summary

Fixes critical OSS issues discovered during README testing:

1. **Proxy Mode broken** - Agent couldn't reach orchestrator in docker-compose
2. **README expected output mismatch** - Didn't match actual demo.sh behavior  
3. **SSN detection missing** - No policy to detect US Social Security Numbers

## Changes

### docker-compose.yml
- Added `ORCHESTRATOR_URL: http://axonflow-orchestrator:8081` to agent environment
- Agent now correctly routes Proxy Mode requests to orchestrator container

### README.md
- Updated expected demo output to match actual `demo.sh` behavior:
  - Demo 1: SQL Injection Blocking (not SSN/PII)
  - Demo 3: "POLICY TRIGGERED" (not "BLOCKED") - credit card triggers policy but doesn't block
  - Demo 3 query text now matches demo.sh exactly ("for the order" suffix)
- Updated Python example to use SQL injection test instead of SSN

### migrations/core/010_policy_tables.sql
- Added `pii_ssn_detection` policy: Detects US SSN patterns (XXX-XX-XXXX)
- Uses `redact` action (flag for redaction, not block)
- Note: Credit card detection already exists in `014_eu_ai_act_templates.sql` as `eu_gdpr_credit_card_detection`

## Code Review Fixes

After initial commit, code review identified:
1. ✅ Demo 3 query text mismatch - fixed to match demo.sh exactly
2. ✅ Duplicate credit card policy - removed (already in migration 014)
3. ✅ SSN regex validated - correctly matches XXX-XX-XXXX but not phone numbers

## Testing

Verified locally:
- Proxy Mode now reaches orchestrator (returns "no healthy providers" without API keys - expected)
- Gateway Mode pre-check works correctly
- demo.sh output matches new README expected output
- SSN regex tested: matches `123-45-6789`, `123 45 6789`, `123456789` but NOT `123-456-7890` (phone)

## Related

- Testing log: `axonflow-business-docs/engineering/OSS_REPO_TESTING_LOG.md`