### PR TITLE
fix(docs): correct broken architecture link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Policy checks add single-digit millisecond overhead.
 
 **Gateway Mode** — Wrap existing LLM calls with governance. Pre-check → your LLM call → audit. Incremental adoption path.
 
-→ **[Architecture deep-dive](https://docs.getaxonflow.com/docs/architecture)**
+→ **[Architecture deep-dive](https://docs.getaxonflow.com/docs/architecture/overview)**
 
 ### vs LangChain / LangSmith
 


### PR DESCRIPTION
## Summary
- Fixed broken link to architecture documentation in README.md
- Changed `/docs/architecture` (404) to `/docs/architecture/overview` (working)

## Test plan
- [x] Verify the new link works: https://docs.getaxonflow.com/docs/architecture/overview

Fixes #41

Reported-by: Ramya Kondam (Senior Engineer, Booking.com)