### PR TITLE
feat: SQL injection response scanning and v1.0.0 release updates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -110,6 +110,11 @@ AGENT_PORT=8443
 
 <!-- Optional: If you have suggestions on how to fix the bug -->
 
+## Reported By
+
+<!-- If reporting on behalf of someone else, @mention them or provide attribution -->
+<!-- Example: @username or "Reported by: Name (Company)" -->
+
 ## Checklist
 
 - [ ] I have searched existing issues to avoid duplicates

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -56,6 +56,11 @@ assignees: ''
 - [ ] No, but I can review a proposed fix
 - [ ] No, reporting for someone else to fix
 
+## Reported By
+
+<!-- If reporting on behalf of someone else, @mention them or provide attribution -->
+<!-- Example: @username or "Reported by: Name (Company)" -->
+
 ## Checklist
 - [ ] I have searched existing issues
 - [ ] I have checked the [documentation](https://docs.getaxonflow.com)

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -114,6 +114,11 @@ assignees: ''
 
 <!-- Link to any related issues, discussions, or external resources -->
 
+## Reported By
+
+<!-- If reporting on behalf of someone else, @mention them or provide attribution -->
+<!-- Example: @username or "Reported by: Name (Company)" -->
+
 ## Checklist
 
 - [ ] I have searched existing issues to avoid duplicates

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,8 +15,11 @@ on:
       - develop
     paths:
       - 'platform/**/*.go'
+      - 'ee/platform/**/*.go'
       - 'go.mod'
       - 'go.sum'
+      - 'ee/go.mod'
+      - 'ee/go.sum'
       - '.github/workflows/test.yml'
   # Merge queue: re-run tests against the merged code with path filtering
   merge_group:
@@ -144,6 +147,16 @@ jobs:
             fi
           done
 
+          echo "=== Applying industry/travel migrations (EU AI Act) ==="
+          if [ -d "migrations/industry/travel" ]; then
+            for migration in migrations/industry/travel/*.sql; do
+              if [ -f "$migration" ] && [[ ! "$migration" =~ _down\.sql$ ]]; then
+                echo "Applying $migration..."
+                psql -h localhost -U test_user -d test_db -f "$migration" || echo "Migration $migration failed or already applied, continuing..."
+              fi
+            done
+          fi
+
       - name: Test Orchestrator
         env:
           DATABASE_URL: postgresql://test_user:test_password@localhost:5432/test_db?sslmode=disable
@@ -213,12 +226,66 @@ jobs:
           cd platform/shared/logger
           go test -v -cover -timeout 5m
 
+      # =============================================================================
+      # Enterprise Module Tests (ee/platform/*)
+      # =============================================================================
+      - name: Install Enterprise dependencies
+        run: |
+          cd ee
+          go mod download
+          # Note: go mod verify skipped for ee/ because it has a replace directive
+          # for axonflow/platform => ../platform (local modules can't be verified)
+
+      - name: Test Enterprise Orchestrator
+        env:
+          DATABASE_URL: postgresql://test_user:test_password@localhost:5432/test_db?sslmode=disable
+        run: |
+          cd ee/platform/orchestrator
+          go test -v -cover -coverprofile=coverage.out ./... -timeout 10m
+
+      - name: Check Enterprise Orchestrator Coverage
+        run: |
+          cd ee/platform/orchestrator
+          coverage=$(go tool cover -func=coverage.out | grep total | awk '{print $3}' | sed 's/%//')
+          echo "Enterprise Orchestrator Coverage: $coverage%"
+
+          # Target 80%+ coverage for EU AI Act, RBI, SEBI modules
+          threshold=80.0
+          if (( $(echo "$coverage < $threshold" | bc -l) )); then
+            echo "❌ Enterprise Orchestrator coverage $coverage% is below threshold $threshold%"
+            exit 1
+          fi
+          echo "✅ Enterprise Orchestrator coverage $coverage% meets threshold $threshold%"
+
+      - name: Test Enterprise Agent
+        env:
+          DATABASE_URL: postgresql://test_user:test_password@localhost:5432/test_db?sslmode=disable
+        run: |
+          cd ee/platform/agent
+          go test -v -cover -coverprofile=coverage.out ./... -timeout 5m
+
+      - name: Check Enterprise Agent Coverage
+        run: |
+          cd ee/platform/agent
+          coverage=$(go tool cover -func=coverage.out | grep total | awk '{print $3}' | sed 's/%//')
+          echo "Enterprise Agent Coverage: $coverage%"
+
+          # Initial threshold - license, marketplace, node enforcement, HITL, circuit breaker
+          threshold=50.0
+          if (( $(echo "$coverage < $threshold" | bc -l) )); then
+            echo "❌ Enterprise Agent coverage $coverage% is below threshold $threshold%"
+            exit 1
+          fi
+          echo "✅ Enterprise Agent coverage $coverage% meets threshold $threshold%"
+
       - name: Generate coverage reports
         if: success()
         run: |
           cd platform/orchestrator && go tool cover -html=coverage.out -o coverage.html
           cd ../agent && go tool cover -html=coverage.out -o coverage.html
           cd ../connectors && go tool cover -html=coverage.out -o coverage.html
+          cd ../../ee/platform/orchestrator && go tool cover -html=coverage.out -o coverage.html
+          cd ../agent && go tool cover -html=coverage.out -o coverage.html
 
       - name: Upload coverage reports
         if: success()
@@ -229,6 +296,8 @@ jobs:
             platform/orchestrator/coverage.html
             platform/agent/coverage.html
             platform/connectors/coverage.html
+            ee/platform/orchestrator/coverage.html
+            ee/platform/agent/coverage.html
           retention-days: 30
 
   race-detector:
@@ -339,6 +408,16 @@ jobs:
             fi
           done
 
+          echo "=== Applying industry/travel migrations (EU AI Act) ==="
+          if [ -d "migrations/industry/travel" ]; then
+            for migration in migrations/industry/travel/*.sql; do
+              if [ -f "$migration" ] && [[ ! "$migration" =~ _down\.sql$ ]]; then
+                echo "Applying $migration..."
+                psql -h localhost -U test_user -d test_db -f "$migration" || echo "Migration $migration failed or already applied, continuing..."
+              fi
+            done
+          fi
+
       - name: Run integration tests
         env:
           DATABASE_URL: postgresql://test_user:test_password@localhost:5432/test_db?sslmode=disable
@@ -384,6 +463,10 @@ jobs:
           echo "✅ All tests passed!"
           echo ""
           echo "Coverage thresholds verified:"
-          echo "  - Orchestrator: 73.5%"
-          echo "  - Agent: 76%"
-          echo "  - Connectors: 62%"
+          echo "  OSS Modules:"
+          echo "    - Orchestrator: 73.5%"
+          echo "    - Agent: 76%"
+          echo "    - Connectors: 62%"
+          echo "  Enterprise Modules:"
+          echo "    - ee/Orchestrator: 50%"
+          echo "    - ee/Agent: 50%"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,67 +7,79 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [Unreleased]
+## [1.0.0] - 2025-12-14
 
-### Added
+**Community Launch Release**
 
-- **Row-Level Security (RLS)**: Database-level multi-tenant isolation for enhanced security
-  - Automatic RLS setup in CloudFormation templates
-  - User-level tenant isolation enforcement
-  - Comprehensive RLS unit and integration tests
-- **Customer Portal Documentation**: Protected documentation portal with SSO integration
-  - Full-page navigation through nginx
-  - Session-preserved documentation access
-  - Build-time API URL configuration
-- **Migration System**: Production-grade database migration tracking
-  - Industry-standard migration helpers with upgrade support
-  - Schema verification tools for deployment validation
-  - Idempotent migrations for safe re-runs
-- **Test Coverage Improvements**:
-  - Orchestrator package: 52% → 70.4% coverage
-  - Agent package: Maintained at 70.3%
-  - Amadeus connector: 74.1% coverage
-  - Comprehensive integration tests for RLS, connectors, and marketplace
-- **Deployment Infrastructure**:
-  - 2-environment deployment system (staging + production)
-  - Configuration-driven deployment with YAML environments
-  - Pre-flight validation to catch errors before deployment
-  - Autonomous deployment monitoring with deep ECS task inspection
-- **Example Workflows**: 10 comprehensive workflow examples (simple to complex)
-- **VPC Endpoint Support**: Conditional VPC endpoint creation for private networking
-- **CI/CD Enhancements**:
-  - Trivy security scanning workflow
-  - Standardized test coverage thresholds (65% minimum)
-  - GitHub Actions OIDC setup for secure AWS deployments
+This is the first public release of AxonFlow, a self-hosted governance and orchestration platform for production AI systems.
 
-### Fixed
+### Core Platform
 
-- **Critical Security**: Production bug in `reset_org_id()` function
-  - Wrong PostgreSQL session scope flag could leak tenant data
-  - Transaction-local flag couldn't override session-wide settings
-  - Now uses correct session-wide scope for connection pooling safety
-- **RLS Integration Tests**: Fixed 4 failing tests with proper cleanup and expectations
-- **Schema Migrations**: Fixed RLS test to handle table not existing in test environment
-- **CloudFormation Networking**: Resolved VPC subnet mismatch for ALB deployment
-- **Customer Portal Deployment**: Fixed Docker networking for proper backend API access
-- **Documentation Links**: Fixed portal navigation to preserve user sessions
-- **Migration Helpers**: Upgraded old `schema_migrations` table to new schema automatically
-- **Deployment Scripts**: Fixed `--target` parameter bug for proper instance targeting
+- **Policy Enforcement Agent**: Real-time policy enforcement with single-digit millisecond overhead
+  - Static policy engine with configurable rules
+  - PII detection (SSN, credit cards, PAN, Aadhaar)
+  - SQL injection blocking in user inputs
+  - Rate limiting and request validation
 
-### Changed
+- **Multi-Agent Planning (MAP)**: Declarative agent orchestration
+  - YAML-based agent configuration
+  - Natural language to workflow conversion
+  - Sequential and parallel execution modes
+  - Error handling with fallbacks
 
-- **CI/CD Standards**: Upgraded Go version from 1.21 to 1.23
-- **Test Infrastructure**: Extended PostgreSQL CI service to orchestrator tests
-- **Password Encoding**: Updated test expectations to match `url.UserPassword()` behavior
-- **Commit Linting**: Skipped for PR #14 (uses squash merge)
+- **MCP Connectors**: Model Context Protocol integration
+  - PostgreSQL, MySQL, MongoDB, Redis, HTTP connectors (Community)
+  - Salesforce, Slack, Snowflake, ServiceNow (Enterprise)
 
-### Security
+- **Gateway Mode**: Wrap existing LLM calls with governance
+  - Pre-check → your LLM call → audit trail
+  - Incremental adoption path for existing codebases
 
-- **RLS Enforcement**: Database-level tenant isolation prevents cross-tenant data access
-- **Migration Security**: Schema verification prevents deployment of invalid database states
-- **Secret Management**: All sensitive credentials now managed through AWS Secrets Manager
+- **Multi-Model Routing**: Intelligent LLM provider management
+  - OpenAI, Anthropic, Ollama (Community)
+  - AWS Bedrock, Google Gemini (Enterprise)
+  - Automatic failover and cost-based routing
+
+### Security & Compliance
+
+- **SQL Injection Response Scanning**: Detect SQLi payloads in MCP connector responses
+  - 37 regex patterns across 8 attack categories
+  - Monitoring mode by default (detect and log, configurable blocking)
+  - Per-connector configuration overrides
+  - Audit trail integration for compliance
+  - Basic scanner (Community), Advanced ML-based scanner (Enterprise)
+
+- **EU AI Act Compliance** (Articles 12, 13, 14, 15, 43):
+  - Decision chain tracing with full audit trails
+  - Transparency headers (X-AI-Decision-ID, X-AI-Model-Provider, etc.)
+  - Human-in-the-Loop (HITL) workflows (Enterprise)
+  - Conformity assessment endpoints (Enterprise)
+  - Emergency circuit breaker (Enterprise)
+
+- **RBI FREE-AI Framework**: Data integrity monitoring for financial AI (India)
+
+- **SEBI AI/ML Guidelines**: Security audit trail for investment platforms (India)
+
+### Infrastructure
+
+- **Docker Compose Deployment**: Local development in under 5 minutes
+- **Row-Level Security**: Database-level multi-tenant isolation
+- **Production Migrations**: Idempotent, versioned database migrations
+- **Test Coverage**: 70%+ coverage across core packages
+
+### Documentation
+
+- Getting Started Guide
+- LLM Provider Configuration
+- MCP Connector Development Guide
+- Security Best Practices
+- EU AI Act Compliance Guide
 
 ---
+
+## Pre-release Development History
+
+The following versions were internal development milestones leading up to v1.0.0.
 
 ## [1.0.12] - 2025-11-07
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ Policy checks add single-digit millisecond overhead.
 
 **Policy Enforcement** — Block SQL injection, detect PII (SSN, credit cards, PAN/Aadhaar), enforce rate limits. Policies apply before requests reach LLMs.
 
+**SQL Injection Response Scanning** — Detect SQLi payloads in MCP connector responses. Protects against data exfiltration when compromised data is returned from databases.
+
 **Audit Trails** — Every request logged with full context. Know what was blocked, why, and by which policy. Token usage tracked for cost analysis.
 
 **Multi-Model Routing** — Route requests across OpenAI, Anthropic, Bedrock, Ollama based on cost, capability, or compliance requirements. Failover included.
@@ -140,7 +142,7 @@ Policy checks add single-digit millisecond overhead.
         PostgreSQL (policies, audit) • Redis (cache)
 ```
 
-- **Agent** (:8080): Policy enforcement, PII detection, MCP connectors
+- **Agent** (:8080): Policy enforcement, PII detection, SQLi response scanning, MCP connectors
 - **Orchestrator** (:8081): LLM routing, dynamic policies, multi-agent planning
 
 ---
@@ -152,6 +154,8 @@ Policy checks add single-digit millisecond overhead.
 | **Core Platform** | | |
 | Policy enforcement | ✅ | ✅ |
 | PII detection (SSN, credit cards, PAN/Aadhaar) | ✅ | ✅ |
+| SQLi response scanning (basic) | ✅ | ✅ |
+| SQLi response scanning (ML-based) | ❌ | ✅ |
 | Audit logging | ✅ | ✅ |
 | **LLM Providers** | | |
 | OpenAI, Anthropic, Ollama | ✅ | ✅ |

--- a/docs/api/orchestrator-api.yaml
+++ b/docs/api/orchestrator-api.yaml
@@ -64,6 +64,11 @@ tags:
     description: |
       SEBI AI/ML Guidelines compliance and DPDP Act 2023 audit exports.
       Enterprise feature for Indian financial services compliance.
+  - name: EU AI Act
+    description: |
+      EU AI Act compliance endpoints for technical documentation export,
+      conformity assessments (Article 43), and accuracy/bias tracking (Article 15).
+      Enterprise feature for EU regulatory compliance.
   - name: Metrics
     description: Performance monitoring
 
@@ -1559,6 +1564,563 @@ paths:
                     message: "Consider enabling for full audit trail"
                 recommendations:
                   - "Enable decision chain tracing to maintain full audit trail of AI decisions"
+
+  # ============================================================================
+  # EU AI Act Compliance Endpoints
+  # ============================================================================
+
+  /api/v1/euaiact/export:
+    post:
+      tags:
+        - EU AI Act
+      summary: Create compliance export
+      description: |
+        Creates a new EU AI Act compliance export job for technical documentation (Article 11).
+
+        Export types:
+        - `full_audit`: Complete audit trail for regulatory review
+        - `conformity_evidence`: Evidence for conformity assessments
+        - `hitl_summary`: Human-in-the-loop decision summary
+        - `decision_chain`: Full decision chain tracing
+        - `policy_violations`: Policy violation records
+        - `accuracy_metrics`: Model accuracy and bias metrics
+      operationId: createEUAIActExport
+      parameters:
+        - $ref: '#/components/parameters/OrgIDHeader'
+        - $ref: '#/components/parameters/UserIDHeader'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EUAIActExportRequest'
+            example:
+              export_type: "full_audit"
+              format: "json"
+              date_from: "2025-01-01T00:00:00Z"
+              date_to: "2025-12-31T23:59:59Z"
+      responses:
+        '202':
+          description: Export job created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EUAIActExport'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+    get:
+      tags:
+        - EU AI Act
+      summary: List exports
+      description: List EU AI Act compliance exports for the organization.
+      operationId: listEUAIActExports
+      parameters:
+        - $ref: '#/components/parameters/OrgIDHeader'
+        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/OffsetParam'
+      responses:
+        '200':
+          description: List of exports
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  exports:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/EUAIActExport'
+                  total:
+                    type: integer
+                  limit:
+                    type: integer
+                  offset:
+                    type: integer
+        '400':
+          $ref: '#/components/responses/BadRequest'
+
+  /api/v1/euaiact/export/{export_id}:
+    get:
+      tags:
+        - EU AI Act
+      summary: Get export status
+      description: Get the status of a specific export job.
+      operationId: getEUAIActExport
+      parameters:
+        - name: export_id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Export details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EUAIActExport'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /api/v1/euaiact/export/{export_id}/download:
+    get:
+      tags:
+        - EU AI Act
+      summary: Download export
+      description: Download a completed export file.
+      operationId: downloadEUAIActExport
+      parameters:
+        - name: export_id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Export file metadata
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  file_path:
+                    type: string
+                  file_size:
+                    type: integer
+                  format:
+                    type: string
+        '400':
+          description: Export not yet completed
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /api/v1/euaiact/conformity:
+    post:
+      tags:
+        - EU AI Act
+      summary: Create conformity assessment
+      description: |
+        Create a new EU AI Act conformity assessment (Article 43).
+        Used to document compliance for high-risk AI systems.
+      operationId: createConformityAssessment
+      parameters:
+        - $ref: '#/components/parameters/OrgIDHeader'
+        - $ref: '#/components/parameters/UserIDHeader'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateConformityRequest'
+            example:
+              system_id: "ai-system-001"
+              system_name: "Customer Risk Scoring Model"
+              risk_category: "high-risk"
+              assessors:
+                - "compliance@company.com"
+      responses:
+        '201':
+          description: Assessment created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConformityAssessment'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+    get:
+      tags:
+        - EU AI Act
+      summary: List conformity assessments
+      description: List conformity assessments for the organization.
+      operationId: listConformityAssessments
+      parameters:
+        - $ref: '#/components/parameters/OrgIDHeader'
+        - name: status
+          in: query
+          schema:
+            type: string
+            enum: [draft, in_progress, submitted, approved, rejected]
+        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/OffsetParam'
+      responses:
+        '200':
+          description: List of assessments
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  assessments:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ConformityAssessment'
+                  total:
+                    type: integer
+                  limit:
+                    type: integer
+                  offset:
+                    type: integer
+
+  /api/v1/euaiact/conformity/{assessment_id}:
+    get:
+      tags:
+        - EU AI Act
+      summary: Get conformity assessment
+      description: Get details of a specific conformity assessment.
+      operationId: getConformityAssessment
+      parameters:
+        - name: assessment_id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Assessment details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConformityAssessment'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    put:
+      tags:
+        - EU AI Act
+      summary: Update conformity assessment
+      description: Update a conformity assessment (only allowed for draft/in_progress status).
+      operationId: updateConformityAssessment
+      parameters:
+        - name: assessment_id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateConformityRequest'
+      responses:
+        '200':
+          description: Assessment updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConformityAssessment'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /api/v1/euaiact/conformity/{assessment_id}/submit:
+    post:
+      tags:
+        - EU AI Act
+      summary: Submit assessment for review
+      description: Submit a conformity assessment for approval review.
+      operationId: submitConformityAssessment
+      parameters:
+        - name: assessment_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - $ref: '#/components/parameters/UserIDHeader'
+      responses:
+        '200':
+          description: Assessment submitted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConformityAssessment'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+
+  /api/v1/euaiact/conformity/{assessment_id}/approve:
+    post:
+      tags:
+        - EU AI Act
+      summary: Approve assessment
+      description: Approve a submitted conformity assessment.
+      operationId: approveConformityAssessment
+      parameters:
+        - name: assessment_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - $ref: '#/components/parameters/UserIDHeader'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                validity_years:
+                  type: integer
+                  default: 1
+                  description: Number of years the approval is valid
+      responses:
+        '200':
+          description: Assessment approved
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConformityAssessment'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+
+  /api/v1/euaiact/conformity/{assessment_id}/reject:
+    post:
+      tags:
+        - EU AI Act
+      summary: Reject assessment
+      description: Reject a submitted conformity assessment.
+      operationId: rejectConformityAssessment
+      parameters:
+        - name: assessment_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - $ref: '#/components/parameters/UserIDHeader'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - reason
+              properties:
+                reason:
+                  type: string
+                  description: Reason for rejection
+      responses:
+        '200':
+          description: Assessment rejected
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConformityAssessment'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+
+  /api/v1/euaiact/accuracy:
+    get:
+      tags:
+        - EU AI Act
+      summary: Get accuracy summary
+      description: |
+        Get accuracy and bias tracking summary for the organization (Article 15).
+        Provides overview of model performance and compliance status.
+      operationId: getAccuracySummary
+      parameters:
+        - $ref: '#/components/parameters/OrgIDHeader'
+      responses:
+        '200':
+          description: Accuracy summary
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccuracySummary'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+
+  /api/v1/euaiact/accuracy/record:
+    post:
+      tags:
+        - EU AI Act
+      summary: Record accuracy metric
+      description: Record an accuracy metric for a model.
+      operationId: recordAccuracyMetric
+      parameters:
+        - $ref: '#/components/parameters/OrgIDHeader'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RecordAccuracyRequest'
+            example:
+              model_id: "model-001"
+              metric_type: "accuracy"
+              value: 0.95
+              sample_size: 10000
+      responses:
+        '201':
+          description: Metric recorded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccuracyMetric'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+
+  /api/v1/euaiact/accuracy/bias:
+    post:
+      tags:
+        - EU AI Act
+      summary: Record bias measurement
+      description: Record a bias detection measurement for a model.
+      operationId: recordBiasMeasurement
+      parameters:
+        - $ref: '#/components/parameters/OrgIDHeader'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RecordBiasRequest'
+            example:
+              model_id: "model-001"
+              category: "gender"
+              group_a: "male"
+              group_b: "female"
+              group_a_rate: 0.82
+              group_b_rate: 0.79
+              sample_size: 5000
+      responses:
+        '201':
+          description: Bias record created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BiasRecord'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+
+  /api/v1/euaiact/accuracy/history:
+    get:
+      tags:
+        - EU AI Act
+      summary: Get accuracy history
+      description: Get historical accuracy metrics for filtering and analysis.
+      operationId: getAccuracyHistory
+      parameters:
+        - $ref: '#/components/parameters/OrgIDHeader'
+        - name: model_id
+          in: query
+          schema:
+            type: string
+        - name: metric_type
+          in: query
+          schema:
+            type: string
+            enum: [accuracy, precision, recall, f1_score, auc_roc, auc_pr, mse, mae, custom]
+        - name: from
+          in: query
+          schema:
+            type: string
+            format: date-time
+        - name: to
+          in: query
+          schema:
+            type: string
+            format: date-time
+        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/OffsetParam'
+      responses:
+        '200':
+          description: Accuracy metrics history
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  metrics:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/AccuracyMetric'
+                  total:
+                    type: integer
+                  limit:
+                    type: integer
+                  offset:
+                    type: integer
+
+  /api/v1/euaiact/accuracy/alerts:
+    get:
+      tags:
+        - EU AI Act
+      summary: Get active alerts
+      description: Get active accuracy and bias alerts for the organization.
+      operationId: getAccuracyAlerts
+      parameters:
+        - $ref: '#/components/parameters/OrgIDHeader'
+      responses:
+        '200':
+          description: Active alerts
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  alerts:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/AccuracyAlert'
+                  total:
+                    type: integer
+
+  /api/v1/euaiact/accuracy/alerts/{alert_id}/acknowledge:
+    post:
+      tags:
+        - EU AI Act
+      summary: Acknowledge alert
+      description: Acknowledge an accuracy or bias alert.
+      operationId: acknowledgeAccuracyAlert
+      parameters:
+        - name: alert_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - $ref: '#/components/parameters/UserIDHeader'
+      responses:
+        '200':
+          description: Alert acknowledged
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: "acknowledged"
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /api/v1/euaiact/accuracy/alerts/{alert_id}/resolve:
+    post:
+      tags:
+        - EU AI Act
+      summary: Resolve alert
+      description: Resolve an accuracy or bias alert.
+      operationId: resolveAccuracyAlert
+      parameters:
+        - name: alert_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - $ref: '#/components/parameters/UserIDHeader'
+      responses:
+        '200':
+          description: Alert resolved
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: "resolved"
+        '404':
+          $ref: '#/components/responses/NotFound'
 
   /api/v1/workflows/execute:
     post:
@@ -3159,6 +3721,493 @@ components:
               enum: [NOT_FOUND, ALREADY_EXISTS, INVALID_REQUEST, UNAUTHORIZED, INTERNAL_ERROR]
             message:
               type: string
+
+    # ============================================================================
+    # EU AI Act Compliance Schemas
+    # ============================================================================
+
+    EUAIActExportRequest:
+      type: object
+      required:
+        - export_type
+        - format
+      properties:
+        export_type:
+          type: string
+          enum: [full_audit, conformity_evidence, hitl_summary, decision_chain, policy_violations, accuracy_metrics]
+          description: Type of compliance data to export
+        format:
+          type: string
+          enum: [json, csv, xml, pdf]
+          description: Output format for the export
+        date_from:
+          type: string
+          format: date-time
+          description: Start date for export range (RFC3339)
+        date_to:
+          type: string
+          format: date-time
+          description: End date for export range (RFC3339)
+        model_ids:
+          type: array
+          items:
+            type: string
+          description: Filter by specific model IDs
+        filters:
+          type: object
+          additionalProperties: true
+          description: Additional filters for the export
+
+    EUAIActExport:
+      type: object
+      properties:
+        id:
+          type: string
+        org_id:
+          type: string
+        export_type:
+          type: string
+          enum: [full_audit, conformity_evidence, hitl_summary, decision_chain, policy_violations, accuracy_metrics]
+        format:
+          type: string
+          enum: [json, csv, xml, pdf]
+        status:
+          type: string
+          enum: [pending, processing, completed, failed]
+        progress:
+          type: integer
+          minimum: 0
+          maximum: 100
+        file_path:
+          type: string
+        file_size:
+          type: integer
+        record_count:
+          type: integer
+        date_from:
+          type: string
+          format: date-time
+        date_to:
+          type: string
+          format: date-time
+        model_ids:
+          type: array
+          items:
+            type: string
+        filters:
+          type: object
+        error:
+          type: string
+        requested_by:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+        started_at:
+          type: string
+          format: date-time
+        completed_at:
+          type: string
+          format: date-time
+
+    CreateConformityRequest:
+      type: object
+      required:
+        - system_id
+        - system_name
+        - risk_category
+      properties:
+        system_id:
+          type: string
+          description: Unique identifier for the AI system
+        system_name:
+          type: string
+          description: Human-readable name for the AI system
+        risk_category:
+          type: string
+          enum: [minimal, limited, high-risk, unacceptable]
+          description: EU AI Act risk classification
+        assessors:
+          type: array
+          items:
+            type: string
+          description: List of assessor email addresses
+
+    UpdateConformityRequest:
+      type: object
+      properties:
+        system_name:
+          type: string
+        risk_category:
+          type: string
+          enum: [minimal, limited, high-risk, unacceptable]
+        assessors:
+          type: array
+          items:
+            type: string
+        requirements:
+          type: array
+          items:
+            $ref: '#/components/schemas/RequirementStatus'
+        evidence:
+          type: array
+          items:
+            $ref: '#/components/schemas/EvidenceItem'
+        findings:
+          type: array
+          items:
+            $ref: '#/components/schemas/Finding'
+        risk_mitigation:
+          type: object
+          additionalProperties: true
+        recommendations:
+          type: array
+          items:
+            type: string
+
+    ConformityAssessment:
+      type: object
+      properties:
+        id:
+          type: string
+        org_id:
+          type: string
+        system_id:
+          type: string
+        system_name:
+          type: string
+        risk_category:
+          type: string
+          enum: [minimal, limited, high-risk, unacceptable]
+        status:
+          type: string
+          enum: [draft, in_progress, submitted, approved, rejected]
+        version:
+          type: integer
+        assessment_date:
+          type: string
+          format: date-time
+        valid_until:
+          type: string
+          format: date-time
+        assessors:
+          type: array
+          items:
+            type: string
+        requirements:
+          type: array
+          items:
+            $ref: '#/components/schemas/RequirementStatus'
+        evidence:
+          type: array
+          items:
+            $ref: '#/components/schemas/EvidenceItem'
+        findings:
+          type: array
+          items:
+            $ref: '#/components/schemas/Finding'
+        risk_mitigation:
+          type: object
+        recommendations:
+          type: array
+          items:
+            type: string
+        created_by:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        submitted_at:
+          type: string
+          format: date-time
+        submitted_by:
+          type: string
+        approved_at:
+          type: string
+          format: date-time
+        approved_by:
+          type: string
+        rejected_at:
+          type: string
+          format: date-time
+        rejected_by:
+          type: string
+        rejection_reason:
+          type: string
+
+    RequirementStatus:
+      type: object
+      properties:
+        requirement_id:
+          type: string
+        article:
+          type: string
+          description: EU AI Act article reference (e.g., "Article 9")
+        description:
+          type: string
+        status:
+          type: string
+          enum: [compliant, non_compliant, partial, not_applicable]
+        notes:
+          type: string
+        evidence_ids:
+          type: array
+          items:
+            type: string
+
+    EvidenceItem:
+      type: object
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+          enum: [document, test_result, audit_log, certification]
+        title:
+          type: string
+        description:
+          type: string
+        file_path:
+          type: string
+        url:
+          type: string
+        uploaded_at:
+          type: string
+          format: date-time
+        uploaded_by:
+          type: string
+
+    Finding:
+      type: object
+      properties:
+        id:
+          type: string
+        severity:
+          type: string
+          enum: [critical, major, minor, observation]
+        category:
+          type: string
+        description:
+          type: string
+        article:
+          type: string
+          description: Related EU AI Act article
+        remediation:
+          type: string
+        status:
+          type: string
+          enum: [open, resolved, accepted]
+
+    RecordAccuracyRequest:
+      type: object
+      required:
+        - model_id
+        - metric_type
+        - value
+      properties:
+        model_id:
+          type: string
+        metric_type:
+          type: string
+          enum: [accuracy, precision, recall, f1_score, auc_roc, auc_pr, mse, mae, custom]
+        value:
+          type: number
+          format: double
+        sample_size:
+          type: integer
+        window_start:
+          type: string
+          format: date-time
+        window_end:
+          type: string
+          format: date-time
+        metadata:
+          type: object
+          additionalProperties: true
+
+    AccuracyMetric:
+      type: object
+      properties:
+        id:
+          type: string
+        org_id:
+          type: string
+        model_id:
+          type: string
+        metric_type:
+          type: string
+          enum: [accuracy, precision, recall, f1_score, auc_roc, auc_pr, mse, mae, custom]
+        value:
+          type: number
+          format: double
+        sample_size:
+          type: integer
+        timestamp:
+          type: string
+          format: date-time
+        window_start:
+          type: string
+          format: date-time
+        window_end:
+          type: string
+          format: date-time
+        metadata:
+          type: object
+
+    RecordBiasRequest:
+      type: object
+      required:
+        - model_id
+        - category
+        - group_a
+        - group_b
+        - group_a_rate
+        - group_b_rate
+      properties:
+        model_id:
+          type: string
+        category:
+          type: string
+          enum: [gender, age, ethnicity, disability, religion, nationality, socioeconomic, custom]
+        group_a:
+          type: string
+          description: Name of the first comparison group
+        group_b:
+          type: string
+          description: Name of the second comparison group
+        group_a_rate:
+          type: number
+          format: double
+          description: Positive outcome rate for group A
+        group_b_rate:
+          type: number
+          format: double
+          description: Positive outcome rate for group B
+        sample_size:
+          type: integer
+        window_start:
+          type: string
+          format: date-time
+        window_end:
+          type: string
+          format: date-time
+        metadata:
+          type: object
+          additionalProperties: true
+
+    BiasRecord:
+      type: object
+      properties:
+        id:
+          type: string
+        org_id:
+          type: string
+        model_id:
+          type: string
+        category:
+          type: string
+          enum: [gender, age, ethnicity, disability, religion, nationality, socioeconomic, custom]
+        score:
+          type: number
+          format: double
+          description: Calculated bias score (difference ratio)
+        threshold:
+          type: number
+          format: double
+        is_violation:
+          type: boolean
+        sample_size:
+          type: integer
+        group_a:
+          type: string
+        group_b:
+          type: string
+        group_a_rate:
+          type: number
+          format: double
+        group_b_rate:
+          type: number
+          format: double
+        timestamp:
+          type: string
+          format: date-time
+        window_start:
+          type: string
+          format: date-time
+        window_end:
+          type: string
+          format: date-time
+        metadata:
+          type: object
+
+    AccuracySummary:
+      type: object
+      properties:
+        org_id:
+          type: string
+        total_models:
+          type: integer
+        models_above_target:
+          type: integer
+        models_below_target:
+          type: integer
+        average_accuracy:
+          type: number
+          format: double
+        active_alerts:
+          type: integer
+        last_updated:
+          type: string
+          format: date-time
+        metrics_by_model:
+          type: object
+          additionalProperties: true
+
+    AccuracyAlert:
+      type: object
+      properties:
+        id:
+          type: string
+        org_id:
+          type: string
+        model_id:
+          type: string
+        alert_type:
+          type: string
+          enum: [accuracy_degradation, bias_detected]
+        severity:
+          type: string
+          enum: [info, warning, critical]
+        title:
+          type: string
+        description:
+          type: string
+        metric_type:
+          type: string
+        bias_category:
+          type: string
+        current_value:
+          type: number
+          format: double
+        threshold:
+          type: number
+          format: double
+        triggered_at:
+          type: string
+          format: date-time
+        acked_at:
+          type: string
+          format: date-time
+        acked_by:
+          type: string
+        resolved_at:
+          type: string
+          format: date-time
+        resolved_by:
+          type: string
 
   responses:
     BadRequest:

--- a/docs/security/sql-injection-scanning.md
+++ b/docs/security/sql-injection-scanning.md
@@ -1,0 +1,196 @@
+# SQL Injection Scanning
+
+AxonFlow provides built-in SQL injection (SQLi) detection for MCP connector responses to protect against data exfiltration and manipulation attacks.
+
+## Overview
+
+SQL injection scanning monitors responses from MCP connectors for patterns that indicate SQL injection attempts. This protects against scenarios where:
+
+- Malicious data injected into databases is returned in query results
+- LLM-generated queries inadvertently include injection payloads
+- External data sources contain compromised content
+
+## Scanning Modes
+
+AxonFlow offers three scanning modes to balance security and performance:
+
+| Mode | Description | Edition | Performance |
+|------|-------------|---------|-------------|
+| `off` | Scanning disabled | Community | N/A |
+| `basic` | Pattern-based regex detection | Community | <1ms |
+| `advanced` | Heuristic analysis with confidence scoring | Enterprise | <10ms |
+
+### Basic Mode (Community)
+
+Basic mode uses compiled regex patterns to detect common SQL injection techniques:
+
+- **Union-based injection** - `UNION SELECT` statements for data extraction
+- **Boolean-blind injection** - `OR 1=1` and similar always-true conditions
+- **Time-based blind injection** - `SLEEP()`, `WAITFOR DELAY`, `PG_SLEEP()`
+- **Stacked queries** - `DROP TABLE`, `DELETE FROM`, `INSERT INTO`
+- **Comment injection** - SQL commands after `--`, `/**/`, or `#`
+- **Error-based injection** - `EXTRACTVALUE`, `UPDATEXML`
+
+### Advanced Mode (Enterprise)
+
+Advanced mode extends basic detection with:
+
+- **Heuristic analysis** for obfuscation detection
+- **Confidence scoring** (0.0-1.0) to reduce false positives
+- **Context-aware detection** that recognizes documentation/code blocks
+- **Multi-stage pipeline** for comprehensive analysis
+
+## Configuration
+
+### Default Configuration
+
+```yaml
+sqli:
+  input_mode: basic      # Scan user inputs
+  response_mode: basic   # Scan connector responses
+  block_on_detection: false  # Monitoring mode (set true to enforce blocking)
+  log_detections: true
+  audit_trail_enabled: true
+  max_content_length: 1048576  # 1MB
+```
+
+> **Note:** By default, SQL injection scanning runs in **monitoring mode** - detections are logged but responses are not blocked. This allows you to validate detection accuracy in your environment before enabling enforcement. Set `block_on_detection: true` to enable blocking.
+
+### Per-Connector Configuration
+
+```yaml
+sqli:
+  response_mode: basic
+  connector_overrides:
+    # Disable for trusted internal cache
+    redis_cache:
+      enabled: false
+    # Use advanced mode for sensitive data
+    postgresql_main:
+      response_mode: advanced
+```
+
+### Programmatic Configuration
+
+```go
+import "axonflow/platform/agent/sqli"
+
+cfg := sqli.DefaultConfig().
+    WithResponseMode(sqli.ModeBasic).
+    WithBlockOnDetection(true).
+    WithConnectorOverride("redis", sqli.ConnectorConfig{
+        Enabled: false,
+    })
+
+middleware, err := sqli.NewScanningMiddleware(
+    sqli.WithMiddlewareConfig(cfg),
+)
+```
+
+## Detection Categories
+
+| Category | Severity | Description |
+|----------|----------|-------------|
+| `stacked_queries` | Critical | Can modify or delete data |
+| `dangerous_query` | Critical | DDL operations (DROP, TRUNCATE, ALTER, CREATE USER, GRANT) |
+| `union_based` | High | Can extract sensitive data |
+| `time_based` | High | Confirms SQL injection vulnerability |
+| `boolean_blind` | Medium | May have false positives |
+| `error_based` | Medium | Error message extraction |
+| `comment_injection` | Medium | Query manipulation |
+| `generic` | Low | General suspicious patterns |
+
+## Response Handling
+
+When SQL injection is detected:
+
+1. **Blocked Response** (default): Returns HTTP 403 Forbidden
+   ```json
+   {
+     "success": false,
+     "error": "Response blocked: potential SQL injection detected (pattern: union_select)"
+   }
+   ```
+
+2. **Detection-Only Mode**: Logs detection but allows response through
+   ```yaml
+   sqli:
+     block_on_detection: false
+   ```
+
+## Audit Trail
+
+When `audit_trail_enabled: true`, detections are logged to the audit queue:
+
+```json
+{
+  "type": "sqli_detection",
+  "timestamp": "2025-12-14T15:30:00Z",
+  "severity": "high",
+  "connector_name": "postgresql_main",
+  "scan_type": "response",
+  "pattern": "union_select",
+  "category": "union_based",
+  "confidence": 0.95,
+  "blocked": true
+}
+```
+
+## Compliance Integration
+
+SQL injection scanning supports compliance requirements:
+
+- **EU AI Act Art. 15**: Accuracy logging for AI system outputs
+- **RBI FREE-AI**: Data integrity monitoring for financial AI
+- **SEBI AIF**: Security audit trail for investment platforms
+
+## Best Practices
+
+1. **Enable scanning by default** - Use `basic` mode for all connectors initially
+2. **Tune per-connector** - Disable for trusted internal services
+3. **Use advanced mode** for sensitive data stores in Enterprise edition
+4. **Monitor audit logs** for detection patterns and false positives
+5. **Set appropriate thresholds** - Adjust confidence threshold for advanced mode
+
+## Performance Impact
+
+| Mode | Average Latency | P99 Latency | Throughput Impact |
+|------|-----------------|-------------|-------------------|
+| `off` | 0ms | 0ms | 0% |
+| `basic` | <1ms | 2ms | <1% |
+| `advanced` | 3-5ms | 10ms | 2-5% |
+
+## Metrics
+
+The middleware exposes metrics for monitoring:
+
+```go
+metrics := sqli.GetGlobalMiddleware().GetMetrics()
+// metrics.ScansTotal - Total scans performed
+// metrics.DetectionsTotal - Total detections
+// metrics.BlockedTotal - Total blocked responses
+```
+
+## Troubleshooting
+
+### False Positives
+
+If legitimate SQL content is being blocked:
+
+1. Check if content contains SQL-like patterns (documentation, logs)
+2. Consider using `advanced` mode for better context awareness
+3. Disable scanning for specific connectors with known safe data
+
+### Performance Issues
+
+If scanning adds unacceptable latency:
+
+1. Reduce `max_content_length` to limit scanned data
+2. Disable scanning for high-throughput connectors
+3. Use `basic` mode instead of `advanced`
+
+## Related Documentation
+
+- [Row-Level Security](row-level-security.md)
+- [MCP Connector Configuration](../guides/connector-configuration.md)
+- [Compliance Guide](../compliance/overview.md)

--- a/platform/agent/Dockerfile
+++ b/platform/agent/Dockerfile
@@ -30,7 +30,16 @@ RUN --mount=type=bind,source=.,target=/src \
       cp -r /src/ee/platform/agent/license/* ./agent/license/ && \
       cp -r /src/ee/platform/agent/marketplace/* ./agent/marketplace/ && \
       cp -r /src/ee/platform/agent/node_enforcement/* ./agent/node_enforcement/ && \
+      if [ -d "/src/ee/platform/agent/rbi" ]; then \
+        cp -r /src/ee/platform/agent/rbi/* ./agent/rbi/ && \
+        echo "  Copied enterprise RBI module (kill switch)"; \
+      fi && \
       echo "Enterprise agent code copied successfully" && \
+      echo "=== Enterprise build: copying RBI compliance module ===" && \
+      if [ -d "/src/ee/platform/agent/rbi" ]; then \
+        cp -r /src/ee/platform/agent/rbi/* ./agent/rbi/ && \
+        echo "  RBI PII detector copied successfully"; \
+      fi && \
       echo "=== Enterprise build: copying EE connectors ===" && \
       for connector in amadeus salesforce slack snowflake; do \
         if [ -d "/src/ee/platform/connectors/$connector" ]; then \

--- a/platform/agent/migration_helpers.go
+++ b/platform/agent/migration_helpers.go
@@ -48,13 +48,14 @@ import (
 //   - saas:              core/ + enterprise/ + industry/*
 //   - in-vpc-healthcare: core/ + enterprise/ + industry/healthcare/
 //   - in-vpc-banking:    core/ + enterprise/ + industry/banking/
+//   - in-vpc-travel:     core/ + enterprise/ + industry/travel/
 //   - in-vpc-enterprise: core/ + enterprise/
 // =============================================================================
 
 // MigrationFile represents a migration file with metadata
 type MigrationFile struct {
 	Path     string // Full path to the file
-	Category string // core, enterprise, healthcare, banking
+	Category string // core, enterprise, healthcare, banking, travel
 	Version  string // Numeric version (e.g., "001", "100")
 	Name     string // Human-readable name
 }
@@ -87,6 +88,7 @@ func getMigrationPaths(basePath string) []string {
 		paths = append(paths, filepath.Join(basePath, "enterprise"))
 		paths = append(paths, filepath.Join(basePath, "industry", "healthcare"))
 		paths = append(paths, filepath.Join(basePath, "industry", "banking"))
+		paths = append(paths, filepath.Join(basePath, "industry", "travel"))
 		log.Println("📦 DEPLOYMENT_MODE=saas: Running all migrations (core + enterprise + industry)")
 
 	case "in-vpc-healthcare":
@@ -101,6 +103,12 @@ func getMigrationPaths(basePath string) []string {
 		paths = append(paths, filepath.Join(basePath, "industry", "banking"))
 		log.Println("📦 DEPLOYMENT_MODE=in-vpc-banking: Running core + enterprise + banking migrations")
 
+	case "in-vpc-travel":
+		// Travel runs core + enterprise + travel industry
+		paths = append(paths, filepath.Join(basePath, "enterprise"))
+		paths = append(paths, filepath.Join(basePath, "industry", "travel"))
+		log.Println("📦 DEPLOYMENT_MODE=in-vpc-travel: Running core + enterprise + travel migrations")
+
 	case "in-vpc-enterprise":
 		// Enterprise runs core + enterprise only
 		paths = append(paths, filepath.Join(basePath, "enterprise"))
@@ -112,6 +120,7 @@ func getMigrationPaths(basePath string) []string {
 		paths = append(paths, filepath.Join(basePath, "enterprise"))
 		paths = append(paths, filepath.Join(basePath, "industry", "healthcare"))
 		paths = append(paths, filepath.Join(basePath, "industry", "banking"))
+		paths = append(paths, filepath.Join(basePath, "industry", "travel"))
 	}
 
 	return paths

--- a/platform/agent/migration_helpers_test.go
+++ b/platform/agent/migration_helpers_test.go
@@ -402,6 +402,7 @@ func TestGetMigrationPaths(t *testing.T) {
 				"/test/migrations/enterprise",
 				"/test/migrations/industry/healthcare",
 				"/test/migrations/industry/banking",
+				"/test/migrations/industry/travel",
 			},
 		},
 		{
@@ -420,6 +421,15 @@ func TestGetMigrationPaths(t *testing.T) {
 				"/test/migrations/core",
 				"/test/migrations/enterprise",
 				"/test/migrations/industry/banking",
+			},
+		},
+		{
+			name:       "In-VPC Travel",
+			deployMode: "in-vpc-travel",
+			expectedPaths: []string{
+				"/test/migrations/core",
+				"/test/migrations/enterprise",
+				"/test/migrations/industry/travel",
 			},
 		},
 		{
@@ -446,6 +456,7 @@ func TestGetMigrationPaths(t *testing.T) {
 				"/test/migrations/enterprise",
 				"/test/migrations/industry/healthcare",
 				"/test/migrations/industry/banking",
+				"/test/migrations/industry/travel",
 			},
 		},
 	}

--- a/platform/agent/rbi/killswitch_oss.go
+++ b/platform/agent/rbi/killswitch_oss.go
@@ -1,0 +1,81 @@
+//go:build !enterprise
+
+// Copyright 2025 AxonFlow
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rbi
+
+import (
+	"context"
+	"database/sql"
+)
+
+// KillSwitchChecker is the OSS stub for kill switch checking.
+// In OSS mode, kill switches are not enforced.
+type KillSwitchChecker struct{}
+
+// NewKillSwitchChecker creates a new kill switch checker.
+// In OSS mode, this returns a no-op implementation.
+func NewKillSwitchChecker(_ *sql.DB) *KillSwitchChecker {
+	return &KillSwitchChecker{}
+}
+
+// KillSwitchCheckResult represents the result of a kill switch check.
+type KillSwitchCheckResult struct {
+	// IsBlocked indicates if the request should be blocked
+	IsBlocked bool `json:"is_blocked"`
+
+	// Reason provides the blocking reason if blocked
+	Reason string `json:"reason,omitempty"`
+
+	// KillSwitchID is the ID of the active kill switch if any
+	KillSwitchID string `json:"kill_switch_id,omitempty"`
+
+	// Scope indicates the kill switch scope
+	Scope string `json:"scope,omitempty"`
+
+	// FallbackBehavior indicates what to do when blocked
+	FallbackBehavior string `json:"fallback_behavior,omitempty"`
+}
+
+// CheckKillSwitch checks if any active kill switch applies to the request.
+// In OSS mode, this always returns not blocked.
+func (k *KillSwitchChecker) CheckKillSwitch(_ context.Context, _, _ string) *KillSwitchCheckResult {
+	return &KillSwitchCheckResult{
+		IsBlocked: false,
+		Reason:    "",
+	}
+}
+
+// KillSwitchEnabled returns whether kill switch enforcement is enabled.
+// In OSS mode, this returns false.
+func KillSwitchEnabled() bool {
+	return false
+}
+
+// ListActiveKillSwitches returns all active kill switches for an org.
+// In OSS mode, this returns an empty slice.
+func (k *KillSwitchChecker) ListActiveKillSwitches(_ context.Context, _ string) ([]*ActiveKillSwitch, error) {
+	return nil, nil
+}
+
+// ActiveKillSwitch represents a simplified view of an active kill switch.
+type ActiveKillSwitch struct {
+	ID               string `json:"id"`
+	Scope            string `json:"scope"`
+	SystemID         string `json:"system_id,omitempty"`
+	TargetIdentifier string `json:"target_identifier,omitempty"`
+	ActivatedBy      string `json:"activated_by"`
+	ActivationReason string `json:"activation_reason"`
+	FallbackBehavior string `json:"fallback_behavior"`
+}

--- a/platform/agent/rbi/killswitch_oss_test.go
+++ b/platform/agent/rbi/killswitch_oss_test.go
@@ -1,0 +1,65 @@
+//go:build !enterprise
+
+// Copyright 2025 AxonFlow
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rbi
+
+import (
+	"context"
+	"testing"
+)
+
+func TestKillSwitchEnabled_OSS(t *testing.T) {
+	if KillSwitchEnabled() {
+		t.Error("Expected KillSwitchEnabled() to return false in OSS mode")
+	}
+}
+
+func TestNewKillSwitchChecker_OSS(t *testing.T) {
+	checker := NewKillSwitchChecker(nil)
+	if checker == nil {
+		t.Error("Expected NewKillSwitchChecker to return non-nil checker")
+	}
+}
+
+func TestCheckKillSwitch_OSS(t *testing.T) {
+	checker := NewKillSwitchChecker(nil)
+	ctx := context.Background()
+
+	result := checker.CheckKillSwitch(ctx, "org-123", "system-456")
+
+	if result == nil {
+		t.Fatal("Expected non-nil result")
+	}
+	if result.IsBlocked {
+		t.Error("Expected OSS stub to return IsBlocked=false")
+	}
+	if result.Reason != "" {
+		t.Errorf("Expected empty reason, got %q", result.Reason)
+	}
+}
+
+func TestListActiveKillSwitches_OSS(t *testing.T) {
+	checker := NewKillSwitchChecker(nil)
+	ctx := context.Background()
+
+	switches, err := checker.ListActiveKillSwitches(ctx, "org-123")
+
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+	if switches != nil && len(switches) > 0 {
+		t.Errorf("Expected empty slice, got %d items", len(switches))
+	}
+}

--- a/platform/agent/rbi/rbi_oss.go
+++ b/platform/agent/rbi/rbi_oss.go
@@ -1,0 +1,179 @@
+//go:build !enterprise
+
+// Copyright 2025 AxonFlow
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package rbi provides RBI FREE-AI Framework compliance for India-specific PII detection.
+// This is the OSS stub - RBI compliance features are disabled in OSS mode.
+// Enterprise builds overlay this with full PII detection for Aadhaar, PAN, UPI, etc.
+package rbi
+
+// IndiaPIIType represents different categories of India-specific PII
+type IndiaPIIType string
+
+const (
+	IndiaPIITypeUPI            IndiaPIIType = "upi_id"
+	IndiaPIITypeAadhaar        IndiaPIIType = "aadhaar"
+	IndiaPIITypePAN            IndiaPIIType = "pan"
+	IndiaPIITypeIFSC           IndiaPIIType = "ifsc"
+	IndiaPIITypeBankAccount    IndiaPIIType = "bank_account_india"
+	IndiaPIITypeGSTIN          IndiaPIIType = "gstin"
+	IndiaPIITypeVoterID        IndiaPIIType = "voter_id"
+	IndiaPIITypeDrivingLicense IndiaPIIType = "driving_license_india"
+	IndiaPIITypePassport       IndiaPIIType = "passport_india"
+	IndiaPIITypeRationCard     IndiaPIIType = "ration_card"
+	IndiaPIITypeIndianPhone    IndiaPIIType = "phone_india"
+	IndiaPIITypePincode        IndiaPIIType = "pincode"
+)
+
+// IndiaPIISeverity represents the risk level of detected India PII
+type IndiaPIISeverity string
+
+const (
+	IndiaPIISeverityLow      IndiaPIISeverity = "low"
+	IndiaPIISeverityMedium   IndiaPIISeverity = "medium"
+	IndiaPIISeverityHigh     IndiaPIISeverity = "high"
+	IndiaPIISeverityCritical IndiaPIISeverity = "critical"
+)
+
+// IndiaPIIDetectionResult represents a single India PII detection
+type IndiaPIIDetectionResult struct {
+	Type        IndiaPIIType     `json:"type"`
+	Value       string           `json:"value"`
+	MaskedValue string           `json:"masked_value"`
+	Severity    IndiaPIISeverity `json:"severity"`
+	Confidence  float64          `json:"confidence"`
+	StartIndex  int              `json:"start_index"`
+	EndIndex    int              `json:"end_index"`
+	Context     string           `json:"context,omitempty"`
+	RBICategory string           `json:"rbi_category"`
+}
+
+// IndiaPIIDetectorConfig configures the India PII detector behavior
+type IndiaPIIDetectorConfig struct {
+	ContextWindow    int
+	MinConfidence    float64
+	EnableValidation bool
+	EnabledTypes     []IndiaPIIType
+}
+
+// IndiaPIIDetector provides India-specific PII detection for RBI compliance.
+// OSS stub: No-op implementation - India PII detection is disabled in OSS mode.
+type IndiaPIIDetector struct {
+	// No fields needed for OSS stub
+}
+
+// DefaultIndiaPIIDetectorConfig returns sensible defaults for RBI compliance.
+// OSS stub: Returns empty config.
+func DefaultIndiaPIIDetectorConfig() IndiaPIIDetectorConfig {
+	return IndiaPIIDetectorConfig{
+		ContextWindow:    50,
+		MinConfidence:    0.6,
+		EnableValidation: true,
+		EnabledTypes:     nil,
+	}
+}
+
+// NewIndiaPIIDetector creates a new India-specific PII detector.
+// OSS stub: Returns a no-op detector.
+func NewIndiaPIIDetector(config IndiaPIIDetectorConfig) *IndiaPIIDetector {
+	return &IndiaPIIDetector{}
+}
+
+// DetectAll scans text for all types of India PII.
+// OSS stub: Always returns empty slice (no detection in OSS mode).
+func (d *IndiaPIIDetector) DetectAll(text string) []IndiaPIIDetectionResult {
+	return nil
+}
+
+// DetectType scans text for a specific type of India PII.
+// OSS stub: Always returns empty slice (no detection in OSS mode).
+func (d *IndiaPIIDetector) DetectType(text string, piiType IndiaPIIType) []IndiaPIIDetectionResult {
+	return nil
+}
+
+// HasIndiaPII quickly checks if text contains any India PII.
+// OSS stub: Always returns false (no detection in OSS mode).
+func (d *IndiaPIIDetector) HasIndiaPII(text string) bool {
+	return false
+}
+
+// HasCriticalPII checks if text contains critical PII (Aadhaar, PAN, UPI, Bank Account).
+// OSS stub: Always returns false (no detection in OSS mode).
+func (d *IndiaPIIDetector) HasCriticalPII(text string) bool {
+	return false
+}
+
+// GetRBISensitiveData returns all detections categorized by RBI data category.
+// OSS stub: Always returns empty map (no detection in OSS mode).
+func (d *IndiaPIIDetector) GetRBISensitiveData(text string) map[string][]IndiaPIIDetectionResult {
+	return make(map[string][]IndiaPIIDetectionResult)
+}
+
+// GetPatternStats returns statistics about loaded patterns.
+// OSS stub: Returns minimal stats indicating OSS mode.
+func (d *IndiaPIIDetector) GetPatternStats() map[string]interface{} {
+	return map[string]interface{}{
+		"total_patterns": 0,
+		"oss_mode":       true,
+		"enterprise":     false,
+	}
+}
+
+// FilterBySeverity filters results by minimum severity.
+// OSS stub: Returns empty slice.
+func FilterIndiaPIIBySeverity(results []IndiaPIIDetectionResult, minSeverity IndiaPIISeverity) []IndiaPIIDetectionResult {
+	return nil
+}
+
+// FilterByConfidence filters results by minimum confidence.
+// OSS stub: Returns empty slice.
+func FilterIndiaPIIByConfidence(results []IndiaPIIDetectionResult, minConfidence float64) []IndiaPIIDetectionResult {
+	return nil
+}
+
+// GetCriticalFinancialPII returns only critical financial PII (UPI, Aadhaar, PAN, Bank accounts).
+// OSS stub: Returns empty slice.
+func GetCriticalFinancialPII(results []IndiaPIIDetectionResult) []IndiaPIIDetectionResult {
+	return nil
+}
+
+// RBIPIICheckResult represents the result of a pre-check PII scan
+type RBIPIICheckResult struct {
+	HasPII           bool                      `json:"has_pii"`
+	CriticalPII      bool                      `json:"critical_pii"`
+	DetectedTypes    []IndiaPIIType            `json:"detected_types,omitempty"`
+	Detections       []IndiaPIIDetectionResult `json:"detections,omitempty"`
+	BlockRecommended bool                      `json:"block_recommended"`
+	Reason           string                    `json:"reason,omitempty"`
+}
+
+// CheckRequestForPII scans a request for India-specific PII and returns a check result.
+// This is the main entry point for pre-check integration.
+// OSS stub: Returns no PII found.
+func CheckRequestForPII(detector *IndiaPIIDetector, query string, blockOnCritical bool) *RBIPIICheckResult {
+	return &RBIPIICheckResult{
+		HasPII:           false,
+		CriticalPII:      false,
+		DetectedTypes:    nil,
+		Detections:       nil,
+		BlockRecommended: false,
+		Reason:           "",
+	}
+}
+
+// IsEnabled returns whether RBI PII detection is enabled.
+// OSS stub: Always returns false.
+func IsEnabled() bool {
+	return false
+}

--- a/platform/agent/rbi/rbi_oss_test.go
+++ b/platform/agent/rbi/rbi_oss_test.go
@@ -1,0 +1,122 @@
+//go:build !enterprise
+
+// Copyright 2025 AxonFlow
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rbi
+
+import (
+	"testing"
+)
+
+func TestOSSStubIsDisabled(t *testing.T) {
+	if IsEnabled() {
+		t.Error("Expected OSS stub to return IsEnabled() = false")
+	}
+}
+
+func TestOSSStubDetectorReturnsNil(t *testing.T) {
+	config := DefaultIndiaPIIDetectorConfig()
+	detector := NewIndiaPIIDetector(config)
+
+	if detector == nil {
+		t.Error("Expected detector to not be nil even in OSS mode")
+	}
+
+	// Test that detection returns no results in OSS mode
+	results := detector.DetectAll("My Aadhaar is 2234 5678 9012")
+	if len(results) != 0 {
+		t.Errorf("Expected OSS stub to return 0 detections, got %d", len(results))
+	}
+
+	// Test HasIndiaPII returns false in OSS mode
+	if detector.HasIndiaPII("My PAN is ABCDE1234F") {
+		t.Error("Expected OSS stub HasIndiaPII to return false")
+	}
+
+	// Test HasCriticalPII returns false in OSS mode
+	if detector.HasCriticalPII("Payment to user@paytm") {
+		t.Error("Expected OSS stub HasCriticalPII to return false")
+	}
+}
+
+func TestOSSStubCheckRequestForPII(t *testing.T) {
+	config := DefaultIndiaPIIDetectorConfig()
+	detector := NewIndiaPIIDetector(config)
+
+	// OSS stub should return no PII found
+	result := CheckRequestForPII(detector, "My Aadhaar is 2234 5678 9012", true)
+
+	if result.HasPII {
+		t.Error("Expected OSS stub to return HasPII = false")
+	}
+	if result.CriticalPII {
+		t.Error("Expected OSS stub to return CriticalPII = false")
+	}
+	if result.BlockRecommended {
+		t.Error("Expected OSS stub to return BlockRecommended = false")
+	}
+	if len(result.DetectedTypes) != 0 {
+		t.Errorf("Expected 0 detected types, got %d", len(result.DetectedTypes))
+	}
+}
+
+func TestOSSStubGetRBISensitiveData(t *testing.T) {
+	config := DefaultIndiaPIIDetectorConfig()
+	detector := NewIndiaPIIDetector(config)
+
+	// OSS stub should return empty map
+	data := detector.GetRBISensitiveData("PAN: ABCDE1234F, Aadhaar: 2234 5678 9012")
+
+	if len(data) != 0 {
+		t.Errorf("Expected OSS stub to return empty map, got %d categories", len(data))
+	}
+}
+
+func TestOSSStubPatternStats(t *testing.T) {
+	config := DefaultIndiaPIIDetectorConfig()
+	detector := NewIndiaPIIDetector(config)
+
+	stats := detector.GetPatternStats()
+
+	// Check OSS-specific fields
+	if ossMode, ok := stats["oss_mode"].(bool); !ok || !ossMode {
+		t.Error("Expected oss_mode = true in OSS stub stats")
+	}
+	if enterprise, ok := stats["enterprise"].(bool); !ok || enterprise {
+		t.Error("Expected enterprise = false in OSS stub stats")
+	}
+	if totalPatterns, ok := stats["total_patterns"].(int); !ok || totalPatterns != 0 {
+		t.Errorf("Expected 0 total_patterns in OSS stub, got %d", totalPatterns)
+	}
+}
+
+func TestOSSFilterFunctions(t *testing.T) {
+	// All filter functions should return nil/empty in OSS mode
+	var emptyResults []IndiaPIIDetectionResult
+
+	filtered := FilterIndiaPIIBySeverity(emptyResults, IndiaPIISeverityCritical)
+	if filtered != nil && len(filtered) != 0 {
+		t.Error("Expected FilterIndiaPIIBySeverity to return nil/empty")
+	}
+
+	filtered = FilterIndiaPIIByConfidence(emptyResults, 0.8)
+	if filtered != nil && len(filtered) != 0 {
+		t.Error("Expected FilterIndiaPIIByConfidence to return nil/empty")
+	}
+
+	filtered = GetCriticalFinancialPII(emptyResults)
+	if filtered != nil && len(filtered) != 0 {
+		t.Error("Expected GetCriticalFinancialPII to return nil/empty")
+	}
+}

--- a/platform/agent/sqli/audit.go
+++ b/platform/agent/sqli/audit.go
@@ -1,0 +1,187 @@
+package sqli
+
+import (
+	"sync"
+	"time"
+)
+
+// AuditEvent represents a SQL injection detection event for audit logging.
+// This struct is designed to integrate with the agent's audit queue system
+// for compliance with EU AI Act, RBI FREE-AI, and SEBI requirements.
+type AuditEvent struct {
+	// Type identifies this as a SQL injection event
+	Type string `json:"type"`
+
+	// Timestamp when the detection occurred (UTC)
+	Timestamp time.Time `json:"timestamp"`
+
+	// Severity of the detection (critical, high, medium, low)
+	Severity string `json:"severity"`
+
+	// UserID from the request context (if available)
+	UserID string `json:"user_id,omitempty"`
+
+	// ClientID from the request context
+	ClientID string `json:"client_id,omitempty"`
+
+	// TenantID for multi-tenant isolation
+	TenantID string `json:"tenant_id,omitempty"`
+
+	// ConnectorName that produced the response
+	ConnectorName string `json:"connector_name"`
+
+	// ScanType indicates what was scanned (input or response)
+	ScanType ScanType `json:"scan_type"`
+
+	// Pattern that matched
+	Pattern string `json:"pattern"`
+
+	// Category of SQL injection detected
+	Category Category `json:"category"`
+
+	// Confidence score (0.0-1.0)
+	Confidence float64 `json:"confidence"`
+
+	// Mode used for scanning
+	Mode Mode `json:"mode"`
+
+	// Blocked indicates whether the content was blocked
+	Blocked bool `json:"blocked"`
+
+	// ScanDuration in nanoseconds
+	ScanDuration time.Duration `json:"scan_duration_ns"`
+
+	// RequestID for tracing (if available)
+	RequestID string `json:"request_id,omitempty"`
+
+	// InputSnippet is a sanitized snippet of the input (for forensics)
+	InputSnippet string `json:"input_snippet,omitempty"`
+}
+
+// AuditEventType is the type string for SQL injection audit events.
+const AuditEventType = "sqli_detection"
+
+// Severity levels for SQL injection detections
+const (
+	SeverityCritical = "critical" // Actively exploited injection
+	SeverityHigh     = "high"     // Definite injection attempt
+	SeverityMedium   = "medium"   // Suspected injection
+	SeverityLow      = "low"      // Minor pattern match
+)
+
+// CategorySeverity maps SQL injection categories to severity levels.
+func CategorySeverity(category Category) string {
+	switch category {
+	case CategoryStackedQueries:
+		return SeverityCritical // Can modify/delete data
+	case CategoryDangerousQuery:
+		return SeverityCritical // DDL operations that can destroy data
+	case CategoryUnionBased:
+		return SeverityHigh // Can extract data
+	case CategoryTimeBased:
+		return SeverityHigh // Confirms vulnerability
+	case CategoryBooleanBlind:
+		return SeverityMedium // May be false positive
+	case CategoryErrorBased:
+		return SeverityMedium
+	case CategoryCommentInjection:
+		return SeverityMedium
+	case CategoryGeneric:
+		return SeverityLow
+	default:
+		return SeverityLow
+	}
+}
+
+// NewAuditEvent creates an audit event from a scan result.
+func NewAuditEvent(result *Result, connectorName string) *AuditEvent {
+	if result == nil || !result.Detected {
+		return nil
+	}
+
+	return &AuditEvent{
+		Type:          AuditEventType,
+		Timestamp:     time.Now().UTC(),
+		Severity:      CategorySeverity(result.Category),
+		ConnectorName: connectorName,
+		ScanType:      result.ScanType,
+		Pattern:       result.Pattern,
+		Category:      result.Category,
+		Confidence:    result.Confidence,
+		Mode:          result.Mode,
+		Blocked:       result.Blocked,
+		ScanDuration:  result.Duration,
+		InputSnippet:  result.Input,
+	}
+}
+
+// WithUserContext adds user context to the audit event.
+func (e *AuditEvent) WithUserContext(userID, clientID, tenantID string) *AuditEvent {
+	e.UserID = userID
+	e.ClientID = clientID
+	e.TenantID = tenantID
+	return e
+}
+
+// WithRequestID adds a request ID for tracing.
+func (e *AuditEvent) WithRequestID(requestID string) *AuditEvent {
+	e.RequestID = requestID
+	return e
+}
+
+// ToAuditDetails converts the event to a map suitable for the audit queue.
+func (e *AuditEvent) ToAuditDetails() map[string]interface{} {
+	return map[string]interface{}{
+		"connector_name": e.ConnectorName,
+		"scan_type":      string(e.ScanType),
+		"pattern":        e.Pattern,
+		"category":       string(e.Category),
+		"confidence":     e.Confidence,
+		"mode":           string(e.Mode),
+		"blocked":        e.Blocked,
+		"scan_duration":  e.ScanDuration.String(),
+		"request_id":     e.RequestID,
+		"input_snippet":  e.InputSnippet,
+	}
+}
+
+// AuditCallback is a function type for audit event callbacks.
+// This allows the middleware to emit audit events to the audit queue
+// without creating a circular dependency.
+type AuditCallback func(event *AuditEvent)
+
+// DefaultAuditCallback is a no-op callback used when no audit system is configured.
+var DefaultAuditCallback AuditCallback = func(event *AuditEvent) {}
+
+// globalAuditCallback holds the configured audit callback.
+// Protected by auditCallbackMu for thread safety.
+var (
+	globalAuditCallback AuditCallback = DefaultAuditCallback
+	auditCallbackMu     sync.RWMutex
+)
+
+// SetAuditCallback configures the global audit callback.
+// This should be called during agent initialization to connect
+// the SQL injection detection to the audit queue.
+// Thread-safe: can be called from any goroutine.
+func SetAuditCallback(callback AuditCallback) {
+	auditCallbackMu.Lock()
+	defer auditCallbackMu.Unlock()
+	if callback == nil {
+		globalAuditCallback = DefaultAuditCallback
+		return
+	}
+	globalAuditCallback = callback
+}
+
+// EmitAuditEvent sends a detection event to the configured audit system.
+// Thread-safe: can be called from any goroutine.
+func EmitAuditEvent(event *AuditEvent) {
+	if event == nil {
+		return
+	}
+	auditCallbackMu.RLock()
+	cb := globalAuditCallback
+	auditCallbackMu.RUnlock()
+	cb(event)
+}

--- a/platform/agent/sqli/audit_test.go
+++ b/platform/agent/sqli/audit_test.go
@@ -1,0 +1,229 @@
+package sqli
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestCategorySeverity(t *testing.T) {
+	tests := []struct {
+		category Category
+		want     string
+	}{
+		{CategoryStackedQueries, SeverityCritical},
+		{CategoryDangerousQuery, SeverityCritical},
+		{CategoryUnionBased, SeverityHigh},
+		{CategoryTimeBased, SeverityHigh},
+		{CategoryBooleanBlind, SeverityMedium},
+		{CategoryErrorBased, SeverityMedium},
+		{CategoryCommentInjection, SeverityMedium},
+		{CategoryGeneric, SeverityLow},
+		{Category("unknown"), SeverityLow},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.category), func(t *testing.T) {
+			if got := CategorySeverity(tt.category); got != tt.want {
+				t.Errorf("CategorySeverity(%v) = %v, want %v", tt.category, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewAuditEvent(t *testing.T) {
+	t.Run("nil result returns nil", func(t *testing.T) {
+		if got := NewAuditEvent(nil, "postgres"); got != nil {
+			t.Error("NewAuditEvent(nil) should return nil")
+		}
+	})
+
+	t.Run("undetected result returns nil", func(t *testing.T) {
+		result := &Result{Detected: false}
+		if got := NewAuditEvent(result, "postgres"); got != nil {
+			t.Error("NewAuditEvent with undetected result should return nil")
+		}
+	})
+
+	t.Run("detected result creates event", func(t *testing.T) {
+		result := &Result{
+			Detected:   true,
+			Blocked:    true,
+			Pattern:    "union_select",
+			Category:   CategoryUnionBased,
+			Confidence: 0.95,
+			ScanType:   ScanTypeResponse,
+			Mode:       ModeBasic,
+			Duration:   5 * time.Millisecond,
+			Input:      "admin' UNION SELECT...",
+		}
+
+		event := NewAuditEvent(result, "postgres")
+
+		if event == nil {
+			t.Fatal("NewAuditEvent returned nil for detected result")
+		}
+		if event.Type != AuditEventType {
+			t.Errorf("Type = %v, want %v", event.Type, AuditEventType)
+		}
+		if event.ConnectorName != "postgres" {
+			t.Errorf("ConnectorName = %v, want postgres", event.ConnectorName)
+		}
+		if event.Pattern != "union_select" {
+			t.Errorf("Pattern = %v, want union_select", event.Pattern)
+		}
+		if event.Category != CategoryUnionBased {
+			t.Errorf("Category = %v, want %v", event.Category, CategoryUnionBased)
+		}
+		if event.Severity != SeverityHigh {
+			t.Errorf("Severity = %v, want %v", event.Severity, SeverityHigh)
+		}
+		if event.Confidence != 0.95 {
+			t.Errorf("Confidence = %v, want 0.95", event.Confidence)
+		}
+		if !event.Blocked {
+			t.Error("Blocked should be true")
+		}
+		if event.Timestamp.IsZero() {
+			t.Error("Timestamp should not be zero")
+		}
+	})
+}
+
+func TestAuditEvent_WithContext(t *testing.T) {
+	result := &Result{
+		Detected: true,
+		Category: CategoryGeneric,
+	}
+	event := NewAuditEvent(result, "redis")
+
+	event.WithUserContext("user123", "client456", "tenant789")
+	event.WithRequestID("req-abc-123")
+
+	if event.UserID != "user123" {
+		t.Errorf("UserID = %v, want user123", event.UserID)
+	}
+	if event.ClientID != "client456" {
+		t.Errorf("ClientID = %v, want client456", event.ClientID)
+	}
+	if event.TenantID != "tenant789" {
+		t.Errorf("TenantID = %v, want tenant789", event.TenantID)
+	}
+	if event.RequestID != "req-abc-123" {
+		t.Errorf("RequestID = %v, want req-abc-123", event.RequestID)
+	}
+}
+
+func TestAuditEvent_ToAuditDetails(t *testing.T) {
+	result := &Result{
+		Detected:   true,
+		Pattern:    "sleep_function",
+		Category:   CategoryTimeBased,
+		Confidence: 1.0,
+		Mode:       ModeAdvanced,
+		Blocked:    true,
+		Duration:   10 * time.Millisecond,
+		Input:      "SELECT SLEEP(5)...",
+		ScanType:   ScanTypeInput,
+	}
+	event := NewAuditEvent(result, "mysql")
+	event.WithRequestID("test-request")
+
+	details := event.ToAuditDetails()
+
+	if details["connector_name"] != "mysql" {
+		t.Errorf("connector_name = %v, want mysql", details["connector_name"])
+	}
+	if details["pattern"] != "sleep_function" {
+		t.Errorf("pattern = %v, want sleep_function", details["pattern"])
+	}
+	if details["category"] != string(CategoryTimeBased) {
+		t.Errorf("category = %v, want %v", details["category"], CategoryTimeBased)
+	}
+	if details["mode"] != string(ModeAdvanced) {
+		t.Errorf("mode = %v, want %v", details["mode"], ModeAdvanced)
+	}
+	if details["blocked"] != true {
+		t.Error("blocked should be true")
+	}
+	if details["request_id"] != "test-request" {
+		t.Errorf("request_id = %v, want test-request", details["request_id"])
+	}
+}
+
+func TestSetAuditCallback(t *testing.T) {
+	// Save original
+	originalCallback := globalAuditCallback
+	defer func() { globalAuditCallback = originalCallback }()
+
+	t.Run("set custom callback", func(t *testing.T) {
+		callCount := 0
+		SetAuditCallback(func(event *AuditEvent) {
+			callCount++
+		})
+
+		// Emit an event
+		event := &AuditEvent{Type: AuditEventType}
+		EmitAuditEvent(event)
+
+		if callCount != 1 {
+			t.Errorf("Callback called %d times, want 1", callCount)
+		}
+	})
+
+	t.Run("set nil callback uses default", func(t *testing.T) {
+		SetAuditCallback(nil)
+
+		// Should not panic
+		event := &AuditEvent{Type: AuditEventType}
+		EmitAuditEvent(event)
+	})
+
+	t.Run("emit nil event is safe", func(t *testing.T) {
+		callCount := 0
+		SetAuditCallback(func(event *AuditEvent) {
+			callCount++
+		})
+
+		EmitAuditEvent(nil)
+
+		if callCount != 0 {
+			t.Error("Callback should not be called for nil event")
+		}
+	})
+}
+
+func TestAuditCallback_Concurrent(t *testing.T) {
+	// Save original
+	originalCallback := globalAuditCallback
+	defer func() { globalAuditCallback = originalCallback }()
+
+	var mu sync.Mutex
+	events := make([]*AuditEvent, 0)
+
+	SetAuditCallback(func(event *AuditEvent) {
+		mu.Lock()
+		events = append(events, event)
+		mu.Unlock()
+	})
+
+	// Emit events concurrently
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			event := &AuditEvent{
+				Type:      AuditEventType,
+				RequestID: string(rune('A' + i%26)),
+			}
+			EmitAuditEvent(event)
+		}(i)
+	}
+
+	wg.Wait()
+
+	if len(events) != 100 {
+		t.Errorf("Got %d events, want 100", len(events))
+	}
+}

--- a/platform/agent/sqli/basic_scanner.go
+++ b/platform/agent/sqli/basic_scanner.go
@@ -1,0 +1,156 @@
+package sqli
+
+import (
+	"context"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// BasicScanner implements pattern-based SQL injection detection.
+// It uses regex patterns to identify common SQL injection techniques.
+// This scanner is available in the Community edition.
+type BasicScanner struct {
+	patterns     *PatternSet
+	maxInputLen  int
+	snippetLen   int
+}
+
+// BasicScannerOption is a functional option for configuring BasicScanner.
+type BasicScannerOption func(*BasicScanner)
+
+// WithPatternSet sets a custom pattern set for the scanner.
+func WithPatternSet(ps *PatternSet) BasicScannerOption {
+	return func(s *BasicScanner) {
+		s.patterns = ps
+	}
+}
+
+// WithMaxInputLength sets the maximum input length to scan.
+func WithMaxInputLength(maxLen int) BasicScannerOption {
+	return func(s *BasicScanner) {
+		s.maxInputLen = maxLen
+	}
+}
+
+// WithSnippetLength sets the length of the input snippet in results.
+func WithSnippetLength(length int) BasicScannerOption {
+	return func(s *BasicScanner) {
+		s.snippetLen = length
+	}
+}
+
+// NewBasicScanner creates a new basic scanner with the given options.
+func NewBasicScanner(opts ...BasicScannerOption) *BasicScanner {
+	s := &BasicScanner{
+		patterns:    NewPatternSet(),
+		maxInputLen: 1048576, // 1MB default
+		snippetLen:  100,     // 100 chars for logging
+	}
+
+	for _, opt := range opts {
+		opt(s)
+	}
+
+	return s
+}
+
+// Scan checks the content for SQL injection patterns.
+func (s *BasicScanner) Scan(ctx context.Context, content string, scanType ScanType) *Result {
+	start := time.Now()
+
+	// Check context cancellation
+	select {
+	case <-ctx.Done():
+		return &Result{
+			Detected: false,
+			ScanType: scanType,
+			Mode:     ModeBasic,
+			Duration: time.Since(start),
+			Metadata: map[string]any{"error": "context cancelled"},
+		}
+	default:
+	}
+
+	// Truncate if too long
+	if len(content) > s.maxInputLen {
+		content = content[:s.maxInputLen]
+	}
+
+	// Scan with all patterns
+	for _, pattern := range s.patterns.Patterns() {
+		if pattern.Regex.MatchString(content) {
+			return &Result{
+				Detected:   true,
+				Blocked:    true, // Basic scanner always recommends blocking
+				Pattern:    pattern.Name,
+				Category:   pattern.Category,
+				Confidence: 1.0, // Pattern match is binary
+				Input:      s.sanitizeInput(content),
+				ScanType:   scanType,
+				Mode:       ModeBasic,
+				Duration:   time.Since(start),
+				Metadata: map[string]any{
+					"pattern_description": pattern.Description,
+					"severity":            pattern.Severity,
+				},
+			}
+		}
+	}
+
+	return &Result{
+		Detected: false,
+		Blocked:  false,
+		ScanType: scanType,
+		Mode:     ModeBasic,
+		Duration: time.Since(start),
+	}
+}
+
+// Mode returns ModeBasic.
+func (s *BasicScanner) Mode() Mode {
+	return ModeBasic
+}
+
+// IsEnterprise returns false as basic scanner is in Community edition.
+func (s *BasicScanner) IsEnterprise() bool {
+	return false
+}
+
+// sanitizeInput creates a safe snippet of the input for logging.
+// It truncates the input and masks potentially sensitive data.
+func (s *BasicScanner) sanitizeInput(input string) string {
+	if len(input) <= s.snippetLen {
+		return sanitizeForLog(input)
+	}
+	return sanitizeForLog(input[:s.snippetLen]) + "..."
+}
+
+// Precompiled masking regexes for performance
+var (
+	passwordMaskRegex = regexp.MustCompile(`(?i)(password|passwd|pwd)\s*[=:]\s*['"]?[^'"\s]+['"]?`)
+	apiKeyMaskRegex   = regexp.MustCompile(`(?i)(api[_-]?key|apikey|secret[_-]?key)\s*[=:]\s*['"]?[^'"\s]+['"]?`)
+	tokenMaskRegex    = regexp.MustCompile(`(?i)(token|bearer)\s*[=:]\s*['"]?[^'"\s]+['"]?`)
+)
+
+// sanitizeForLog removes or masks sensitive patterns in the input.
+func sanitizeForLog(input string) string {
+	// Replace newlines with spaces first
+	input = strings.ReplaceAll(input, "\n", " ")
+
+	// Replace potential password fields
+	input = passwordMaskRegex.ReplaceAllString(input, "[REDACTED_PASSWORD]")
+	// Replace potential API keys
+	input = apiKeyMaskRegex.ReplaceAllString(input, "[REDACTED_KEY]")
+	// Replace potential tokens
+	input = tokenMaskRegex.ReplaceAllString(input, "[REDACTED_TOKEN]")
+
+	return input
+}
+
+func init() {
+	// Register basic scanner in the registry
+	RegisterScanner(ModeBasic, func() Scanner {
+		return NewBasicScanner()
+	})
+}

--- a/platform/agent/sqli/basic_scanner_test.go
+++ b/platform/agent/sqli/basic_scanner_test.go
@@ -1,0 +1,614 @@
+package sqli
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNewBasicScanner(t *testing.T) {
+	t.Run("default configuration", func(t *testing.T) {
+		scanner := NewBasicScanner()
+		if scanner == nil {
+			t.Fatal("NewBasicScanner returned nil")
+		}
+		if scanner.patterns == nil {
+			t.Error("patterns should not be nil")
+		}
+		if scanner.maxInputLen != 1048576 {
+			t.Errorf("maxInputLen = %d, want %d", scanner.maxInputLen, 1048576)
+		}
+		if scanner.snippetLen != 100 {
+			t.Errorf("snippetLen = %d, want %d", scanner.snippetLen, 100)
+		}
+	})
+
+	t.Run("with custom options", func(t *testing.T) {
+		customPatterns := &PatternSet{patterns: []*Pattern{}}
+		scanner := NewBasicScanner(
+			WithPatternSet(customPatterns),
+			WithMaxInputLength(500),
+			WithSnippetLength(50),
+		)
+		if scanner.patterns != customPatterns {
+			t.Error("custom pattern set not applied")
+		}
+		if scanner.maxInputLen != 500 {
+			t.Errorf("maxInputLen = %d, want %d", scanner.maxInputLen, 500)
+		}
+		if scanner.snippetLen != 50 {
+			t.Errorf("snippetLen = %d, want %d", scanner.snippetLen, 50)
+		}
+	})
+}
+
+func TestBasicScanner_Mode(t *testing.T) {
+	scanner := NewBasicScanner()
+	if got := scanner.Mode(); got != ModeBasic {
+		t.Errorf("Mode() = %v, want %v", got, ModeBasic)
+	}
+}
+
+func TestBasicScanner_IsEnterprise(t *testing.T) {
+	scanner := NewBasicScanner()
+	if got := scanner.IsEnterprise(); got != false {
+		t.Errorf("IsEnterprise() = %v, want false", got)
+	}
+}
+
+func TestBasicScanner_Scan_Detection(t *testing.T) {
+	scanner := NewBasicScanner()
+	ctx := context.Background()
+
+	tests := []struct {
+		name           string
+		input          string
+		scanType       ScanType
+		wantDetected   bool
+		wantCategory   Category
+		wantPatternIn  []string // Pattern name should contain one of these
+	}{
+		// UNION-based injections
+		{
+			name:          "union select",
+			input:         "SELECT * FROM users WHERE id=1 UNION SELECT password FROM admin",
+			scanType:      ScanTypeInput,
+			wantDetected:  true,
+			wantCategory:  CategoryUnionBased,
+			wantPatternIn: []string{"union"},
+		},
+		{
+			name:          "union all select",
+			input:         "1 UNION ALL SELECT username, password FROM users",
+			scanType:      ScanTypeInput,
+			wantDetected:  true,
+			wantCategory:  CategoryUnionBased,
+			wantPatternIn: []string{"union"},
+		},
+		{
+			name:          "union injection after quote",
+			input:         "' UNION SELECT * FROM users--",
+			scanType:      ScanTypeInput,
+			wantDetected:  true,
+			wantCategory:  CategoryUnionBased,
+			wantPatternIn: []string{"union"},
+		},
+
+		// Boolean-based blind injections
+		{
+			name:          "or 1=1",
+			input:         "admin' OR 1=1--",
+			scanType:      ScanTypeInput,
+			wantDetected:  true,
+			wantCategory:  CategoryBooleanBlind,
+			wantPatternIn: []string{"or"},
+		},
+		{
+			name:          "or 'a'='a'",
+			input:         "' OR 'a'='a'",
+			scanType:      ScanTypeInput,
+			wantDetected:  true,
+			wantCategory:  CategoryBooleanBlind,
+			wantPatternIn: []string{"or"},
+		},
+
+		// Time-based blind injections
+		{
+			name:          "sleep function",
+			input:         "1; SELECT SLEEP(5)--",
+			scanType:      ScanTypeInput,
+			wantDetected:  true,
+			wantCategory:  CategoryTimeBased,
+			wantPatternIn: []string{"sleep"},
+		},
+		{
+			name:          "waitfor delay",
+			input:         "'; WAITFOR DELAY '0:0:5'--",
+			scanType:      ScanTypeInput,
+			wantDetected:  true,
+			wantCategory:  CategoryTimeBased,
+			wantPatternIn: []string{"waitfor"},
+		},
+		{
+			name:          "pg_sleep",
+			input:         "'; SELECT PG_SLEEP(5)--",
+			scanType:      ScanTypeInput,
+			wantDetected:  true,
+			wantCategory:  CategoryTimeBased,
+			wantPatternIn: []string{"pg_sleep"},
+		},
+		{
+			name:          "benchmark",
+			input:         "SELECT BENCHMARK(10000000, SHA1('test'))",
+			scanType:      ScanTypeInput,
+			wantDetected:  true,
+			wantCategory:  CategoryTimeBased,
+			wantPatternIn: []string{"benchmark"},
+		},
+
+		// Stacked queries
+		{
+			name:          "drop table",
+			input:         "1; DROP TABLE users--",
+			scanType:      ScanTypeInput,
+			wantDetected:  true,
+			wantCategory:  CategoryStackedQueries,
+			wantPatternIn: []string{"drop"},
+		},
+		{
+			name:          "drop database",
+			input:         "'; DROP DATABASE production--",
+			scanType:      ScanTypeInput,
+			wantDetected:  true,
+			wantCategory:  CategoryStackedQueries,
+			wantPatternIn: []string{"drop"},
+		},
+		{
+			name:          "delete from",
+			input:         "1; DELETE FROM users WHERE 1=1--",
+			scanType:      ScanTypeInput,
+			wantDetected:  true,
+			wantCategory:  CategoryStackedQueries,
+			wantPatternIn: []string{"delete"},
+		},
+		{
+			name:          "update set",
+			input:         "'; UPDATE users SET admin=1--",
+			scanType:      ScanTypeInput,
+			wantDetected:  true,
+			wantCategory:  CategoryStackedQueries,
+			wantPatternIn: []string{"update"},
+		},
+		{
+			name:          "insert into",
+			input:         "'; INSERT INTO users VALUES('hacker','password')--",
+			scanType:      ScanTypeInput,
+			wantDetected:  true,
+			wantCategory:  CategoryStackedQueries,
+			wantPatternIn: []string{"insert"},
+		},
+
+		// Dangerous query patterns (non-stacked DDL/privilege operations)
+		{
+			name:          "truncate table",
+			input:         "TRUNCATE TABLE users",
+			scanType:      ScanTypeInput,
+			wantDetected:  true,
+			wantCategory:  CategoryDangerousQuery,
+			wantPatternIn: []string{"truncate"},
+		},
+		{
+			name:          "alter table",
+			input:         "ALTER TABLE users ADD COLUMN backdoor VARCHAR(255)",
+			scanType:      ScanTypeInput,
+			wantDetected:  true,
+			wantCategory:  CategoryDangerousQuery,
+			wantPatternIn: []string{"alter"},
+		},
+		{
+			name:          "delete without where",
+			input:         "DELETE FROM users;",
+			scanType:      ScanTypeInput,
+			wantDetected:  true,
+			wantCategory:  CategoryDangerousQuery,
+			wantPatternIn: []string{"delete"},
+		},
+		{
+			name:          "create user",
+			input:         "CREATE USER hacker IDENTIFIED BY 'password123'",
+			scanType:      ScanTypeInput,
+			wantDetected:  true,
+			wantCategory:  CategoryDangerousQuery,
+			wantPatternIn: []string{"create_user"},
+		},
+		{
+			name:          "grant privileges",
+			input:         "GRANT ALL PRIVILEGES ON *.* TO 'hacker'@'%'",
+			scanType:      ScanTypeInput,
+			wantDetected:  true,
+			wantCategory:  CategoryDangerousQuery,
+			wantPatternIn: []string{"grant"},
+		},
+		{
+			name:          "revoke privileges",
+			input:         "REVOKE SELECT ON database.* FROM 'user'@'localhost'",
+			scanType:      ScanTypeInput,
+			wantDetected:  true,
+			wantCategory:  CategoryDangerousQuery,
+			wantPatternIn: []string{"revoke"},
+		},
+		{
+			name:          "standalone drop table",
+			input:         "DROP TABLE sensitive_data",
+			scanType:      ScanTypeInput,
+			wantDetected:  true,
+			wantCategory:  CategoryDangerousQuery,
+			wantPatternIn: []string{"drop"},
+		},
+
+		// Generic patterns
+		{
+			name:          "information_schema",
+			input:         "SELECT * FROM INFORMATION_SCHEMA.TABLES",
+			scanType:      ScanTypeInput,
+			wantDetected:  true,
+			wantCategory:  CategoryGeneric,
+			wantPatternIn: []string{"information_schema"},
+		},
+		{
+			name:          "load_file",
+			input:         "SELECT LOAD_FILE('/etc/passwd')",
+			scanType:      ScanTypeInput,
+			wantDetected:  true,
+			wantCategory:  CategoryGeneric,
+			wantPatternIn: []string{"load_file"},
+		},
+		{
+			name:          "into outfile",
+			input:         "SELECT '<?php system($_GET[\"cmd\"]); ?>' INTO OUTFILE '/var/www/shell.php'",
+			scanType:      ScanTypeInput,
+			wantDetected:  true,
+			wantCategory:  CategoryGeneric,
+			wantPatternIn: []string{"outfile"},
+		},
+
+		// Safe inputs (no detection expected)
+		{
+			name:         "normal select",
+			input:        "What are the top 10 products by sales?",
+			scanType:     ScanTypeInput,
+			wantDetected: false,
+		},
+		{
+			name:         "normal text",
+			input:        "Hello, how can I help you today?",
+			scanType:     ScanTypeInput,
+			wantDetected: false,
+		},
+		{
+			name:         "empty input",
+			input:        "",
+			scanType:     ScanTypeInput,
+			wantDetected: false,
+		},
+		{
+			name:         "json response",
+			input:        `{"name": "John", "email": "john@example.com"}`,
+			scanType:     ScanTypeResponse,
+			wantDetected: false,
+		},
+		{
+			name:         "safe sql-like text",
+			input:        "Please select your favorite option from the dropdown",
+			scanType:     ScanTypeInput,
+			wantDetected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := scanner.Scan(ctx, tt.input, tt.scanType)
+
+			if result.Detected != tt.wantDetected {
+				t.Errorf("Detected = %v, want %v", result.Detected, tt.wantDetected)
+			}
+
+			if tt.wantDetected {
+				if result.Category != tt.wantCategory {
+					t.Errorf("Category = %v, want %v", result.Category, tt.wantCategory)
+				}
+
+				if len(tt.wantPatternIn) > 0 {
+					found := false
+					for _, sub := range tt.wantPatternIn {
+						if strings.Contains(strings.ToLower(result.Pattern), strings.ToLower(sub)) {
+							found = true
+							break
+						}
+					}
+					if !found {
+						t.Errorf("Pattern = %v, want to contain one of %v", result.Pattern, tt.wantPatternIn)
+					}
+				}
+
+				if result.Confidence != 1.0 {
+					t.Errorf("Confidence = %v, want 1.0", result.Confidence)
+				}
+
+				if !result.Blocked {
+					t.Error("Blocked should be true when detected")
+				}
+			}
+
+			if result.ScanType != tt.scanType {
+				t.Errorf("ScanType = %v, want %v", result.ScanType, tt.scanType)
+			}
+
+			if result.Mode != ModeBasic {
+				t.Errorf("Mode = %v, want %v", result.Mode, ModeBasic)
+			}
+
+			if result.Duration <= 0 {
+				t.Error("Duration should be positive")
+			}
+		})
+	}
+}
+
+func TestBasicScanner_Scan_ResponseType(t *testing.T) {
+	scanner := NewBasicScanner()
+	ctx := context.Background()
+
+	// Test that response scanning works the same as input scanning
+	maliciousResponse := "The query returned: admin' UNION SELECT password FROM users--"
+	result := scanner.Scan(ctx, maliciousResponse, ScanTypeResponse)
+
+	if !result.Detected {
+		t.Error("Should detect SQL injection in response")
+	}
+	if result.ScanType != ScanTypeResponse {
+		t.Errorf("ScanType = %v, want %v", result.ScanType, ScanTypeResponse)
+	}
+}
+
+func TestBasicScanner_Scan_ContextCancellation(t *testing.T) {
+	scanner := NewBasicScanner()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	result := scanner.Scan(ctx, "UNION SELECT * FROM users", ScanTypeInput)
+
+	if result.Detected {
+		t.Error("Should not detect when context is cancelled")
+	}
+	if result.Metadata == nil || result.Metadata["error"] != "context cancelled" {
+		t.Error("Should have error metadata for context cancellation")
+	}
+}
+
+func TestBasicScanner_Scan_LongInput(t *testing.T) {
+	scanner := NewBasicScanner(WithMaxInputLength(100))
+	ctx := context.Background()
+
+	// Create input longer than max
+	longInput := strings.Repeat("a", 50) + "UNION SELECT * FROM users" + strings.Repeat("b", 100)
+
+	result := scanner.Scan(ctx, longInput, ScanTypeInput)
+
+	// Should not detect because injection is beyond truncation point
+	if result.Detected {
+		t.Error("Should not detect injection beyond truncation point")
+	}
+
+	// Create input with injection within truncation
+	shortInput := "UNION SELECT * FROM users" + strings.Repeat("b", 200)
+	result = scanner.Scan(ctx, shortInput, ScanTypeInput)
+
+	if !result.Detected {
+		t.Error("Should detect injection within truncation point")
+	}
+}
+
+func TestBasicScanner_Scan_InputSnippet(t *testing.T) {
+	scanner := NewBasicScanner(WithSnippetLength(20))
+	ctx := context.Background()
+
+	longMalicious := "UNION SELECT password, username, email, address FROM users WHERE 1=1"
+	result := scanner.Scan(ctx, longMalicious, ScanTypeInput)
+
+	if !result.Detected {
+		t.Fatal("Should detect injection")
+	}
+
+	// Input snippet should be truncated
+	if len(result.Input) > 25 { // 20 + "..."
+		t.Errorf("Input snippet should be truncated, got length %d", len(result.Input))
+	}
+}
+
+func TestBasicScanner_Registration(t *testing.T) {
+	// Test that basic scanner is properly registered
+	scanner, err := NewScanner(ModeBasic)
+	if err != nil {
+		t.Fatalf("NewScanner(ModeBasic) error = %v", err)
+	}
+	if scanner == nil {
+		t.Fatal("NewScanner(ModeBasic) returned nil")
+	}
+	if _, ok := scanner.(*BasicScanner); !ok {
+		t.Errorf("NewScanner(ModeBasic) returned %T, want *BasicScanner", scanner)
+	}
+}
+
+func TestBasicScanner_Scan_Performance(t *testing.T) {
+	scanner := NewBasicScanner()
+	ctx := context.Background()
+
+	// Typical input size
+	input := "What is the weather forecast for tomorrow in New York?"
+
+	start := time.Now()
+	iterations := 1000
+	for i := 0; i < iterations; i++ {
+		scanner.Scan(ctx, input, ScanTypeInput)
+	}
+	elapsed := time.Since(start)
+
+	avgTime := elapsed / time.Duration(iterations)
+	if avgTime > time.Millisecond {
+		t.Errorf("Average scan time = %v, want < 1ms", avgTime)
+	}
+}
+
+func TestPatternSet(t *testing.T) {
+	ps := NewPatternSet()
+
+	t.Run("has patterns", func(t *testing.T) {
+		patterns := ps.Patterns()
+		if len(patterns) == 0 {
+			t.Error("PatternSet should have patterns")
+		}
+	})
+
+	t.Run("patterns by category", func(t *testing.T) {
+		categories := []Category{
+			CategoryUnionBased,
+			CategoryBooleanBlind,
+			CategoryTimeBased,
+			CategoryErrorBased,
+			CategoryStackedQueries,
+			CategoryCommentInjection,
+			CategoryGeneric,
+		}
+
+		for _, cat := range categories {
+			patterns := ps.PatternsByCategory(cat)
+			if len(patterns) == 0 {
+				t.Errorf("No patterns for category %v", cat)
+			}
+			for _, p := range patterns {
+				if p.Category != cat {
+					t.Errorf("Pattern %s has category %v, expected %v", p.Name, p.Category, cat)
+				}
+			}
+		}
+	})
+
+	t.Run("all patterns have required fields", func(t *testing.T) {
+		for _, p := range ps.Patterns() {
+			if p.Name == "" {
+				t.Error("Pattern should have a name")
+			}
+			if p.Regex == nil {
+				t.Errorf("Pattern %s should have a regex", p.Name)
+			}
+			if p.Category == "" {
+				t.Errorf("Pattern %s should have a category", p.Name)
+			}
+			if p.Description == "" {
+				t.Errorf("Pattern %s should have a description", p.Name)
+			}
+			if p.Severity < 1 || p.Severity > 10 {
+				t.Errorf("Pattern %s severity %d should be 1-10", p.Name, p.Severity)
+			}
+		}
+	})
+}
+
+func TestTestOnlyPattern(t *testing.T) {
+	p := TestOnlyPattern("test", `\bTEST\b`, CategoryGeneric)
+	if p.Name != "test" {
+		t.Errorf("Name = %v, want test", p.Name)
+	}
+	if p.Category != CategoryGeneric {
+		t.Errorf("Category = %v, want %v", p.Category, CategoryGeneric)
+	}
+	if !p.Regex.MatchString("TEST pattern") {
+		t.Error("Regex should match TEST")
+	}
+}
+
+// Benchmark tests
+func BenchmarkBasicScanner_SafeInput(b *testing.B) {
+	scanner := NewBasicScanner()
+	ctx := context.Background()
+	input := "What is the weather forecast for tomorrow?"
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		scanner.Scan(ctx, input, ScanTypeInput)
+	}
+}
+
+func BenchmarkBasicScanner_MaliciousInput(b *testing.B) {
+	scanner := NewBasicScanner()
+	ctx := context.Background()
+	input := "admin' OR 1=1--"
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		scanner.Scan(ctx, input, ScanTypeInput)
+	}
+}
+
+func BenchmarkBasicScanner_LongInput(b *testing.B) {
+	scanner := NewBasicScanner()
+	ctx := context.Background()
+	input := strings.Repeat("This is a normal text without any SQL injection. ", 100)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		scanner.Scan(ctx, input, ScanTypeInput)
+	}
+}
+
+// TestSanitizeForLog tests the sanitization of sensitive data in log output
+func TestSanitizeForLog(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "password field redacted",
+			input:    "SELECT * FROM users WHERE password='secret123'",
+			expected: "SELECT * FROM users WHERE [REDACTED_PASSWORD]",
+		},
+		{
+			name:     "api_key redacted",
+			input:    "api_key=sk-12345678 AND user_id=1",
+			expected: "[REDACTED_KEY] AND user_id=1",
+		},
+		{
+			name:     "token redacted",
+			input:    "Authorization: token=abc123xyz",
+			expected: "Authorization: [REDACTED_TOKEN]",
+		},
+		{
+			name:     "newlines replaced with spaces",
+			input:    "line1\nline2\nline3",
+			expected: "line1 line2 line3",
+		},
+		{
+			name:     "no sensitive data unchanged",
+			input:    "SELECT id, name FROM users WHERE id = 1",
+			expected: "SELECT id, name FROM users WHERE id = 1",
+		},
+		{
+			name:     "multiple sensitive fields",
+			input:    "password=secret api_key=key123",
+			expected: "[REDACTED_PASSWORD] [REDACTED_KEY]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := sanitizeForLog(tt.input)
+			if result != tt.expected {
+				t.Errorf("sanitizeForLog(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}

--- a/platform/agent/sqli/config.go
+++ b/platform/agent/sqli/config.go
@@ -1,0 +1,143 @@
+package sqli
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Config holds the SQL injection scanning configuration.
+type Config struct {
+	// InputMode is the scanning mode for user input/prompts.
+	// Default: basic
+	InputMode Mode `json:"input_mode" yaml:"input_mode"`
+
+	// ResponseMode is the scanning mode for MCP connector responses.
+	// Default: basic
+	ResponseMode Mode `json:"response_mode" yaml:"response_mode"`
+
+	// BlockOnDetection determines whether to block content when injection is detected.
+	// If false, detection is logged but content is allowed through.
+	// Default: true
+	BlockOnDetection bool `json:"block_on_detection" yaml:"block_on_detection"`
+
+	// LogDetections determines whether to log detection events.
+	// Default: true
+	LogDetections bool `json:"log_detections" yaml:"log_detections"`
+
+	// AuditTrailEnabled determines whether to write detections to the audit trail.
+	// Required for compliance (EU AI Act, RBI, SEBI).
+	// Default: true
+	AuditTrailEnabled bool `json:"audit_trail_enabled" yaml:"audit_trail_enabled"`
+
+	// MaxContentLength is the maximum content length to scan (bytes).
+	// Content exceeding this limit is truncated for scanning.
+	// Default: 1MB (1048576)
+	MaxContentLength int `json:"max_content_length" yaml:"max_content_length"`
+
+	// ConnectorOverrides allows per-connector configuration overrides.
+	// Key is the connector name (e.g., "postgresql", "salesforce").
+	ConnectorOverrides map[string]ConnectorConfig `json:"connector_overrides,omitempty" yaml:"connector_overrides,omitempty"`
+}
+
+// ConnectorConfig holds per-connector scanning configuration.
+type ConnectorConfig struct {
+	// ResponseMode overrides the default response scanning mode for this connector.
+	ResponseMode Mode `json:"response_mode" yaml:"response_mode"`
+
+	// Enabled allows disabling scanning for specific connectors.
+	// Default: true
+	Enabled bool `json:"enabled" yaml:"enabled"`
+}
+
+// DefaultConfig returns the default configuration.
+// Scanning is enabled by default in monitoring mode (detect and log, but don't block).
+// Set BlockOnDetection to true after validating in your environment.
+func DefaultConfig() Config {
+	return Config{
+		InputMode:         ModeBasic,
+		ResponseMode:      ModeBasic,
+		BlockOnDetection:  false, // Monitor mode: detect and log, don't block
+		LogDetections:     true,
+		AuditTrailEnabled: true,
+		MaxContentLength:  1048576, // 1MB
+		ConnectorOverrides: make(map[string]ConnectorConfig),
+	}
+}
+
+// Validate validates the configuration and returns any errors.
+func (c *Config) Validate() error {
+	var errs []string
+
+	if !c.InputMode.IsValid() {
+		errs = append(errs, fmt.Sprintf("invalid input_mode: %q", c.InputMode))
+	}
+
+	if !c.ResponseMode.IsValid() {
+		errs = append(errs, fmt.Sprintf("invalid response_mode: %q", c.ResponseMode))
+	}
+
+	if c.MaxContentLength <= 0 {
+		errs = append(errs, "max_content_length must be positive")
+	}
+
+	for name, override := range c.ConnectorOverrides {
+		if !override.ResponseMode.IsValid() && override.ResponseMode != "" {
+			errs = append(errs, fmt.Sprintf("invalid response_mode for connector %q: %q", name, override.ResponseMode))
+		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("configuration errors: %s", strings.Join(errs, "; "))
+	}
+
+	return nil
+}
+
+// GetResponseModeForConnector returns the response scanning mode for a specific connector.
+// Uses the connector override if configured, otherwise falls back to the default.
+func (c *Config) GetResponseModeForConnector(connectorName string) Mode {
+	if override, ok := c.ConnectorOverrides[connectorName]; ok {
+		if override.ResponseMode != "" {
+			return override.ResponseMode
+		}
+	}
+	return c.ResponseMode
+}
+
+// IsConnectorEnabled returns whether scanning is enabled for a specific connector.
+func (c *Config) IsConnectorEnabled(connectorName string) bool {
+	if override, ok := c.ConnectorOverrides[connectorName]; ok {
+		return override.Enabled
+	}
+	return true // Enabled by default
+}
+
+// WithInputMode returns a copy of the config with the input mode set.
+func (c Config) WithInputMode(mode Mode) Config {
+	c.InputMode = mode
+	return c
+}
+
+// WithResponseMode returns a copy of the config with the response mode set.
+func (c Config) WithResponseMode(mode Mode) Config {
+	c.ResponseMode = mode
+	return c
+}
+
+// WithBlockOnDetection returns a copy of the config with block on detection set.
+func (c Config) WithBlockOnDetection(block bool) Config {
+	c.BlockOnDetection = block
+	return c
+}
+
+// WithConnectorOverride returns a copy of the config with a connector override added.
+func (c Config) WithConnectorOverride(connectorName string, override ConnectorConfig) Config {
+	// Deep copy the map to avoid modifying the original
+	newOverrides := make(map[string]ConnectorConfig)
+	for k, v := range c.ConnectorOverrides {
+		newOverrides[k] = v
+	}
+	newOverrides[connectorName] = override
+	c.ConnectorOverrides = newOverrides
+	return c
+}

--- a/platform/agent/sqli/config_test.go
+++ b/platform/agent/sqli/config_test.go
@@ -1,0 +1,394 @@
+package sqli
+
+import (
+	"testing"
+)
+
+func TestDefaultConfig(t *testing.T) {
+	cfg := DefaultConfig()
+
+	t.Run("input mode is basic", func(t *testing.T) {
+		if cfg.InputMode != ModeBasic {
+			t.Errorf("InputMode = %v, want %v", cfg.InputMode, ModeBasic)
+		}
+	})
+
+	t.Run("response mode is basic", func(t *testing.T) {
+		if cfg.ResponseMode != ModeBasic {
+			t.Errorf("ResponseMode = %v, want %v", cfg.ResponseMode, ModeBasic)
+		}
+	})
+
+	t.Run("block on detection is false (monitoring mode)", func(t *testing.T) {
+		if cfg.BlockOnDetection {
+			t.Error("BlockOnDetection should be false by default (monitoring mode)")
+		}
+	})
+
+	t.Run("log detections is true", func(t *testing.T) {
+		if !cfg.LogDetections {
+			t.Error("LogDetections should be true by default")
+		}
+	})
+
+	t.Run("audit trail is enabled", func(t *testing.T) {
+		if !cfg.AuditTrailEnabled {
+			t.Error("AuditTrailEnabled should be true by default")
+		}
+	})
+
+	t.Run("max content length is 1MB", func(t *testing.T) {
+		if cfg.MaxContentLength != 1048576 {
+			t.Errorf("MaxContentLength = %d, want %d", cfg.MaxContentLength, 1048576)
+		}
+	})
+
+	t.Run("connector overrides is initialized", func(t *testing.T) {
+		if cfg.ConnectorOverrides == nil {
+			t.Error("ConnectorOverrides should be initialized")
+		}
+	})
+}
+
+func TestConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  Config
+		wantErr bool
+	}{
+		{
+			name:    "default config is valid",
+			config:  DefaultConfig(),
+			wantErr: false,
+		},
+		{
+			name: "all off modes is valid",
+			config: Config{
+				InputMode:        ModeOff,
+				ResponseMode:     ModeOff,
+				MaxContentLength: 1000,
+			},
+			wantErr: false,
+		},
+		{
+			name: "advanced modes are valid",
+			config: Config{
+				InputMode:        ModeAdvanced,
+				ResponseMode:     ModeAdvanced,
+				MaxContentLength: 1000,
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid input mode",
+			config: Config{
+				InputMode:        Mode("invalid"),
+				ResponseMode:     ModeBasic,
+				MaxContentLength: 1000,
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid response mode",
+			config: Config{
+				InputMode:        ModeBasic,
+				ResponseMode:     Mode("invalid"),
+				MaxContentLength: 1000,
+			},
+			wantErr: true,
+		},
+		{
+			name: "zero max content length",
+			config: Config{
+				InputMode:        ModeBasic,
+				ResponseMode:     ModeBasic,
+				MaxContentLength: 0,
+			},
+			wantErr: true,
+		},
+		{
+			name: "negative max content length",
+			config: Config{
+				InputMode:        ModeBasic,
+				ResponseMode:     ModeBasic,
+				MaxContentLength: -1,
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid connector override mode",
+			config: Config{
+				InputMode:        ModeBasic,
+				ResponseMode:     ModeBasic,
+				MaxContentLength: 1000,
+				ConnectorOverrides: map[string]ConnectorConfig{
+					"postgresql": {ResponseMode: Mode("invalid")},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty connector override mode is valid",
+			config: Config{
+				InputMode:        ModeBasic,
+				ResponseMode:     ModeBasic,
+				MaxContentLength: 1000,
+				ConnectorOverrides: map[string]ConnectorConfig{
+					"postgresql": {ResponseMode: "", Enabled: true},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid connector override",
+			config: Config{
+				InputMode:        ModeBasic,
+				ResponseMode:     ModeBasic,
+				MaxContentLength: 1000,
+				ConnectorOverrides: map[string]ConnectorConfig{
+					"postgresql": {ResponseMode: ModeAdvanced, Enabled: true},
+					"redis":      {ResponseMode: ModeOff, Enabled: false},
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Config.Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestConfig_GetResponseModeForConnector(t *testing.T) {
+	tests := []struct {
+		name          string
+		config        Config
+		connectorName string
+		want          Mode
+	}{
+		{
+			name: "no override returns default",
+			config: Config{
+				ResponseMode: ModeBasic,
+			},
+			connectorName: "postgresql",
+			want:          ModeBasic,
+		},
+		{
+			name: "override returns override mode",
+			config: Config{
+				ResponseMode: ModeBasic,
+				ConnectorOverrides: map[string]ConnectorConfig{
+					"postgresql": {ResponseMode: ModeAdvanced},
+				},
+			},
+			connectorName: "postgresql",
+			want:          ModeAdvanced,
+		},
+		{
+			name: "different connector returns default",
+			config: Config{
+				ResponseMode: ModeBasic,
+				ConnectorOverrides: map[string]ConnectorConfig{
+					"postgresql": {ResponseMode: ModeAdvanced},
+				},
+			},
+			connectorName: "mysql",
+			want:          ModeBasic,
+		},
+		{
+			name: "empty override mode returns default",
+			config: Config{
+				ResponseMode: ModeBasic,
+				ConnectorOverrides: map[string]ConnectorConfig{
+					"postgresql": {ResponseMode: ""},
+				},
+			},
+			connectorName: "postgresql",
+			want:          ModeBasic,
+		},
+		{
+			name: "off mode override",
+			config: Config{
+				ResponseMode: ModeBasic,
+				ConnectorOverrides: map[string]ConnectorConfig{
+					"redis": {ResponseMode: ModeOff},
+				},
+			},
+			connectorName: "redis",
+			want:          ModeOff,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.config.GetResponseModeForConnector(tt.connectorName)
+			if got != tt.want {
+				t.Errorf("GetResponseModeForConnector(%q) = %v, want %v", tt.connectorName, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConfig_IsConnectorEnabled(t *testing.T) {
+	tests := []struct {
+		name          string
+		config        Config
+		connectorName string
+		want          bool
+	}{
+		{
+			name:          "no override returns true",
+			config:        Config{},
+			connectorName: "postgresql",
+			want:          true,
+		},
+		{
+			name: "enabled override returns true",
+			config: Config{
+				ConnectorOverrides: map[string]ConnectorConfig{
+					"postgresql": {Enabled: true},
+				},
+			},
+			connectorName: "postgresql",
+			want:          true,
+		},
+		{
+			name: "disabled override returns false",
+			config: Config{
+				ConnectorOverrides: map[string]ConnectorConfig{
+					"redis": {Enabled: false},
+				},
+			},
+			connectorName: "redis",
+			want:          false,
+		},
+		{
+			name: "different connector returns true",
+			config: Config{
+				ConnectorOverrides: map[string]ConnectorConfig{
+					"redis": {Enabled: false},
+				},
+			},
+			connectorName: "postgresql",
+			want:          true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.config.IsConnectorEnabled(tt.connectorName)
+			if got != tt.want {
+				t.Errorf("IsConnectorEnabled(%q) = %v, want %v", tt.connectorName, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConfig_WithInputMode(t *testing.T) {
+	cfg := DefaultConfig()
+	newCfg := cfg.WithInputMode(ModeOff)
+
+	if newCfg.InputMode != ModeOff {
+		t.Errorf("WithInputMode: InputMode = %v, want %v", newCfg.InputMode, ModeOff)
+	}
+	// Original should be unchanged
+	if cfg.InputMode != ModeBasic {
+		t.Errorf("Original config was modified: InputMode = %v, want %v", cfg.InputMode, ModeBasic)
+	}
+}
+
+func TestConfig_WithResponseMode(t *testing.T) {
+	cfg := DefaultConfig()
+	newCfg := cfg.WithResponseMode(ModeAdvanced)
+
+	if newCfg.ResponseMode != ModeAdvanced {
+		t.Errorf("WithResponseMode: ResponseMode = %v, want %v", newCfg.ResponseMode, ModeAdvanced)
+	}
+	// Original should be unchanged
+	if cfg.ResponseMode != ModeBasic {
+		t.Errorf("Original config was modified: ResponseMode = %v, want %v", cfg.ResponseMode, ModeBasic)
+	}
+}
+
+func TestConfig_WithBlockOnDetection(t *testing.T) {
+	cfg := DefaultConfig() // Default is false (monitoring mode)
+	newCfg := cfg.WithBlockOnDetection(true)
+
+	if newCfg.BlockOnDetection != true {
+		t.Error("WithBlockOnDetection(true): BlockOnDetection should be true")
+	}
+	// Original should be unchanged
+	if cfg.BlockOnDetection {
+		t.Error("Original config was modified: BlockOnDetection should still be false")
+	}
+}
+
+func TestConfig_WithConnectorOverride(t *testing.T) {
+	cfg := DefaultConfig()
+	override := ConnectorConfig{
+		ResponseMode: ModeOff,
+		Enabled:      false,
+	}
+	newCfg := cfg.WithConnectorOverride("redis", override)
+
+	got, ok := newCfg.ConnectorOverrides["redis"]
+	if !ok {
+		t.Fatal("WithConnectorOverride: redis override not found")
+	}
+	if got.ResponseMode != ModeOff {
+		t.Errorf("WithConnectorOverride: ResponseMode = %v, want %v", got.ResponseMode, ModeOff)
+	}
+	if got.Enabled != false {
+		t.Error("WithConnectorOverride: Enabled should be false")
+	}
+
+	// Original should not have the override
+	if _, ok := cfg.ConnectorOverrides["redis"]; ok {
+		t.Error("Original config was modified: redis override should not exist")
+	}
+}
+
+func TestConfig_WithConnectorOverride_NilMap(t *testing.T) {
+	cfg := Config{
+		InputMode:          ModeBasic,
+		ResponseMode:       ModeBasic,
+		ConnectorOverrides: nil, // nil map
+	}
+
+	override := ConnectorConfig{ResponseMode: ModeOff}
+	newCfg := cfg.WithConnectorOverride("redis", override)
+
+	if newCfg.ConnectorOverrides == nil {
+		t.Fatal("WithConnectorOverride should initialize nil map")
+	}
+	if _, ok := newCfg.ConnectorOverrides["redis"]; !ok {
+		t.Error("WithConnectorOverride: redis override not found")
+	}
+}
+
+func TestConfig_ChainedWith(t *testing.T) {
+	cfg := DefaultConfig().
+		WithInputMode(ModeAdvanced).
+		WithResponseMode(ModeOff).
+		WithBlockOnDetection(false).
+		WithConnectorOverride("postgresql", ConnectorConfig{ResponseMode: ModeBasic})
+
+	if cfg.InputMode != ModeAdvanced {
+		t.Errorf("Chained InputMode = %v, want %v", cfg.InputMode, ModeAdvanced)
+	}
+	if cfg.ResponseMode != ModeOff {
+		t.Errorf("Chained ResponseMode = %v, want %v", cfg.ResponseMode, ModeOff)
+	}
+	if cfg.BlockOnDetection {
+		t.Error("Chained BlockOnDetection should be false")
+	}
+	if override, ok := cfg.ConnectorOverrides["postgresql"]; !ok || override.ResponseMode != ModeBasic {
+		t.Error("Chained ConnectorOverride not set correctly")
+	}
+}

--- a/platform/agent/sqli/doc.go
+++ b/platform/agent/sqli/doc.go
@@ -1,0 +1,53 @@
+// Package sqli provides SQL injection detection for AxonFlow.
+//
+// This package implements configurable SQL injection scanning with three modes:
+//   - off: No scanning (for performance-critical use cases)
+//   - basic: Pattern matching using regex (fast, good accuracy)
+//   - advanced: ML/heuristic analysis (slower, best accuracy) - Enterprise only
+//
+// # Usage
+//
+// Create a scanner using the factory function:
+//
+//	scanner, err := sqli.NewScanner(sqli.ModeBasic)
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	result := scanner.Scan(ctx, input, sqli.ScanTypeInput)
+//	if result.Detected {
+//	    log.Printf("SQL injection detected: %s", result.Pattern)
+//	}
+//
+// Or use the middleware for MCP connector response scanning:
+//
+//	middleware, err := sqli.NewScanningMiddleware()
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	scanResult, err := middleware.ScanQueryResponse(ctx, "postgresql", rows)
+//	if scanResult.Blocked {
+//	    // Handle blocked response
+//	}
+//
+// # Configuration
+//
+// Scanning can be configured separately for input (user prompts) and output
+// (MCP connector responses):
+//
+//	config := sqli.DefaultConfig().
+//	    WithInputMode(sqli.ModeBasic).
+//	    WithResponseMode(sqli.ModeBasic).
+//	    WithBlockOnDetection(true)  // Enable blocking (default is monitoring mode)
+//
+// # Community vs Enterprise
+//
+// The basic scanner is available in the Community edition.
+// The advanced scanner (ML/heuristic) requires an Enterprise license.
+//
+// # Compliance Integration
+//
+// Detection events can be logged to the audit trail for compliance with:
+//   - EU AI Act (Article 15 - Accuracy)
+//   - RBI FREE-AI Framework (Data Integrity)
+//   - SEBI AI/ML Guidelines (Audit Trail)
+package sqli

--- a/platform/agent/sqli/middleware.go
+++ b/platform/agent/sqli/middleware.go
@@ -1,0 +1,445 @@
+package sqli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"sync"
+	"time"
+)
+
+// ScanningMiddleware provides SQL injection scanning for MCP connector responses.
+// It integrates with the agent's request/response pipeline to detect and optionally
+// block responses containing SQL injection payloads.
+type ScanningMiddleware struct {
+	config        Config
+	scanner       Scanner // Response scanner
+	inputScanner  Scanner // Cached input scanner (may differ from response scanner)
+	mu            sync.RWMutex
+
+	// Metrics
+	scansTotal      int64
+	detectionsTotal int64
+	blockedTotal    int64
+}
+
+// MiddlewareOption configures the ScanningMiddleware.
+type MiddlewareOption func(*ScanningMiddleware)
+
+// WithMiddlewareConfig sets the configuration.
+func WithMiddlewareConfig(cfg Config) MiddlewareOption {
+	return func(m *ScanningMiddleware) {
+		m.config = cfg
+	}
+}
+
+// WithMiddlewareScanner sets a custom scanner (useful for testing).
+func WithMiddlewareScanner(s Scanner) MiddlewareOption {
+	return func(m *ScanningMiddleware) {
+		m.scanner = s
+	}
+}
+
+// NewScanningMiddleware creates a new scanning middleware.
+func NewScanningMiddleware(opts ...MiddlewareOption) (*ScanningMiddleware, error) {
+	m := &ScanningMiddleware{
+		config: DefaultConfig(),
+	}
+
+	for _, opt := range opts {
+		opt(m)
+	}
+
+	// Validate configuration
+	if err := m.config.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid configuration: %w", err)
+	}
+
+	// Create response scanner based on response mode
+	if m.scanner == nil {
+		scanner, err := NewScanner(m.config.ResponseMode)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create response scanner: %w", err)
+		}
+		m.scanner = scanner
+	}
+
+	// Create input scanner (may differ from response scanner)
+	if m.inputScanner == nil {
+		inputScanner, err := NewScanner(m.config.InputMode)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create input scanner: %w", err)
+		}
+		m.inputScanner = inputScanner
+	}
+
+	return m, nil
+}
+
+// ScanQueryResponse scans a query response for SQL injection.
+// It returns true if the response should be blocked.
+func (m *ScanningMiddleware) ScanQueryResponse(ctx context.Context, connectorName string, rows []map[string]interface{}) (*ResponseScanResult, error) {
+	start := time.Now()
+
+	m.mu.Lock()
+	m.scansTotal++
+	m.mu.Unlock()
+
+	// Check if scanning is disabled for this connector
+	if !m.config.IsConnectorEnabled(connectorName) {
+		return &ResponseScanResult{
+			Blocked:  false,
+			Duration: time.Since(start),
+		}, nil
+	}
+
+	// Get the scanning mode for this connector
+	mode := m.config.GetResponseModeForConnector(connectorName)
+	if mode == ModeOff {
+		return &ResponseScanResult{
+			Blocked:  false,
+			Duration: time.Since(start),
+		}, nil
+	}
+
+	// Convert rows to scannable content
+	content := m.rowsToContent(rows)
+
+	// Scan the content
+	result := m.scanner.Scan(ctx, content, ScanTypeResponse)
+
+	scanResult := &ResponseScanResult{
+		Detected:      result.Detected,
+		Blocked:       result.Detected && m.config.BlockOnDetection,
+		Pattern:       result.Pattern,
+		Category:      result.Category,
+		Confidence:    result.Confidence,
+		ConnectorName: connectorName,
+		Duration:      time.Since(start),
+		ScanResult:    result,
+	}
+
+	if result.Detected {
+		m.mu.Lock()
+		m.detectionsTotal++
+		if scanResult.Blocked {
+			m.blockedTotal++
+		}
+		m.mu.Unlock()
+
+		if m.config.LogDetections {
+			log.Printf("[SQLi] Detection in connector '%s' response: pattern=%s category=%s blocked=%v",
+				connectorName, result.Pattern, result.Category, scanResult.Blocked)
+		}
+
+		// Emit audit event for compliance
+		if m.config.AuditTrailEnabled {
+			auditEvent := NewAuditEvent(result, connectorName)
+			EmitAuditEvent(auditEvent)
+		}
+	}
+
+	return scanResult, nil
+}
+
+// ScanCommandResponse scans a command response for SQL injection.
+func (m *ScanningMiddleware) ScanCommandResponse(ctx context.Context, connectorName string, message string, metadata map[string]interface{}) (*ResponseScanResult, error) {
+	start := time.Now()
+
+	m.mu.Lock()
+	m.scansTotal++
+	m.mu.Unlock()
+
+	// Check if scanning is disabled for this connector
+	if !m.config.IsConnectorEnabled(connectorName) {
+		return &ResponseScanResult{
+			Blocked:  false,
+			Duration: time.Since(start),
+		}, nil
+	}
+
+	// Get the scanning mode for this connector
+	mode := m.config.GetResponseModeForConnector(connectorName)
+	if mode == ModeOff {
+		return &ResponseScanResult{
+			Blocked:  false,
+			Duration: time.Since(start),
+		}, nil
+	}
+
+	// Convert message and metadata to scannable content
+	var content string
+	if message != "" {
+		content = message
+	}
+	if len(metadata) > 0 {
+		metaJSON, _ := json.Marshal(metadata)
+		if content != "" {
+			content += " "
+		}
+		content += string(metaJSON)
+	}
+
+	// Scan the content
+	result := m.scanner.Scan(ctx, content, ScanTypeResponse)
+
+	scanResult := &ResponseScanResult{
+		Detected:      result.Detected,
+		Blocked:       result.Detected && m.config.BlockOnDetection,
+		Pattern:       result.Pattern,
+		Category:      result.Category,
+		Confidence:    result.Confidence,
+		ConnectorName: connectorName,
+		Duration:      time.Since(start),
+		ScanResult:    result,
+	}
+
+	if result.Detected {
+		m.mu.Lock()
+		m.detectionsTotal++
+		if scanResult.Blocked {
+			m.blockedTotal++
+		}
+		m.mu.Unlock()
+
+		if m.config.LogDetections {
+			log.Printf("[SQLi] Detection in connector '%s' command response: pattern=%s category=%s blocked=%v",
+				connectorName, result.Pattern, result.Category, scanResult.Blocked)
+		}
+
+		// Emit audit event for compliance
+		if m.config.AuditTrailEnabled {
+			auditEvent := NewAuditEvent(result, connectorName)
+			EmitAuditEvent(auditEvent)
+		}
+	}
+
+	return scanResult, nil
+}
+
+// ScanInput scans user input for SQL injection.
+func (m *ScanningMiddleware) ScanInput(ctx context.Context, input string) (*Result, error) {
+	m.mu.Lock()
+	m.scansTotal++
+	m.mu.Unlock()
+
+	// Check input mode
+	if m.config.InputMode == ModeOff {
+		return &Result{
+			Detected: false,
+			ScanType: ScanTypeInput,
+			Mode:     ModeOff,
+		}, nil
+	}
+
+	// Use cached input scanner
+	result := m.inputScanner.Scan(ctx, input, ScanTypeInput)
+
+	if result.Detected {
+		m.mu.Lock()
+		m.detectionsTotal++
+		if m.config.BlockOnDetection {
+			m.blockedTotal++
+		}
+		m.mu.Unlock()
+
+		if m.config.LogDetections {
+			log.Printf("[SQLi] Detection in user input: pattern=%s category=%s",
+				result.Pattern, result.Category)
+		}
+
+		// Emit audit event for compliance
+		if m.config.AuditTrailEnabled {
+			auditEvent := NewAuditEvent(result, "user_input")
+			EmitAuditEvent(auditEvent)
+		}
+	}
+
+	return result, nil
+}
+
+// GetMetrics returns current scanning metrics.
+func (m *ScanningMiddleware) GetMetrics() MiddlewareMetrics {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	return MiddlewareMetrics{
+		ScansTotal:      m.scansTotal,
+		DetectionsTotal: m.detectionsTotal,
+		BlockedTotal:    m.blockedTotal,
+	}
+}
+
+// ResetMetrics resets the metrics counters.
+func (m *ScanningMiddleware) ResetMetrics() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.scansTotal = 0
+	m.detectionsTotal = 0
+	m.blockedTotal = 0
+}
+
+// UpdateConfig updates the middleware configuration.
+func (m *ScanningMiddleware) UpdateConfig(cfg Config) error {
+	if err := cfg.Validate(); err != nil {
+		return fmt.Errorf("invalid configuration: %w", err)
+	}
+
+	// Create new response scanner if mode changed
+	responseScanner, err := NewScanner(cfg.ResponseMode)
+	if err != nil {
+		return fmt.Errorf("failed to create response scanner: %w", err)
+	}
+
+	// Create new input scanner if mode changed
+	inputScanner, err := NewScanner(cfg.InputMode)
+	if err != nil {
+		return fmt.Errorf("failed to create input scanner: %w", err)
+	}
+
+	m.mu.Lock()
+	m.config = cfg
+	m.scanner = responseScanner
+	m.inputScanner = inputScanner
+	m.mu.Unlock()
+
+	return nil
+}
+
+// rowsToContent converts query result rows into a scannable string.
+func (m *ScanningMiddleware) rowsToContent(rows []map[string]interface{}) string {
+	if len(rows) == 0 {
+		return ""
+	}
+
+	// For efficiency, limit scanning to first N rows and reasonable content length
+	maxRows := 100
+	if len(rows) < maxRows {
+		maxRows = len(rows)
+	}
+
+	// Marshal rows to JSON for scanning
+	rowsToScan := rows[:maxRows]
+	content, err := json.Marshal(rowsToScan)
+	if err != nil {
+		// Fall back to basic string conversion
+		var sb []byte
+		for i, row := range rowsToScan {
+			if i > 0 {
+				sb = append(sb, ' ')
+			}
+			rowContent, _ := json.Marshal(row)
+			sb = append(sb, rowContent...)
+		}
+		return string(sb)
+	}
+
+	// Truncate if too long
+	if len(content) > m.config.MaxContentLength {
+		return string(content[:m.config.MaxContentLength])
+	}
+
+	return string(content)
+}
+
+// ResponseScanResult contains the result of scanning a connector response.
+type ResponseScanResult struct {
+	// Detected indicates whether SQL injection was detected.
+	Detected bool
+
+	// Blocked indicates whether the response should be blocked.
+	// This is true only if Detected is true AND BlockOnDetection is enabled.
+	Blocked bool
+
+	// Pattern is the name of the pattern that matched (if any).
+	Pattern string
+
+	// Category is the category of SQL injection detected.
+	Category Category
+
+	// Confidence is the detection confidence score.
+	Confidence float64
+
+	// ConnectorName is the name of the connector that produced the response.
+	ConnectorName string
+
+	// Duration is the time taken to scan the response.
+	Duration time.Duration
+
+	// ScanResult is the underlying scan result (for detailed access).
+	ScanResult *Result
+}
+
+// MiddlewareMetrics contains scanning metrics.
+type MiddlewareMetrics struct {
+	// ScansTotal is the total number of scans performed.
+	ScansTotal int64
+
+	// DetectionsTotal is the total number of detections.
+	DetectionsTotal int64
+
+	// BlockedTotal is the total number of blocked responses.
+	BlockedTotal int64
+}
+
+// Global middleware instance (lazy initialized)
+var (
+	globalMiddleware   *ScanningMiddleware
+	globalMiddlewareMu sync.RWMutex
+)
+
+// GetGlobalMiddleware returns the global scanning middleware instance.
+// If not initialized, it creates one with default configuration.
+func GetGlobalMiddleware() *ScanningMiddleware {
+	globalMiddlewareMu.RLock()
+	if globalMiddleware != nil {
+		globalMiddlewareMu.RUnlock()
+		return globalMiddleware
+	}
+	globalMiddlewareMu.RUnlock()
+
+	globalMiddlewareMu.Lock()
+	defer globalMiddlewareMu.Unlock()
+
+	// Double-check after acquiring write lock
+	if globalMiddleware != nil {
+		return globalMiddleware
+	}
+
+	// Initialize with default configuration
+	m, err := NewScanningMiddleware()
+	if err != nil {
+		log.Printf("[SQLi] Warning: Failed to initialize global middleware: %v", err)
+		// Return a no-op middleware
+		m = &ScanningMiddleware{
+			config:  DefaultConfig().WithResponseMode(ModeOff),
+			scanner: &NoOpScanner{},
+		}
+	}
+	globalMiddleware = m
+
+	return globalMiddleware
+}
+
+// SetGlobalMiddleware sets the global scanning middleware instance.
+// This is useful for initialization with custom configuration.
+func SetGlobalMiddleware(m *ScanningMiddleware) {
+	globalMiddlewareMu.Lock()
+	defer globalMiddlewareMu.Unlock()
+	globalMiddleware = m
+}
+
+// InitGlobalMiddleware initializes the global middleware with the given configuration.
+func InitGlobalMiddleware(cfg Config) error {
+	m, err := NewScanningMiddleware(WithMiddlewareConfig(cfg))
+	if err != nil {
+		return err
+	}
+
+	SetGlobalMiddleware(m)
+	log.Printf("[SQLi] Global middleware initialized: input_mode=%s response_mode=%s block=%v",
+		cfg.InputMode, cfg.ResponseMode, cfg.BlockOnDetection)
+	return nil
+}

--- a/platform/agent/sqli/middleware_test.go
+++ b/platform/agent/sqli/middleware_test.go
@@ -1,0 +1,525 @@
+package sqli
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestNewScanningMiddleware(t *testing.T) {
+	t.Run("default configuration", func(t *testing.T) {
+		m, err := NewScanningMiddleware()
+		if err != nil {
+			t.Fatalf("NewScanningMiddleware() error = %v", err)
+		}
+		if m == nil {
+			t.Fatal("NewScanningMiddleware() returned nil")
+		}
+	})
+
+	t.Run("with custom config", func(t *testing.T) {
+		cfg := DefaultConfig().WithResponseMode(ModeOff)
+		m, err := NewScanningMiddleware(WithMiddlewareConfig(cfg))
+		if err != nil {
+			t.Fatalf("NewScanningMiddleware() error = %v", err)
+		}
+		if m == nil {
+			t.Fatal("NewScanningMiddleware() returned nil")
+		}
+	})
+
+	t.Run("with invalid config", func(t *testing.T) {
+		cfg := Config{
+			InputMode:        Mode("invalid"),
+			ResponseMode:     ModeBasic,
+			MaxContentLength: 1000,
+		}
+		_, err := NewScanningMiddleware(WithMiddlewareConfig(cfg))
+		if err == nil {
+			t.Error("NewScanningMiddleware() should return error for invalid config")
+		}
+	})
+
+	t.Run("with custom scanner", func(t *testing.T) {
+		scanner := &NoOpScanner{}
+		m, err := NewScanningMiddleware(WithMiddlewareScanner(scanner))
+		if err != nil {
+			t.Fatalf("NewScanningMiddleware() error = %v", err)
+		}
+		if m.scanner != scanner {
+			t.Error("Custom scanner not applied")
+		}
+	})
+}
+
+func TestScanningMiddleware_ScanQueryResponse(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("clean response passes", func(t *testing.T) {
+		m, _ := NewScanningMiddleware()
+		rows := []map[string]interface{}{
+			{"id": 1, "name": "John Doe", "email": "john@example.com"},
+			{"id": 2, "name": "Jane Smith", "email": "jane@example.com"},
+		}
+
+		result, err := m.ScanQueryResponse(ctx, "postgres", rows)
+		if err != nil {
+			t.Fatalf("ScanQueryResponse() error = %v", err)
+		}
+		if result.Detected {
+			t.Error("Should not detect SQL injection in clean data")
+		}
+		if result.Blocked {
+			t.Error("Should not block clean data")
+		}
+	})
+
+	t.Run("malicious response detected", func(t *testing.T) {
+		// Default is monitoring mode (detect but don't block)
+		m, _ := NewScanningMiddleware()
+		rows := []map[string]interface{}{
+			{"id": 1, "data": "admin' UNION SELECT password FROM users--"},
+		}
+
+		result, err := m.ScanQueryResponse(ctx, "postgres", rows)
+		if err != nil {
+			t.Fatalf("ScanQueryResponse() error = %v", err)
+		}
+		if !result.Detected {
+			t.Error("Should detect SQL injection")
+		}
+		if result.Blocked {
+			t.Error("Should not block by default (monitoring mode)")
+		}
+		if result.Category != CategoryUnionBased {
+			t.Errorf("Category = %v, want %v", result.Category, CategoryUnionBased)
+		}
+	})
+
+	t.Run("malicious response blocked when enabled", func(t *testing.T) {
+		cfg := DefaultConfig().WithBlockOnDetection(true)
+		m, _ := NewScanningMiddleware(WithMiddlewareConfig(cfg))
+		rows := []map[string]interface{}{
+			{"id": 1, "data": "admin' UNION SELECT password FROM users--"},
+		}
+
+		result, err := m.ScanQueryResponse(ctx, "postgres", rows)
+		if err != nil {
+			t.Fatalf("ScanQueryResponse() error = %v", err)
+		}
+		if !result.Detected {
+			t.Error("Should detect SQL injection")
+		}
+		if !result.Blocked {
+			t.Error("Should block when BlockOnDetection is true")
+		}
+	})
+
+	t.Run("detection without blocking", func(t *testing.T) {
+		cfg := DefaultConfig().WithBlockOnDetection(false)
+		m, _ := NewScanningMiddleware(WithMiddlewareConfig(cfg))
+		rows := []map[string]interface{}{
+			{"id": 1, "data": "admin' OR 1=1--"},
+		}
+
+		result, err := m.ScanQueryResponse(ctx, "postgres", rows)
+		if err != nil {
+			t.Fatalf("ScanQueryResponse() error = %v", err)
+		}
+		if !result.Detected {
+			t.Error("Should detect SQL injection")
+		}
+		if result.Blocked {
+			t.Error("Should not block when BlockOnDetection is false")
+		}
+	})
+
+	t.Run("disabled connector skips scanning", func(t *testing.T) {
+		cfg := DefaultConfig().WithConnectorOverride("redis", ConnectorConfig{Enabled: false})
+		m, _ := NewScanningMiddleware(WithMiddlewareConfig(cfg))
+		rows := []map[string]interface{}{
+			{"key": "admin' UNION SELECT * FROM users--"},
+		}
+
+		result, err := m.ScanQueryResponse(ctx, "redis", rows)
+		if err != nil {
+			t.Fatalf("ScanQueryResponse() error = %v", err)
+		}
+		if result.Detected || result.Blocked {
+			t.Error("Should skip scanning for disabled connector")
+		}
+	})
+
+	t.Run("off mode for connector skips scanning", func(t *testing.T) {
+		cfg := DefaultConfig().WithConnectorOverride("cache", ConnectorConfig{
+			ResponseMode: ModeOff,
+			Enabled:      true,
+		})
+		m, _ := NewScanningMiddleware(WithMiddlewareConfig(cfg))
+		rows := []map[string]interface{}{
+			{"value": "DROP TABLE users--"},
+		}
+
+		result, err := m.ScanQueryResponse(ctx, "cache", rows)
+		if err != nil {
+			t.Fatalf("ScanQueryResponse() error = %v", err)
+		}
+		if result.Detected || result.Blocked {
+			t.Error("Should skip scanning when mode is off")
+		}
+	})
+
+	t.Run("empty rows pass", func(t *testing.T) {
+		m, _ := NewScanningMiddleware()
+		result, err := m.ScanQueryResponse(ctx, "postgres", []map[string]interface{}{})
+		if err != nil {
+			t.Fatalf("ScanQueryResponse() error = %v", err)
+		}
+		if result.Detected {
+			t.Error("Empty rows should not trigger detection")
+		}
+	})
+
+	t.Run("duration is recorded", func(t *testing.T) {
+		m, _ := NewScanningMiddleware()
+		rows := []map[string]interface{}{
+			{"id": 1, "name": "test"},
+		}
+		result, _ := m.ScanQueryResponse(ctx, "postgres", rows)
+		if result.Duration <= 0 {
+			t.Error("Duration should be positive")
+		}
+	})
+}
+
+func TestScanningMiddleware_ScanCommandResponse(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("clean message passes", func(t *testing.T) {
+		m, _ := NewScanningMiddleware()
+		result, err := m.ScanCommandResponse(ctx, "postgres", "5 rows updated successfully", nil)
+		if err != nil {
+			t.Fatalf("ScanCommandResponse() error = %v", err)
+		}
+		if result.Detected {
+			t.Error("Should not detect in clean message")
+		}
+	})
+
+	t.Run("malicious message detected", func(t *testing.T) {
+		m, _ := NewScanningMiddleware()
+		result, err := m.ScanCommandResponse(ctx, "postgres",
+			"Error: syntax near ' UNION SELECT * FROM admin_passwords--", nil)
+		if err != nil {
+			t.Fatalf("ScanCommandResponse() error = %v", err)
+		}
+		if !result.Detected {
+			t.Error("Should detect SQL injection in message")
+		}
+	})
+
+	t.Run("malicious metadata detected", func(t *testing.T) {
+		m, _ := NewScanningMiddleware()
+		metadata := map[string]interface{}{
+			"query": "SELECT * FROM users WHERE id=' OR 1=1--",
+		}
+		result, err := m.ScanCommandResponse(ctx, "postgres", "OK", metadata)
+		if err != nil {
+			t.Fatalf("ScanCommandResponse() error = %v", err)
+		}
+		if !result.Detected {
+			t.Error("Should detect SQL injection in metadata")
+		}
+	})
+
+	t.Run("disabled connector skips", func(t *testing.T) {
+		cfg := DefaultConfig().WithConnectorOverride("test", ConnectorConfig{Enabled: false})
+		m, _ := NewScanningMiddleware(WithMiddlewareConfig(cfg))
+		result, err := m.ScanCommandResponse(ctx, "test", "; DROP TABLE users--", nil)
+		if err != nil {
+			t.Fatalf("ScanCommandResponse() error = %v", err)
+		}
+		if result.Detected {
+			t.Error("Should skip scanning for disabled connector")
+		}
+	})
+}
+
+func TestScanningMiddleware_ScanInput(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("clean input passes", func(t *testing.T) {
+		m, _ := NewScanningMiddleware()
+		result, err := m.ScanInput(ctx, "Show me the top 10 customers by revenue")
+		if err != nil {
+			t.Fatalf("ScanInput() error = %v", err)
+		}
+		if result.Detected {
+			t.Error("Should not detect in clean input")
+		}
+	})
+
+	t.Run("malicious input detected", func(t *testing.T) {
+		m, _ := NewScanningMiddleware()
+		result, err := m.ScanInput(ctx, "'; DROP TABLE users; --")
+		if err != nil {
+			t.Fatalf("ScanInput() error = %v", err)
+		}
+		if !result.Detected {
+			t.Error("Should detect SQL injection in input")
+		}
+	})
+
+	t.Run("input scanning disabled", func(t *testing.T) {
+		cfg := DefaultConfig().WithInputMode(ModeOff)
+		m, _ := NewScanningMiddleware(WithMiddlewareConfig(cfg))
+		result, err := m.ScanInput(ctx, "'; DROP TABLE users; --")
+		if err != nil {
+			t.Fatalf("ScanInput() error = %v", err)
+		}
+		if result.Detected {
+			t.Error("Should not detect when input mode is off")
+		}
+	})
+}
+
+func TestScanningMiddleware_Metrics(t *testing.T) {
+	ctx := context.Background()
+	// Enable blocking to test blocked metrics
+	cfg := DefaultConfig().WithBlockOnDetection(true)
+	m, _ := NewScanningMiddleware(WithMiddlewareConfig(cfg))
+
+	// Initial metrics should be zero
+	metrics := m.GetMetrics()
+	if metrics.ScansTotal != 0 || metrics.DetectionsTotal != 0 || metrics.BlockedTotal != 0 {
+		t.Error("Initial metrics should be zero")
+	}
+
+	// Perform a clean scan
+	m.ScanQueryResponse(ctx, "postgres", []map[string]interface{}{{"id": 1}})
+	metrics = m.GetMetrics()
+	if metrics.ScansTotal != 1 {
+		t.Errorf("ScansTotal = %d, want 1", metrics.ScansTotal)
+	}
+	if metrics.DetectionsTotal != 0 {
+		t.Error("DetectionsTotal should be 0 for clean scan")
+	}
+
+	// Perform a detection scan
+	m.ScanQueryResponse(ctx, "postgres", []map[string]interface{}{
+		{"data": "' UNION SELECT * FROM passwords--"},
+	})
+	metrics = m.GetMetrics()
+	if metrics.ScansTotal != 2 {
+		t.Errorf("ScansTotal = %d, want 2", metrics.ScansTotal)
+	}
+	if metrics.DetectionsTotal != 1 {
+		t.Errorf("DetectionsTotal = %d, want 1", metrics.DetectionsTotal)
+	}
+	if metrics.BlockedTotal != 1 {
+		t.Errorf("BlockedTotal = %d, want 1", metrics.BlockedTotal)
+	}
+
+	// Reset metrics
+	m.ResetMetrics()
+	metrics = m.GetMetrics()
+	if metrics.ScansTotal != 0 || metrics.DetectionsTotal != 0 || metrics.BlockedTotal != 0 {
+		t.Error("Metrics should be zero after reset")
+	}
+}
+
+func TestScanningMiddleware_UpdateConfig(t *testing.T) {
+	m, _ := NewScanningMiddleware()
+
+	// Update to valid config
+	newCfg := DefaultConfig().WithResponseMode(ModeOff).WithBlockOnDetection(false)
+	err := m.UpdateConfig(newCfg)
+	if err != nil {
+		t.Fatalf("UpdateConfig() error = %v", err)
+	}
+
+	// Verify scanning is now off
+	ctx := context.Background()
+	result, _ := m.ScanQueryResponse(ctx, "postgres", []map[string]interface{}{
+		{"data": "' UNION SELECT * FROM users--"},
+	})
+	if result.Detected {
+		t.Error("Should not detect when mode is off")
+	}
+
+	// Update to invalid config should fail
+	invalidCfg := Config{
+		InputMode:        Mode("invalid"),
+		ResponseMode:     ModeBasic,
+		MaxContentLength: 1000,
+	}
+	err = m.UpdateConfig(invalidCfg)
+	if err == nil {
+		t.Error("UpdateConfig() should return error for invalid config")
+	}
+}
+
+func TestScanningMiddleware_RowsToContent(t *testing.T) {
+	m, _ := NewScanningMiddleware()
+
+	t.Run("empty rows", func(t *testing.T) {
+		content := m.rowsToContent(nil)
+		if content != "" {
+			t.Errorf("rowsToContent(nil) = %q, want empty", content)
+		}
+	})
+
+	t.Run("single row", func(t *testing.T) {
+		rows := []map[string]interface{}{
+			{"id": 1, "name": "test"},
+		}
+		content := m.rowsToContent(rows)
+		if content == "" {
+			t.Error("rowsToContent should return non-empty for rows")
+		}
+	})
+
+	t.Run("large dataset truncated", func(t *testing.T) {
+		// Create rows that would exceed max content length
+		cfg := DefaultConfig()
+		cfg.MaxContentLength = 100
+		m, _ := NewScanningMiddleware(WithMiddlewareConfig(cfg))
+
+		rows := make([]map[string]interface{}, 1000)
+		for i := range rows {
+			rows[i] = map[string]interface{}{
+				"id":   i,
+				"data": "This is a very long string that should cause truncation when scanning large datasets",
+			}
+		}
+
+		content := m.rowsToContent(rows)
+		if len(content) > cfg.MaxContentLength {
+			t.Errorf("rowsToContent length = %d, want <= %d", len(content), cfg.MaxContentLength)
+		}
+	})
+}
+
+func TestGlobalMiddleware(t *testing.T) {
+	// Reset global state for testing
+	globalMiddlewareMu.Lock()
+	globalMiddleware = nil
+	globalMiddlewareMu.Unlock()
+
+	t.Run("get returns initialized middleware", func(t *testing.T) {
+		m := GetGlobalMiddleware()
+		if m == nil {
+			t.Fatal("GetGlobalMiddleware() returned nil")
+		}
+
+		// Should return same instance
+		m2 := GetGlobalMiddleware()
+		if m != m2 {
+			t.Error("GetGlobalMiddleware() should return same instance")
+		}
+	})
+
+	t.Run("set replaces middleware", func(t *testing.T) {
+		custom, _ := NewScanningMiddleware(
+			WithMiddlewareConfig(DefaultConfig().WithResponseMode(ModeOff)),
+		)
+		SetGlobalMiddleware(custom)
+
+		m := GetGlobalMiddleware()
+		if m != custom {
+			t.Error("SetGlobalMiddleware should replace the instance")
+		}
+	})
+
+	t.Run("init with config", func(t *testing.T) {
+		cfg := DefaultConfig().WithInputMode(ModeOff).WithResponseMode(ModeBasic)
+		err := InitGlobalMiddleware(cfg)
+		if err != nil {
+			t.Fatalf("InitGlobalMiddleware() error = %v", err)
+		}
+
+		m := GetGlobalMiddleware()
+		if m == nil {
+			t.Fatal("GetGlobalMiddleware() returned nil after init")
+		}
+	})
+
+	t.Run("init with invalid config fails", func(t *testing.T) {
+		cfg := Config{
+			InputMode:        Mode("invalid"),
+			ResponseMode:     ModeBasic,
+			MaxContentLength: 1000,
+		}
+		err := InitGlobalMiddleware(cfg)
+		if err == nil {
+			t.Error("InitGlobalMiddleware should fail with invalid config")
+		}
+	})
+}
+
+func TestScanningMiddleware_ConcurrentAccess(t *testing.T) {
+	m, _ := NewScanningMiddleware()
+	ctx := context.Background()
+
+	// Run concurrent scans
+	done := make(chan bool, 10)
+	for i := 0; i < 10; i++ {
+		go func(i int) {
+			rows := []map[string]interface{}{
+				{"id": i, "name": "test"},
+			}
+			m.ScanQueryResponse(ctx, "postgres", rows)
+			done <- true
+		}(i)
+	}
+
+	// Wait for all goroutines
+	for i := 0; i < 10; i++ {
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("Concurrent scan timed out")
+		}
+	}
+
+	// Verify metrics
+	metrics := m.GetMetrics()
+	if metrics.ScansTotal != 10 {
+		t.Errorf("ScansTotal = %d, want 10", metrics.ScansTotal)
+	}
+}
+
+func BenchmarkScanningMiddleware_ScanQueryResponse(b *testing.B) {
+	m, _ := NewScanningMiddleware()
+	ctx := context.Background()
+	rows := []map[string]interface{}{
+		{"id": 1, "name": "John Doe", "email": "john@example.com"},
+		{"id": 2, "name": "Jane Smith", "email": "jane@example.com"},
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		m.ScanQueryResponse(ctx, "postgres", rows)
+	}
+}
+
+func BenchmarkScanningMiddleware_ScanQueryResponse_LargeDataset(b *testing.B) {
+	m, _ := NewScanningMiddleware()
+	ctx := context.Background()
+
+	// Create a larger dataset
+	rows := make([]map[string]interface{}, 100)
+	for i := range rows {
+		rows[i] = map[string]interface{}{
+			"id":    i,
+			"name":  "User " + string(rune('A'+i%26)),
+			"email": "user" + string(rune('0'+i%10)) + "@example.com",
+			"data":  "Some data content here that needs to be scanned",
+		}
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		m.ScanQueryResponse(ctx, "postgres", rows)
+	}
+}

--- a/platform/agent/sqli/patterns.go
+++ b/platform/agent/sqli/patterns.go
@@ -1,0 +1,344 @@
+package sqli
+
+import (
+	"regexp"
+)
+
+// Pattern represents a SQL injection detection pattern.
+type Pattern struct {
+	// Name is a human-readable identifier for the pattern.
+	Name string
+
+	// Category classifies the type of SQL injection this pattern detects.
+	Category Category
+
+	// Regex is the compiled regular expression.
+	Regex *regexp.Regexp
+
+	// Description explains what this pattern detects.
+	Description string
+
+	// Severity indicates the risk level (1-10).
+	Severity int
+}
+
+// PatternSet holds a collection of SQL injection patterns.
+type PatternSet struct {
+	patterns []*Pattern
+}
+
+// NewPatternSet creates a new pattern set with the default SQL injection patterns.
+func NewPatternSet() *PatternSet {
+	return &PatternSet{
+		patterns: defaultPatterns(),
+	}
+}
+
+// Patterns returns all patterns in the set.
+func (ps *PatternSet) Patterns() []*Pattern {
+	return ps.patterns
+}
+
+// PatternsByCategory returns patterns filtered by category.
+func (ps *PatternSet) PatternsByCategory(category Category) []*Pattern {
+	var result []*Pattern
+	for _, p := range ps.patterns {
+		if p.Category == category {
+			result = append(result, p)
+		}
+	}
+	return result
+}
+
+// defaultPatterns returns the built-in SQL injection patterns.
+// These patterns are designed to balance detection accuracy with performance.
+func defaultPatterns() []*Pattern {
+	return []*Pattern{
+		// UNION-based SQL injection
+		{
+			Name:        "union_select",
+			Category:    CategoryUnionBased,
+			Regex:       regexp.MustCompile(`(?i)\bUNION\s+(ALL\s+)?SELECT\b`),
+			Description: "Detects UNION SELECT statements used to extract data",
+			Severity:    9,
+		},
+		{
+			Name:        "union_injection",
+			Category:    CategoryUnionBased,
+			Regex:       regexp.MustCompile(`(?i)['"\)]\s*UNION\s+(ALL\s+)?SELECT`),
+			Description: "Detects UNION injection after string termination",
+			Severity:    10,
+		},
+
+		// Boolean-based blind SQL injection
+		{
+			Name:        "or_true_condition",
+			Category:    CategoryBooleanBlind,
+			Regex:       regexp.MustCompile(`(?i)\bOR\s+['"]?\d+['"]?\s*=\s*['"]?\d+['"]?`),
+			Description: "Detects OR with always-true numeric comparison (OR 1=1)",
+			Severity:    8,
+		},
+		{
+			Name:        "or_string_condition",
+			Category:    CategoryBooleanBlind,
+			Regex:       regexp.MustCompile(`(?i)\bOR\s+['"][^'"]*['"]\s*=\s*['"][^'"]*['"]`),
+			Description: "Detects OR with always-true string comparison (OR 'a'='a')",
+			Severity:    8,
+		},
+		{
+			Name:        "and_false_condition",
+			Category:    CategoryBooleanBlind,
+			Regex:       regexp.MustCompile(`(?i)\bAND\s+['"]?\d+['"]?\s*=\s*['"]?\d+['"]?`),
+			Description: "Detects AND with numeric comparison for boolean blind",
+			Severity:    7,
+		},
+
+		// Time-based blind SQL injection
+		{
+			Name:        "sleep_function",
+			Category:    CategoryTimeBased,
+			Regex:       regexp.MustCompile(`(?i)\bSLEEP\s*\(\s*\d+\s*\)`),
+			Description: "Detects MySQL SLEEP function for time-based blind injection",
+			Severity:    9,
+		},
+		{
+			Name:        "waitfor_delay",
+			Category:    CategoryTimeBased,
+			Regex:       regexp.MustCompile(`(?i)\bWAITFOR\s+DELAY\s+['"][^'"]+['"]`),
+			Description: "Detects SQL Server WAITFOR DELAY for time-based blind injection",
+			Severity:    9,
+		},
+		{
+			Name:        "pg_sleep",
+			Category:    CategoryTimeBased,
+			Regex:       regexp.MustCompile(`(?i)\bPG_SLEEP\s*\(\s*\d+\s*\)`),
+			Description: "Detects PostgreSQL pg_sleep function",
+			Severity:    9,
+		},
+		{
+			Name:        "benchmark_function",
+			Category:    CategoryTimeBased,
+			Regex:       regexp.MustCompile(`(?i)\bBENCHMARK\s*\(\s*\d+\s*,`),
+			Description: "Detects MySQL BENCHMARK function for time-based injection",
+			Severity:    9,
+		},
+
+		// Error-based SQL injection
+		{
+			Name:        "extractvalue",
+			Category:    CategoryErrorBased,
+			Regex:       regexp.MustCompile(`(?i)\bEXTRACTVALUE\s*\(`),
+			Description: "Detects EXTRACTVALUE function used in error-based injection",
+			Severity:    8,
+		},
+		{
+			Name:        "updatexml",
+			Category:    CategoryErrorBased,
+			Regex:       regexp.MustCompile(`(?i)\bUPDATEXML\s*\(`),
+			Description: "Detects UPDATEXML function used in error-based injection",
+			Severity:    8,
+		},
+		{
+			Name:        "convert_int",
+			Category:    CategoryErrorBased,
+			Regex:       regexp.MustCompile(`(?i)\bCONVERT\s*\(\s*INT\s*,`),
+			Description: "Detects CONVERT(INT, ...) for error-based injection",
+			Severity:    7,
+		},
+
+		// Stacked queries
+		{
+			Name:        "semicolon_drop",
+			Category:    CategoryStackedQueries,
+			Regex:       regexp.MustCompile(`(?i);\s*DROP\s+(TABLE|DATABASE)\b`),
+			Description: "Detects stacked DROP TABLE/DATABASE statement",
+			Severity:    10,
+		},
+		{
+			Name:        "semicolon_delete",
+			Category:    CategoryStackedQueries,
+			Regex:       regexp.MustCompile(`(?i);\s*DELETE\s+FROM\b`),
+			Description: "Detects stacked DELETE statement",
+			Severity:    10,
+		},
+		{
+			Name:        "semicolon_update",
+			Category:    CategoryStackedQueries,
+			Regex:       regexp.MustCompile(`(?i);\s*UPDATE\s+\w+\s+SET\b`),
+			Description: "Detects stacked UPDATE statement",
+			Severity:    9,
+		},
+		{
+			Name:        "semicolon_insert",
+			Category:    CategoryStackedQueries,
+			Regex:       regexp.MustCompile(`(?i);\s*INSERT\s+INTO\b`),
+			Description: "Detects stacked INSERT statement",
+			Severity:    9,
+		},
+		{
+			Name:        "semicolon_exec",
+			Category:    CategoryStackedQueries,
+			Regex:       regexp.MustCompile(`(?i);\s*(EXEC|EXECUTE)\s*\(`),
+			Description: "Detects stacked EXEC/EXECUTE statement",
+			Severity:    10,
+		},
+
+		// Comment-based injection
+		{
+			Name:        "inline_comment",
+			Category:    CategoryCommentInjection,
+			Regex:       regexp.MustCompile(`(?i)/\*.*\*/\s*(UNION|SELECT|INSERT|UPDATE|DELETE|DROP)`),
+			Description: "Detects SQL commands after inline comment",
+			Severity:    8,
+		},
+		{
+			Name:        "line_comment_mysql",
+			Category:    CategoryCommentInjection,
+			Regex:       regexp.MustCompile(`(?i)#\s*(UNION|SELECT|INSERT|UPDATE|DELETE|DROP)`),
+			Description: "Detects SQL commands after MySQL line comment",
+			Severity:    8,
+		},
+		{
+			Name:        "line_comment_double_dash",
+			Category:    CategoryCommentInjection,
+			Regex:       regexp.MustCompile(`(?i)--\s*(UNION|SELECT|INSERT|UPDATE|DELETE|DROP)`),
+			Description: "Detects SQL commands after double-dash comment",
+			Severity:    8,
+		},
+
+		// Generic patterns
+		{
+			Name:        "select_from",
+			Category:    CategoryGeneric,
+			Regex:       regexp.MustCompile(`(?i)['"\)]\s*;\s*SELECT\s+.+\s+FROM\b`),
+			Description: "Detects SELECT ... FROM after string termination",
+			Severity:    9,
+		},
+		{
+			Name:        "admin_bypass",
+			Category:    CategoryGeneric,
+			Regex:       regexp.MustCompile(`(?i)['"]?\s*OR\s+['"]?[^'"]*['"]?\s*=\s*['"]?[^'"]*['"]?\s*--`),
+			Description: "Detects authentication bypass pattern with comment",
+			Severity:    10,
+		},
+		{
+			Name:        "hex_encoding",
+			Category:    CategoryGeneric,
+			Regex:       regexp.MustCompile(`(?i)0x[0-9a-f]{8,}`),
+			Description: "Detects potential hex-encoded SQL injection payload",
+			Severity:    6,
+		},
+		{
+			Name:        "char_function",
+			Category:    CategoryGeneric,
+			Regex:       regexp.MustCompile(`(?i)\bCHAR\s*\(\s*\d+(\s*,\s*\d+)+\s*\)`),
+			Description: "Detects CHAR() function used to obfuscate injection",
+			Severity:    7,
+		},
+		{
+			Name:        "concat_function",
+			Category:    CategoryGeneric,
+			Regex:       regexp.MustCompile(`(?i)\bCONCAT\s*\([^)]*SELECT\b`),
+			Description: "Detects CONCAT with embedded SELECT",
+			Severity:    8,
+		},
+		{
+			Name:        "information_schema",
+			Category:    CategoryGeneric,
+			Regex:       regexp.MustCompile(`(?i)\bINFORMATION_SCHEMA\b`),
+			Description: "Detects access to INFORMATION_SCHEMA for database enumeration",
+			Severity:    8,
+		},
+		{
+			Name:        "sys_tables",
+			Category:    CategoryGeneric,
+			Regex:       regexp.MustCompile(`(?i)\b(sysobjects|syscolumns|sys\.tables|sys\.columns)\b`),
+			Description: "Detects access to system tables for database enumeration",
+			Severity:    8,
+		},
+		{
+			Name:        "load_file",
+			Category:    CategoryGeneric,
+			Regex:       regexp.MustCompile(`(?i)\bLOAD_FILE\s*\(`),
+			Description: "Detects LOAD_FILE function for file access",
+			Severity:    10,
+		},
+		{
+			Name:        "into_outfile",
+			Category:    CategoryGeneric,
+			Regex:       regexp.MustCompile(`(?i)\bINTO\s+(OUT|DUMP)FILE\b`),
+			Description: "Detects INTO OUTFILE/DUMPFILE for file writing",
+			Severity:    10,
+		},
+
+		// Dangerous query patterns - DDL and privilege operations
+		{
+			Name:        "drop_table",
+			Category:    CategoryDangerousQuery,
+			Regex:       regexp.MustCompile(`(?i)\bDROP\s+TABLE\b`),
+			Description: "Detects DROP TABLE statement",
+			Severity:    10,
+		},
+		{
+			Name:        "drop_database",
+			Category:    CategoryDangerousQuery,
+			Regex:       regexp.MustCompile(`(?i)\bDROP\s+DATABASE\b`),
+			Description: "Detects DROP DATABASE statement",
+			Severity:    10,
+		},
+		{
+			Name:        "truncate_table",
+			Category:    CategoryDangerousQuery,
+			Regex:       regexp.MustCompile(`(?i)\bTRUNCATE\s+TABLE\b`),
+			Description: "Detects TRUNCATE TABLE statement",
+			Severity:    10,
+		},
+		{
+			Name:        "alter_table",
+			Category:    CategoryDangerousQuery,
+			Regex:       regexp.MustCompile(`(?i)\bALTER\s+TABLE\b`),
+			Description: "Detects ALTER TABLE statement (schema modification)",
+			Severity:    8,
+		},
+		{
+			Name:        "delete_without_where",
+			Category:    CategoryDangerousQuery,
+			Regex:       regexp.MustCompile(`(?i)\bDELETE\s+FROM\s+\w+\s*(?:;|$)`),
+			Description: "Detects DELETE FROM without WHERE clause",
+			Severity:    9,
+		},
+		{
+			Name:        "create_user",
+			Category:    CategoryDangerousQuery,
+			Regex:       regexp.MustCompile(`(?i)\bCREATE\s+USER\b`),
+			Description: "Detects CREATE USER statement",
+			Severity:    9,
+		},
+		{
+			Name:        "grant_privileges",
+			Category:    CategoryDangerousQuery,
+			Regex:       regexp.MustCompile(`(?i)\bGRANT\s+`),
+			Description: "Detects GRANT privilege statement",
+			Severity:    9,
+		},
+		{
+			Name:        "revoke_privileges",
+			Category:    CategoryDangerousQuery,
+			Regex:       regexp.MustCompile(`(?i)\bREVOKE\s+`),
+			Description: "Detects REVOKE privilege statement",
+			Severity:    9,
+		},
+	}
+}
+
+// TestOnlyPattern creates a pattern for testing purposes.
+// This function should only be used in tests.
+func TestOnlyPattern(name string, regex string, category Category) *Pattern {
+	return &Pattern{
+		Name:        name,
+		Category:    category,
+		Regex:       regexp.MustCompile(regex),
+		Description: "Test pattern",
+		Severity:    5,
+	}
+}

--- a/platform/agent/sqli/scanner.go
+++ b/platform/agent/sqli/scanner.go
@@ -1,0 +1,215 @@
+package sqli
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// Mode represents the SQL injection scanning mode.
+type Mode string
+
+const (
+	// ModeOff disables SQL injection scanning.
+	ModeOff Mode = "off"
+
+	// ModeBasic enables pattern-based SQL injection detection using regex.
+	// This mode is fast (<1ms) and available in Community edition.
+	ModeBasic Mode = "basic"
+
+	// ModeAdvanced enables ML/heuristic SQL injection detection.
+	// This mode provides higher accuracy but is slower (~5-10ms).
+	// Available in Enterprise edition only.
+	ModeAdvanced Mode = "advanced"
+)
+
+// DefaultMode is the default scanning mode (security-first approach).
+const DefaultMode = ModeBasic
+
+// ValidModes returns all valid scanning modes.
+func ValidModes() []Mode {
+	return []Mode{ModeOff, ModeBasic, ModeAdvanced}
+}
+
+// IsValid checks if the mode is a valid scanning mode.
+func (m Mode) IsValid() bool {
+	switch m {
+	case ModeOff, ModeBasic, ModeAdvanced:
+		return true
+	default:
+		return false
+	}
+}
+
+// String returns the string representation of the mode.
+func (m Mode) String() string {
+	return string(m)
+}
+
+// ParseMode parses a string into a Mode, returning an error if invalid.
+func ParseMode(s string) (Mode, error) {
+	mode := Mode(s)
+	if !mode.IsValid() {
+		return "", fmt.Errorf("invalid scanning mode: %q, valid modes are: off, basic, advanced", s)
+	}
+	return mode, nil
+}
+
+// ScanType indicates what is being scanned.
+type ScanType string
+
+const (
+	// ScanTypeInput indicates scanning of user input/prompts.
+	ScanTypeInput ScanType = "input"
+
+	// ScanTypeResponse indicates scanning of MCP connector responses.
+	ScanTypeResponse ScanType = "response"
+)
+
+// Result represents the outcome of a SQL injection scan.
+type Result struct {
+	// Detected indicates whether SQL injection was detected.
+	Detected bool `json:"detected"`
+
+	// Blocked indicates whether the content was blocked (vs just logged).
+	Blocked bool `json:"blocked"`
+
+	// Pattern is the pattern that matched (if detected).
+	Pattern string `json:"pattern,omitempty"`
+
+	// Category classifies the type of SQL injection detected.
+	Category Category `json:"category,omitempty"`
+
+	// Confidence is the confidence level of the detection (0.0-1.0).
+	// Basic mode typically returns 1.0 for matches, 0.0 otherwise.
+	// Advanced mode returns a probability score.
+	Confidence float64 `json:"confidence,omitempty"`
+
+	// Input is a sanitized snippet of the scanned content (for logging).
+	Input string `json:"input,omitempty"`
+
+	// ScanType indicates what was scanned (input or response).
+	ScanType ScanType `json:"scan_type"`
+
+	// Mode is the scanning mode that was used.
+	Mode Mode `json:"mode"`
+
+	// Duration is how long the scan took.
+	Duration time.Duration `json:"duration_ns"`
+
+	// Metadata contains additional scanner-specific information.
+	Metadata map[string]any `json:"metadata,omitempty"`
+}
+
+// Category classifies the type of SQL injection detected.
+type Category string
+
+const (
+	// CategoryUnionBased represents UNION-based SQL injection.
+	CategoryUnionBased Category = "union_based"
+
+	// CategoryBooleanBlind represents boolean-based blind SQL injection.
+	CategoryBooleanBlind Category = "boolean_blind"
+
+	// CategoryTimeBased represents time-based blind SQL injection.
+	CategoryTimeBased Category = "time_based"
+
+	// CategoryErrorBased represents error-based SQL injection.
+	CategoryErrorBased Category = "error_based"
+
+	// CategoryStackedQueries represents stacked queries SQL injection.
+	CategoryStackedQueries Category = "stacked_queries"
+
+	// CategoryCommentInjection represents comment-based SQL injection.
+	CategoryCommentInjection Category = "comment_injection"
+
+	// CategoryGeneric represents generic SQL injection patterns.
+	CategoryGeneric Category = "generic"
+
+	// CategoryDangerousQuery represents dangerous SQL operations that should be blocked.
+	// This includes DDL operations (DROP, ALTER, TRUNCATE) and privilege modifications.
+	CategoryDangerousQuery Category = "dangerous_query"
+)
+
+// Scanner is the interface for SQL injection detection.
+type Scanner interface {
+	// Scan checks the content for SQL injection patterns.
+	// Returns a Result indicating whether injection was detected.
+	Scan(ctx context.Context, content string, scanType ScanType) *Result
+
+	// Mode returns the scanning mode of this scanner.
+	Mode() Mode
+
+	// IsEnterprise returns true if this scanner requires an enterprise license.
+	IsEnterprise() bool
+}
+
+// NoOpScanner is a scanner that does nothing (used for ModeOff).
+type NoOpScanner struct{}
+
+// Scan always returns a clean result.
+func (s *NoOpScanner) Scan(_ context.Context, _ string, scanType ScanType) *Result {
+	return &Result{
+		Detected: false,
+		Blocked:  false,
+		ScanType: scanType,
+		Mode:     ModeOff,
+		Duration: 0,
+	}
+}
+
+// Mode returns ModeOff.
+func (s *NoOpScanner) Mode() Mode {
+	return ModeOff
+}
+
+// IsEnterprise returns false.
+func (s *NoOpScanner) IsEnterprise() bool {
+	return false
+}
+
+// scannerRegistry holds registered scanner factories.
+var scannerRegistry = make(map[Mode]func() Scanner)
+
+// RegisterScanner registers a scanner factory for a given mode.
+// This is used by the enterprise package to register the advanced scanner.
+func RegisterScanner(mode Mode, factory func() Scanner) {
+	scannerRegistry[mode] = factory
+}
+
+// NewScanner creates a new scanner for the given mode.
+// Returns an error if the mode is not available (e.g., advanced mode without enterprise license).
+func NewScanner(mode Mode) (Scanner, error) {
+	if !mode.IsValid() {
+		return nil, fmt.Errorf("invalid scanning mode: %q", mode)
+	}
+
+	if mode == ModeOff {
+		return &NoOpScanner{}, nil
+	}
+
+	factory, ok := scannerRegistry[mode]
+	if !ok {
+		if mode == ModeAdvanced {
+			return nil, fmt.Errorf("advanced scanning mode requires enterprise license")
+		}
+		return nil, fmt.Errorf("scanner not registered for mode: %q", mode)
+	}
+
+	return factory(), nil
+}
+
+// MustNewScanner creates a new scanner, panicking on error.
+// Use only in initialization code where errors are programming mistakes.
+func MustNewScanner(mode Mode) Scanner {
+	scanner, err := NewScanner(mode)
+	if err != nil {
+		panic(fmt.Sprintf("failed to create scanner: %v", err))
+	}
+	return scanner
+}
+
+func init() {
+	// NoOp scanner is always available
+	RegisterScanner(ModeOff, func() Scanner { return &NoOpScanner{} })
+}

--- a/platform/agent/sqli/scanner_test.go
+++ b/platform/agent/sqli/scanner_test.go
@@ -1,0 +1,256 @@
+package sqli
+
+import (
+	"context"
+	"testing"
+)
+
+func TestMode_IsValid(t *testing.T) {
+	tests := []struct {
+		name  string
+		mode  Mode
+		valid bool
+	}{
+		{"off is valid", ModeOff, true},
+		{"basic is valid", ModeBasic, true},
+		{"advanced is valid", ModeAdvanced, true},
+		{"empty is invalid", Mode(""), false},
+		{"unknown is invalid", Mode("unknown"), false},
+		{"BASIC uppercase is invalid", Mode("BASIC"), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.mode.IsValid(); got != tt.valid {
+				t.Errorf("Mode(%q).IsValid() = %v, want %v", tt.mode, got, tt.valid)
+			}
+		})
+	}
+}
+
+func TestMode_String(t *testing.T) {
+	tests := []struct {
+		mode Mode
+		want string
+	}{
+		{ModeOff, "off"},
+		{ModeBasic, "basic"},
+		{ModeAdvanced, "advanced"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			if got := tt.mode.String(); got != tt.want {
+				t.Errorf("Mode.String() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseMode(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    Mode
+		wantErr bool
+	}{
+		{"parse off", "off", ModeOff, false},
+		{"parse basic", "basic", ModeBasic, false},
+		{"parse advanced", "advanced", ModeAdvanced, false},
+		{"parse empty", "", Mode(""), true},
+		{"parse invalid", "invalid", Mode(""), true},
+		{"parse uppercase", "BASIC", Mode(""), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseMode(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseMode(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("ParseMode(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidModes(t *testing.T) {
+	modes := ValidModes()
+	if len(modes) != 3 {
+		t.Errorf("ValidModes() returned %d modes, want 3", len(modes))
+	}
+
+	expected := map[Mode]bool{ModeOff: true, ModeBasic: true, ModeAdvanced: true}
+	for _, m := range modes {
+		if !expected[m] {
+			t.Errorf("unexpected mode in ValidModes(): %v", m)
+		}
+	}
+}
+
+func TestNoOpScanner(t *testing.T) {
+	scanner := &NoOpScanner{}
+
+	t.Run("Mode returns off", func(t *testing.T) {
+		if got := scanner.Mode(); got != ModeOff {
+			t.Errorf("NoOpScanner.Mode() = %v, want %v", got, ModeOff)
+		}
+	})
+
+	t.Run("IsEnterprise returns false", func(t *testing.T) {
+		if got := scanner.IsEnterprise(); got != false {
+			t.Errorf("NoOpScanner.IsEnterprise() = %v, want false", got)
+		}
+	})
+
+	t.Run("Scan returns clean result for input", func(t *testing.T) {
+		result := scanner.Scan(context.Background(), "SELECT * FROM users", ScanTypeInput)
+		if result.Detected {
+			t.Error("NoOpScanner should never detect")
+		}
+		if result.Blocked {
+			t.Error("NoOpScanner should never block")
+		}
+		if result.ScanType != ScanTypeInput {
+			t.Errorf("result.ScanType = %v, want %v", result.ScanType, ScanTypeInput)
+		}
+		if result.Mode != ModeOff {
+			t.Errorf("result.Mode = %v, want %v", result.Mode, ModeOff)
+		}
+	})
+
+	t.Run("Scan returns clean result for response", func(t *testing.T) {
+		result := scanner.Scan(context.Background(), "malicious content", ScanTypeResponse)
+		if result.Detected {
+			t.Error("NoOpScanner should never detect")
+		}
+		if result.ScanType != ScanTypeResponse {
+			t.Errorf("result.ScanType = %v, want %v", result.ScanType, ScanTypeResponse)
+		}
+	})
+}
+
+func TestNewScanner_Off(t *testing.T) {
+	scanner, err := NewScanner(ModeOff)
+	if err != nil {
+		t.Fatalf("NewScanner(ModeOff) error = %v", err)
+	}
+	if scanner == nil {
+		t.Fatal("NewScanner(ModeOff) returned nil")
+	}
+	if _, ok := scanner.(*NoOpScanner); !ok {
+		t.Errorf("NewScanner(ModeOff) returned %T, want *NoOpScanner", scanner)
+	}
+}
+
+func TestNewScanner_InvalidMode(t *testing.T) {
+	_, err := NewScanner(Mode("invalid"))
+	if err == nil {
+		t.Error("NewScanner with invalid mode should return error")
+	}
+}
+
+func TestNewScanner_AdvancedWithoutLicense(t *testing.T) {
+	// Advanced scanner is not registered in community edition
+	// First, ensure we don't have it registered
+	delete(scannerRegistry, ModeAdvanced)
+
+	_, err := NewScanner(ModeAdvanced)
+	if err == nil {
+		t.Error("NewScanner(ModeAdvanced) should return error without enterprise license")
+	}
+	if err.Error() != "advanced scanning mode requires enterprise license" {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestMustNewScanner_Panics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("MustNewScanner with invalid mode should panic")
+		}
+	}()
+
+	MustNewScanner(Mode("invalid"))
+}
+
+func TestMustNewScanner_Success(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("MustNewScanner(ModeOff) panicked: %v", r)
+		}
+	}()
+
+	scanner := MustNewScanner(ModeOff)
+	if scanner == nil {
+		t.Error("MustNewScanner(ModeOff) returned nil")
+	}
+}
+
+func TestRegisterScanner(t *testing.T) {
+	// Create a mock scanner
+	mockScanner := &NoOpScanner{}
+	mockFactory := func() Scanner { return mockScanner }
+
+	// Register for a custom mode (using basic for test since advanced requires license check)
+	// Save original and restore after test
+	original := scannerRegistry[ModeBasic]
+	defer func() {
+		if original != nil {
+			scannerRegistry[ModeBasic] = original
+		} else {
+			delete(scannerRegistry, ModeBasic)
+		}
+	}()
+
+	RegisterScanner(ModeBasic, mockFactory)
+
+	scanner, err := NewScanner(ModeBasic)
+	if err != nil {
+		t.Fatalf("NewScanner after RegisterScanner error = %v", err)
+	}
+	if scanner != mockScanner {
+		t.Error("NewScanner did not return registered scanner")
+	}
+}
+
+func TestCategory_Values(t *testing.T) {
+	// Ensure all categories are distinct
+	categories := []Category{
+		CategoryUnionBased,
+		CategoryBooleanBlind,
+		CategoryTimeBased,
+		CategoryErrorBased,
+		CategoryStackedQueries,
+		CategoryCommentInjection,
+		CategoryGeneric,
+	}
+
+	seen := make(map[Category]bool)
+	for _, c := range categories {
+		if seen[c] {
+			t.Errorf("duplicate category: %v", c)
+		}
+		seen[c] = true
+		if c == "" {
+			t.Error("category should not be empty")
+		}
+	}
+}
+
+func TestScanType_Values(t *testing.T) {
+	if ScanTypeInput != "input" {
+		t.Errorf("ScanTypeInput = %q, want %q", ScanTypeInput, "input")
+	}
+	if ScanTypeResponse != "response" {
+		t.Errorf("ScanTypeResponse = %q, want %q", ScanTypeResponse, "response")
+	}
+}
+
+func TestDefaultMode(t *testing.T) {
+	if DefaultMode != ModeBasic {
+		t.Errorf("DefaultMode = %v, want %v", DefaultMode, ModeBasic)
+	}
+}

--- a/platform/orchestrator/Dockerfile
+++ b/platform/orchestrator/Dockerfile
@@ -30,6 +30,21 @@ RUN --mount=type=bind,source=.,target=/src \
       cp -r /src/ee/platform/agent/marketplace/* ./agent/marketplace/ && \
       cp -r /src/ee/platform/agent/node_enforcement/* ./agent/node_enforcement/ && \
       echo "Enterprise agent code copied successfully" && \
+      echo "=== Copying EE compliance modules ===" && \
+      if [ -d "/src/ee/platform/orchestrator/sebi" ]; then \
+        cp -r /src/ee/platform/orchestrator/sebi/* ./orchestrator/sebi/ && \
+        echo "SEBI compliance module copied"; \
+      fi && \
+      if [ -d "/src/ee/platform/orchestrator/rbi" ]; then \
+        mkdir -p ./orchestrator/rbi/ && \
+        cp -r /src/ee/platform/orchestrator/rbi/* ./orchestrator/rbi/ && \
+        echo "RBI compliance module copied"; \
+      fi && \
+      if [ -d "/src/ee/platform/orchestrator/euaiact" ]; then \
+        mkdir -p ./orchestrator/euaiact/ && \
+        cp -r /src/ee/platform/orchestrator/euaiact/* ./orchestrator/euaiact/ && \
+        echo "EU AI Act compliance module copied"; \
+      fi && \
       echo "=== Downloading enterprise dependencies ===" && \
       go get github.com/aws/aws-sdk-go-v2/service/marketplacemetering@latest && \
       echo "Enterprise dependencies downloaded"; \

--- a/platform/orchestrator/dynamic_policy_engine_test.go
+++ b/platform/orchestrator/dynamic_policy_engine_test.go
@@ -583,8 +583,10 @@ func TestCalculateRiskScore(t *testing.T) {
 				Query: "SELECT password FROM users",
 				User:  UserContext{Role: "user"},
 			},
-			expectedMin: 0.9,
-			expectedMax: 1.0,
+			// Sensitive data keywords (password, secret, key, token) use sensitive_data weight (0.7)
+			// SQL injection patterns use sql_injection weight (0.9) via unified sqli scanner
+			expectedMin: 0.7,
+			expectedMax: 0.7,
 		},
 	}
 

--- a/platform/orchestrator/euaiact/euaiact_community.go
+++ b/platform/orchestrator/euaiact/euaiact_community.go
@@ -1,0 +1,64 @@
+//go:build !enterprise
+
+// Copyright 2025 AxonFlow
+// SPDX-License-Identifier: Apache-2.0
+
+// Package euaiact provides EU AI Act compliance functionality.
+// This is the Community stub - EU AI Act compliance is an Enterprise feature.
+package euaiact
+
+import (
+	"database/sql"
+	"net/http"
+
+	"github.com/gorilla/mux"
+)
+
+// Module is the EU AI Act compliance module.
+// Community stub: No-op implementation - EU AI Act compliance is disabled in Community builds.
+type Module struct {
+	// No fields needed for Community stub
+}
+
+// ModuleConfig contains configuration for the EU AI Act module.
+// Community stub: Configuration is ignored.
+type ModuleConfig struct {
+	DB                   *sql.DB
+	DefaultAccuracyMin   float64
+	DefaultBiasMax       float64
+	AlertCooldownMinutes int
+}
+
+// NewModule creates a new EU AI Act compliance module.
+// Community stub: Returns a no-op module. EU AI Act compliance is an enterprise feature.
+func NewModule(config ModuleConfig) (*Module, error) {
+	return &Module{}, nil
+}
+
+// RegisterRoutes registers all EU AI Act routes on a standard http.ServeMux.
+// Community stub: No-op - no routes are registered in Community builds.
+func (m *Module) RegisterRoutes(mux *http.ServeMux) {
+	// No-op in Community builds - EU AI Act compliance is an enterprise feature
+}
+
+// RegisterRoutesWithMux registers all EU AI Act routes on a gorilla/mux Router.
+// Community stub: No-op - no routes are registered in Community builds.
+func (m *Module) RegisterRoutesWithMux(r *mux.Router) {
+	// No-op in Community builds - EU AI Act compliance is an enterprise feature
+}
+
+// HealthCheck returns the health status of all EU AI Act services.
+// Community stub: Returns "disabled" for all components.
+func (m *Module) HealthCheck() map[string]string {
+	return map[string]string{
+		"export":     "disabled",
+		"conformity": "disabled",
+		"accuracy":   "disabled",
+	}
+}
+
+// IsHealthy returns true if all EU AI Act services are healthy.
+// Community stub: Always returns false (feature not available).
+func (m *Module) IsHealthy() bool {
+	return false
+}

--- a/platform/orchestrator/euaiact/euaiact_community_test.go
+++ b/platform/orchestrator/euaiact/euaiact_community_test.go
@@ -1,0 +1,74 @@
+//go:build !enterprise
+
+// Copyright 2025 AxonFlow
+// SPDX-License-Identifier: Apache-2.0
+
+package euaiact
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+)
+
+func TestNewModule_Community(t *testing.T) {
+	module, err := NewModule(ModuleConfig{})
+	if err != nil {
+		t.Fatalf("NewModule() error = %v", err)
+	}
+	if module == nil {
+		t.Fatal("NewModule() returned nil")
+	}
+}
+
+func TestModule_IsHealthy_Community(t *testing.T) {
+	module, _ := NewModule(ModuleConfig{})
+	if module.IsHealthy() {
+		t.Error("IsHealthy() should return false in Community builds")
+	}
+}
+
+func TestModule_HealthCheck_Community(t *testing.T) {
+	module, _ := NewModule(ModuleConfig{})
+	health := module.HealthCheck()
+
+	expected := map[string]string{
+		"export":     "disabled",
+		"conformity": "disabled",
+		"accuracy":   "disabled",
+	}
+
+	for k, v := range expected {
+		if health[k] != v {
+			t.Errorf("HealthCheck()[%s] = %v, want %v", k, health[k], v)
+		}
+	}
+}
+
+func TestModule_RegisterRoutesWithMux_Community(t *testing.T) {
+	module, _ := NewModule(ModuleConfig{})
+	r := mux.NewRouter()
+
+	// Should not panic
+	module.RegisterRoutesWithMux(r)
+
+	// Test that no routes are registered by trying to access an endpoint
+	req := httptest.NewRequest("GET", "/api/v1/euaiact/export", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	// Should return 404 since no routes are registered in Community builds
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("Expected 404 in Community builds, got %d", rr.Code)
+	}
+}
+
+func TestModule_RegisterRoutes_Community(t *testing.T) {
+	module, _ := NewModule(ModuleConfig{})
+	mux := http.NewServeMux()
+
+	// Should not panic
+	module.RegisterRoutes(mux)
+}

--- a/platform/orchestrator/sebi/sebi_oss.go
+++ b/platform/orchestrator/sebi/sebi_oss.go
@@ -1,0 +1,59 @@
+//go:build !enterprise
+
+// Copyright 2025 AxonFlow
+// SPDX-License-Identifier: Apache-2.0
+
+// Package sebi provides SEBI AI/ML Guidelines compliance functionality.
+// This is the OSS stub - SEBI compliance is an Enterprise feature for Indian markets.
+package sebi
+
+import (
+	"database/sql"
+	"net/http"
+
+	"github.com/gorilla/mux"
+)
+
+// SEBIModule contains all SEBI compliance services and handlers.
+// OSS stub: No-op implementation - SEBI compliance is disabled in OSS mode.
+type SEBIModule struct {
+	// No fields needed for OSS stub
+}
+
+// SEBIModuleConfig holds configuration for the SEBI module.
+// OSS stub: Configuration is ignored.
+type SEBIModuleConfig struct {
+	DB *sql.DB
+}
+
+// NewSEBIModule creates a new SEBI compliance module.
+// OSS stub: Returns a no-op module. SEBI compliance is an enterprise feature.
+func NewSEBIModule(config SEBIModuleConfig) (*SEBIModule, error) {
+	return &SEBIModule{}, nil
+}
+
+// RegisterRoutes registers all SEBI API routes on a standard http.ServeMux.
+// OSS stub: No-op - no routes are registered in OSS mode.
+func (m *SEBIModule) RegisterRoutes(mux *http.ServeMux) {
+	// No-op in OSS mode - SEBI compliance is an enterprise feature
+}
+
+// RegisterRoutesWithMux registers all SEBI API routes on a gorilla/mux Router.
+// OSS stub: No-op - no routes are registered in OSS mode.
+func (m *SEBIModule) RegisterRoutesWithMux(r *mux.Router) {
+	// No-op in OSS mode - SEBI compliance is an enterprise feature
+}
+
+// HealthCheck returns the health status of all SEBI services.
+// OSS stub: Returns "disabled" for all components.
+func (m *SEBIModule) HealthCheck() map[string]string {
+	return map[string]string{
+		"audit_export": "disabled",
+	}
+}
+
+// IsHealthy returns true if all SEBI services are healthy.
+// OSS stub: Always returns false (feature not available).
+func (m *SEBIModule) IsHealthy() bool {
+	return false
+}

--- a/platform/orchestrator/sebi/sebi_oss_test.go
+++ b/platform/orchestrator/sebi/sebi_oss_test.go
@@ -1,0 +1,62 @@
+//go:build !enterprise
+
+// Copyright 2025 AxonFlow
+// SPDX-License-Identifier: Apache-2.0
+
+package sebi
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/gorilla/mux"
+)
+
+func TestNewSEBIModule_OSS(t *testing.T) {
+	config := SEBIModuleConfig{
+		DB: nil,
+	}
+
+	module, err := NewSEBIModule(config)
+	if err != nil {
+		t.Fatalf("NewSEBIModule() error = %v", err)
+	}
+
+	if module == nil {
+		t.Fatal("NewSEBIModule() returned nil module")
+	}
+}
+
+func TestSEBIModule_IsHealthy_OSS(t *testing.T) {
+	module := &SEBIModule{}
+
+	if module.IsHealthy() {
+		t.Error("IsHealthy() should return false for OSS stub")
+	}
+}
+
+func TestSEBIModule_HealthCheck_OSS(t *testing.T) {
+	module := &SEBIModule{}
+
+	status := module.HealthCheck()
+
+	if status["audit_export"] != "disabled" {
+		t.Errorf("HealthCheck()[audit_export] = %v, want disabled", status["audit_export"])
+	}
+}
+
+func TestSEBIModule_RegisterRoutes_OSS(t *testing.T) {
+	module := &SEBIModule{}
+	mux := http.NewServeMux()
+
+	// Should not panic
+	module.RegisterRoutes(mux)
+}
+
+func TestSEBIModule_RegisterRoutesWithMux_OSS(t *testing.T) {
+	module := &SEBIModule{}
+	r := mux.NewRouter()
+
+	// Should not panic
+	module.RegisterRoutesWithMux(r)
+}


### PR DESCRIPTION
## SQL Injection Response Scanning
- Detect SQLi payloads in MCP connector responses
- 37 regex patterns across 8 attack categories
- Monitoring mode by default (configurable blocking)
- Full test coverage in `platform/agent/sqli/`

## Documentation & Release
- v1.0.0 CHANGELOG for community launch
- README updates (SQLi feature, token usage tracking)
- SQL injection scanning guide (`docs/security/`)

## Also includes
Build stubs for enterprise compliance modules (EU AI Act, SEBI, RBI)

---
Source commits: 2333568, ecad0e6, deb44d4, 080bfd2, 2e559c9