### PR TITLE
chore(sync): BSL 1.1 license headers, connector stubs, Python demo files

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,34 +149,75 @@ Policy checks add single-digit millisecond overhead.
 
 ## Community vs Enterprise
 
-| | Community (Free) | Enterprise |
-|---|:---:|:---:|
+| Feature | Community (Free) | Enterprise |
+|---------|------------|------------|
 | **Core Platform** | | |
-| Policy enforcement | ✅ | ✅ |
-| PII detection (SSN, credit cards, PAN/Aadhaar) | ✅ | ✅ |
+| Policy enforcement engine | ✅ | ✅ |
+| Single-digit ms inline governance | ✅ | ✅ |
+| PII detection (SSN, credit cards, PAN, Aadhaar) | ✅ | ✅ |
 | SQLi response scanning (basic) | ✅ | ✅ |
 | SQLi response scanning (ML-based) | ❌ | ✅ |
 | Audit logging | ✅ | ✅ |
+| Static Policy API (list, get) | ✅ | ✅ |
 | **LLM Providers** | | |
-| OpenAI, Anthropic, Ollama | ✅ | ✅ |
-| AWS Bedrock, Google Gemini | ❌ | ✅ |
+| OpenAI | ✅ | ✅ |
+| Anthropic (Claude) | ✅ | ✅ |
+| Ollama (local/air-gapped) | ✅ | ✅ |
+| AWS Bedrock | ❌ | ✅ |
+| Google Gemini | ❌ | ✅ |
 | Multi-provider routing & failover | ✅ | ✅ |
+| Customer Portal provider UI | ❌ | ✅ |
 | **MCP Connectors** | | |
-| PostgreSQL, MySQL, MongoDB, Redis, HTTP | ✅ | ✅ |
-| Salesforce, Slack, Snowflake, ServiceNow | ❌ | ✅ |
-| **Multi-Agent Planning** | | |
+| PostgreSQL, MySQL, MongoDB | ✅ | ✅ |
+| Redis, HTTP/REST, Cassandra | ✅ | ✅ |
+| S3, Azure Blob, GCS (cloud storage) | ✅ | ✅ |
+| Amadeus (Travel API) | ❌ | ✅ |
+| Salesforce | ❌ | ✅ |
+| Slack | ❌ | ✅ |
+| Snowflake | ❌ | ✅ |
+| HubSpot | ❌ | ✅ |
+| Jira | ❌ | ✅ |
+| ServiceNow | ❌ | ✅ |
+| Customer Portal Connector UI | ❌ | ✅ |
+| **Multi-Agent Planning (MAP)** | | |
 | YAML agent configuration | ✅ | ✅ |
+| Parallel task execution | ✅ | ✅ |
+| Conditional logic & branching | ✅ | ✅ |
+| Agent registry with hot reload | ✅ | ✅ |
 | REST API (list, get, validate) | ✅ | ✅ |
 | REST API (CRUD, versions, sandbox) | ❌ | ✅ |
+| Database-backed agent storage | ❌ | ✅ |
+| **Policy Management** | | |
+| Static policies (SQL injection, PII) | ✅ | ✅ |
+| Dynamic policy CRUD API | ✅ | ✅ |
+| Policy versioning | ✅ | ✅ |
+| Policy templates library | Basic | Full (EU AI Act, HIPAA, PCI-DSS, SEBI) |
+| Customer Portal Policy UI | ❌ | ✅ |
 | **EU AI Act Compliance** | | |
-| Decision chain tracing (Art. 12, 13) | ✅ | ✅ |
+| Decision chain tracing | ✅ | ✅ |
 | Transparency headers (X-AI-*) | ✅ | ✅ |
-| Human-in-the-Loop (HITL) workflows | ❌ | ✅ |
-| Conformity assessment (Art. 43) | ❌ | ✅ |
+| Human-in-the-Loop (HITL) queue | ❌ | ✅ |
 | Emergency circuit breaker | ❌ | ✅ |
-| **Platform** | | |
-| Customer Portal UI | ❌ | ✅ |
+| Conformity assessment workflow | ❌ | ✅ |
+| Accuracy metrics & bias detection | ❌ | ✅ |
+| 10-year audit retention | ❌ | ✅ |
+| EU AI Act export format | ❌ | ✅ |
+| **India Compliance (SEBI/RBI)** | | |
+| India PII detection (Aadhaar, PAN, UPI) | ✅ Pattern-based | ✅ With checksum |
+| SEBI AI/ML Guidelines - basic detection | ✅ | ✅ |
+| SEBI compliance module (export, 5-year retention) | ❌ | ✅ |
+| RBI FREE-AI Framework (kill switch, board reports) | ❌ | ✅ |
+| Compliance dashboard | ❌ | ✅ |
+| **Platform Features** | | |
+| Customer dashboard UI | ❌ | ✅ |
+| Usage analytics & reporting | ❌ | ✅ |
+| AWS Marketplace integration | ❌ | ✅ |
+| **Deployment** | | |
+| Docker Compose (local) | ✅ | ✅ |
+| AWS ECS/Fargate | Manual | One-click CloudFormation |
 | Multi-tenant isolation | ❌ | ✅ |
+| **Support** | | |
+| Community (GitHub Issues) | ✅ | ✅ |
 | Priority support & SLA | ❌ | ✅ |
 
 → **[Full feature comparison](https://docs.getaxonflow.com/docs/features/community-vs-enterprise)**

--- a/platform/agent/Dockerfile
+++ b/platform/agent/Dockerfile
@@ -32,16 +32,35 @@ RUN --mount=type=bind,source=.,target=/src \
       cp -r /src/ee/platform/agent/node_enforcement/* ./agent/node_enforcement/ && \
       if [ -d "/src/ee/platform/agent/rbi" ]; then \
         cp -r /src/ee/platform/agent/rbi/* ./agent/rbi/ && \
-        echo "  Copied enterprise RBI module (kill switch)"; \
+        echo "  Copied enterprise RBI module"; \
+      fi && \
+      if [ -d "/src/ee/platform/agent/hitl" ]; then \
+        mkdir -p ./agent/hitl && \
+        cp -r /src/ee/platform/agent/hitl/* ./agent/hitl/ && \
+        echo "  Copied enterprise HITL module (EU AI Act Article 14)"; \
+      fi && \
+      if [ -d "/src/ee/platform/agent/circuitbreaker" ]; then \
+        mkdir -p ./agent/circuitbreaker && \
+        cp -r /src/ee/platform/agent/circuitbreaker/* ./agent/circuitbreaker/ && \
+        echo "  Copied enterprise Circuit Breaker module (EU AI Act Article 14)"; \
+      fi && \
+      if [ -d "/src/ee/platform/agent/sqli" ]; then \
+        mkdir -p /go/src/axonflow/ee/platform/agent/sqli && \
+        cp -r /src/ee/platform/agent/sqli/* /go/src/axonflow/ee/platform/agent/sqli/ && \
+        echo "module axonflow/ee/platform" > /go/src/axonflow/ee/platform/go.mod && \
+        echo "" >> /go/src/axonflow/ee/platform/go.mod && \
+        echo "go 1.24.0" >> /go/src/axonflow/ee/platform/go.mod && \
+        echo "" >> /go/src/axonflow/ee/platform/go.mod && \
+        echo "require axonflow/platform v0.0.0" >> /go/src/axonflow/ee/platform/go.mod && \
+        echo "" >> /go/src/axonflow/ee/platform/go.mod && \
+        echo "replace axonflow/platform => /go/src/axonflow/platform" >> /go/src/axonflow/ee/platform/go.mod && \
+        go mod edit -require axonflow/ee/platform@v0.0.0 && \
+        go mod edit -replace axonflow/ee/platform=/go/src/axonflow/ee/platform && \
+        echo "  Copied enterprise SQLi scanner (ML-based) and configured modules"; \
       fi && \
       echo "Enterprise agent code copied successfully" && \
-      echo "=== Enterprise build: copying RBI compliance module ===" && \
-      if [ -d "/src/ee/platform/agent/rbi" ]; then \
-        cp -r /src/ee/platform/agent/rbi/* ./agent/rbi/ && \
-        echo "  RBI PII detector copied successfully"; \
-      fi && \
       echo "=== Enterprise build: copying EE connectors ===" && \
-      for connector in amadeus salesforce slack snowflake; do \
+      for connector in amadeus salesforce slack snowflake hubspot jira servicenow; do \
         if [ -d "/src/ee/platform/connectors/$connector" ]; then \
           cp -r /src/ee/platform/connectors/$connector/* ./connectors/$connector/ && \
           echo "  Copied enterprise connector: $connector"; \

--- a/platform/agent/agent_bench_test.go
+++ b/platform/agent/agent_bench_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/agent/audit_queue.go
+++ b/platform/agent/audit_queue.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/agent/audit_queue_test.go
+++ b/platform/agent/audit_queue_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/agent/auth.go
+++ b/platform/agent/auth.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/agent/auth_test.go
+++ b/platform/agent/auth_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/agent/circuitbreaker/circuitbreaker_community.go
+++ b/platform/agent/circuitbreaker/circuitbreaker_community.go
@@ -1,0 +1,69 @@
+// Copyright 2025 AxonFlow
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build !enterprise
+
+// Package circuitbreaker provides emergency stop functionality for
+// AI governance and EU AI Act Article 14 compliance.
+//
+// This is the Community Edition stub - Circuit Breaker functionality is an Enterprise feature.
+// Upgrade to Enterprise at https://getaxonflow.com/enterprise for:
+//   - Emergency stop/interrupt capability for AI operations
+//   - Scope-based circuit tripping (global, tenant, client, policy)
+//   - EU AI Act Article 14 compliance
+//   - Audit trail with two-person deactivation
+package circuitbreaker
+
+import (
+	"database/sql"
+	"time"
+
+	"github.com/gorilla/mux"
+)
+
+// Handler provides HTTP handlers for circuit breaker operations.
+// Community Edition: No-op implementation.
+type Handler struct{}
+
+// NewHandler creates a new circuit breaker handler.
+// Community Edition: Returns a no-op handler.
+func NewHandler(cb *CircuitBreaker) *Handler {
+	return &Handler{}
+}
+
+// RegisterRoutes registers circuit breaker routes with a mux router.
+// Community Edition: Does not register any routes (feature not available).
+func (h *Handler) RegisterRoutes(r *mux.Router) {
+	// Circuit breaker is an Enterprise feature
+	// Routes are registered in enterprise builds
+}
+
+// CircuitBreaker manages emergency stop functionality.
+// Community Edition: No-op implementation.
+type CircuitBreaker struct{}
+
+// Config contains circuit breaker configuration.
+type Config struct {
+	DefaultTimeout           time.Duration
+	MaxTimeout               time.Duration
+	ErrorThreshold           int
+	PolicyViolationThreshold int
+	PolicyViolationWindow    time.Duration
+	EnableAutoRecovery       bool
+}
+
+// New creates a new circuit breaker.
+// Community Edition: Returns a no-op circuit breaker.
+func New(repo *Repository, config Config) *CircuitBreaker {
+	return &CircuitBreaker{}
+}
+
+// Repository provides data access for circuit breaker state.
+// Community Edition: No-op implementation.
+type Repository struct{}
+
+// NewRepository creates a new circuit breaker repository.
+// Community Edition: Returns a no-op repository.
+func NewRepository(db *sql.DB) *Repository {
+	return &Repository{}
+}

--- a/platform/agent/connector_factory.go
+++ b/platform/agent/connector_factory.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/agent/connector_factory_test.go
+++ b/platform/agent/connector_factory_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/agent/connector_refresh_api.go
+++ b/platform/agent/connector_refresh_api.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/agent/connector_refresh_api_test.go
+++ b/platform/agent/connector_refresh_api_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/agent/db_auth.go
+++ b/platform/agent/db_auth.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/agent/db_auth_test.go
+++ b/platform/agent/db_auth_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/agent/db_policies.go
+++ b/platform/agent/db_policies.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/agent/db_policies_test.go
+++ b/platform/agent/db_policies_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/agent/decision_chain.go
+++ b/platform/agent/decision_chain.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/agent/decision_chain_test.go
+++ b/platform/agent/decision_chain_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/agent/doc.go
+++ b/platform/agent/doc.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/agent/gateway_handlers.go
+++ b/platform/agent/gateway_handlers.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/agent/gateway_handlers_integration_test.go
+++ b/platform/agent/gateway_handlers_integration_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/agent/gateway_handlers_test.go
+++ b/platform/agent/gateway_handlers_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/agent/grafana_password_substitution_test.go
+++ b/platform/agent/grafana_password_substitution_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/agent/hitl/hitl_community.go
+++ b/platform/agent/hitl/hitl_community.go
@@ -1,0 +1,65 @@
+// Copyright 2025 AxonFlow
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build !enterprise
+
+// Package hitl provides Human-in-the-Loop (HITL) queue functionality for
+// AI governance and EU AI Act Article 14 compliance.
+//
+// This is the Community Edition stub - HITL functionality is an Enterprise feature.
+// Upgrade to Enterprise at https://getaxonflow.com/enterprise for:
+//   - Human oversight queue for high-risk AI decisions
+//   - Approval/rejection workflow with audit trail
+//   - EU AI Act Article 14 compliance
+//   - Override capability with justification tracking
+package hitl
+
+import (
+	"database/sql"
+	"time"
+
+	"github.com/gorilla/mux"
+)
+
+// Handler provides HTTP handlers for HITL queue operations.
+// Community Edition: No-op implementation.
+type Handler struct{}
+
+// NewHandler creates a new HITL handler.
+// Community Edition: Returns a no-op handler.
+func NewHandler(service *Service) *Handler {
+	return &Handler{}
+}
+
+// RegisterRoutes registers HITL routes with a mux router.
+// Community Edition: Does not register any routes (feature not available).
+func (h *Handler) RegisterRoutes(r *mux.Router) {
+	// HITL queue is an Enterprise feature
+	// Routes are registered in enterprise builds
+}
+
+// Service provides business logic for HITL queue operations.
+// Community Edition: No-op implementation.
+type Service struct{}
+
+// ServiceConfig contains configuration for the HITL service.
+type ServiceConfig struct {
+	DefaultExpiry time.Duration
+	MaxExpiry     time.Duration
+}
+
+// NewService creates a new HITL service.
+// Community Edition: Returns a no-op service.
+func NewService(repo *Repository, config ServiceConfig) *Service {
+	return &Service{}
+}
+
+// Repository provides data access for HITL approval requests.
+// Community Edition: No-op implementation.
+type Repository struct{}
+
+// NewRepository creates a new HITL repository.
+// Community Edition: Returns a no-op repository.
+func NewRepository(db *sql.DB) *Repository {
+	return &Repository{}
+}

--- a/platform/agent/license/license_community.go
+++ b/platform/agent/license/license_community.go
@@ -1,9 +1,7 @@
 //go:build !enterprise
 
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/agent/license/license_community_test.go
+++ b/platform/agent/license/license_community_test.go
@@ -1,9 +1,7 @@
 //go:build !enterprise
 
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/agent/marketplace/marketplace_community.go
+++ b/platform/agent/marketplace/marketplace_community.go
@@ -1,9 +1,7 @@
 //go:build !enterprise
 
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/agent/marketplace/marketplace_community_test.go
+++ b/platform/agent/marketplace/marketplace_community_test.go
@@ -1,9 +1,7 @@
 //go:build !enterprise
 
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/agent/mcp_config_file_test.go
+++ b/platform/agent/mcp_config_file_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/agent/mcp_handler.go
+++ b/platform/agent/mcp_handler.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //
@@ -30,16 +28,22 @@ import (
 	"axonflow/platform/agent/policy"
 	"axonflow/platform/agent/sqli"
 	"axonflow/platform/connectors/amadeus"
+	"axonflow/platform/connectors/azureblob"
 	"axonflow/platform/connectors/base"
 	"axonflow/platform/connectors/cassandra"
 	"axonflow/platform/connectors/config"
+	"axonflow/platform/connectors/gcs"
 	httpconnector "axonflow/platform/connectors/http"
+	"axonflow/platform/connectors/hubspot"
+	"axonflow/platform/connectors/jira"
 	"axonflow/platform/connectors/mongodb"
 	"axonflow/platform/connectors/mysql"
 	"axonflow/platform/connectors/postgres"
 	"axonflow/platform/connectors/redis"
 	"axonflow/platform/connectors/registry"
+	"axonflow/platform/connectors/s3"
 	"axonflow/platform/connectors/salesforce"
+	"axonflow/platform/connectors/servicenow"
 	"axonflow/platform/connectors/slack"
 	"axonflow/platform/connectors/snowflake"
 )
@@ -205,6 +209,18 @@ func registerConnectorFromConfig(cfg *base.ConnectorConfig) error {
 		connector = httpconnector.NewHTTPConnector()
 	case "redis":
 		connector = redis.NewRedisConnector()
+	case "s3":
+		connector = s3.NewS3Connector()
+	case "azureblob":
+		connector = azureblob.NewAzureBlobConnector()
+	case "gcs":
+		connector = gcs.NewGCSConnector()
+	case "hubspot":
+		connector = hubspot.NewHubSpotConnector()
+	case "jira":
+		connector = jira.NewJiraConnector()
+	case "servicenow":
+		connector = servicenow.NewServiceNowConnector()
 	default:
 		return fmt.Errorf("unsupported connector type: %s", cfg.Type)
 	}

--- a/platform/agent/mcp_handler_test.go
+++ b/platform/agent/mcp_handler_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/agent/migration_helpers.go
+++ b/platform/agent/migration_helpers.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/agent/migration_helpers_test.go
+++ b/platform/agent/migration_helpers_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/agent/node_enforcement/enforcement_community.go
+++ b/platform/agent/node_enforcement/enforcement_community.go
@@ -1,9 +1,7 @@
 //go:build !enterprise
 
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/agent/node_enforcement/enforcement_community_test.go
+++ b/platform/agent/node_enforcement/enforcement_community_test.go
@@ -1,9 +1,7 @@
 //go:build !enterprise
 
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/agent/policy/doc.go
+++ b/platform/agent/policy/doc.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/agent/policy/permissions.go
+++ b/platform/agent/policy/permissions.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/agent/policy/permissions_test.go
+++ b/platform/agent/policy/permissions_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/agent/rbi/killswitch_community.go
+++ b/platform/agent/rbi/killswitch_community.go
@@ -1,9 +1,7 @@
 //go:build !enterprise
 
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/agent/rbi/killswitch_community_test.go
+++ b/platform/agent/rbi/killswitch_community_test.go
@@ -1,9 +1,7 @@
 //go:build !enterprise
 
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/agent/rbi/rbi_community.go
+++ b/platform/agent/rbi/rbi_community.go
@@ -1,9 +1,7 @@
 //go:build !enterprise
 
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/agent/rbi/rbi_community_test.go
+++ b/platform/agent/rbi/rbi_community_test.go
@@ -1,9 +1,7 @@
 //go:build !enterprise
 
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/agent/redis_rate_limit.go
+++ b/platform/agent/redis_rate_limit.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/agent/redis_rate_limit_test.go
+++ b/platform/agent/redis_rate_limit_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/agent/rls.go
+++ b/platform/agent/rls.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/agent/rls_test.go
+++ b/platform/agent/rls_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/agent/rls_unit_test.go
+++ b/platform/agent/rls_unit_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/agent/run_test.go
+++ b/platform/agent/run_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/agent/sebi_compliance_test.go
+++ b/platform/agent/sebi_compliance_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/agent/selfhosted_security_test.go
+++ b/platform/agent/selfhosted_security_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/agent/static_policies.go
+++ b/platform/agent/static_policies.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/agent/static_policies_test.go
+++ b/platform/agent/static_policies_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/agent/static_policy_api_handlers.go
+++ b/platform/agent/static_policy_api_handlers.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/agent/static_policy_api_handlers_test.go
+++ b/platform/agent/static_policy_api_handlers_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/agent/tenant_connector_integration_test.go
+++ b/platform/agent/tenant_connector_integration_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/agent/tenant_connector_registry.go
+++ b/platform/agent/tenant_connector_registry.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/agent/tenant_connector_registry_test.go
+++ b/platform/agent/tenant_connector_registry_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/agent/tenant_isolation_test.go
+++ b/platform/agent/tenant_isolation_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/agent/transparency.go
+++ b/platform/agent/transparency.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/agent/transparency_context.go
+++ b/platform/agent/transparency_context.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/agent/transparency_test.go
+++ b/platform/agent/transparency_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/cmd/agent/doc.go
+++ b/platform/cmd/agent/doc.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/cmd/agent/enterprise_imports.go
+++ b/platform/cmd/agent/enterprise_imports.go
@@ -1,0 +1,12 @@
+// Copyright 2025 AxonFlow
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build enterprise
+
+package main
+
+// Enterprise imports - these packages register themselves via init()
+import (
+	// Advanced SQL injection scanner (ML-based)
+	_ "axonflow/ee/platform/agent/sqli"
+)

--- a/platform/cmd/agent/main.go
+++ b/platform/cmd/agent/main.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/cmd/orchestrator/doc.go
+++ b/platform/cmd/orchestrator/doc.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/cmd/orchestrator/main.go
+++ b/platform/cmd/orchestrator/main.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/common/usage/doc.go
+++ b/platform/common/usage/doc.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/common/usage/pricing.go
+++ b/platform/common/usage/pricing.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/common/usage/pricing_test.go
+++ b/platform/common/usage/pricing_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/common/usage/recorder.go
+++ b/platform/common/usage/recorder.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/common/usage/recorder_test.go
+++ b/platform/common/usage/recorder_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/connectors/amadeus/connector.go
+++ b/platform/connectors/amadeus/connector.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/connectors/amadeus/connector_test.go
+++ b/platform/connectors/amadeus/connector_test.go
@@ -1,6 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
+// SPDX-License-Identifier: BUSL-1.1
 
 package amadeus
 

--- a/platform/connectors/amadeus/doc.go
+++ b/platform/connectors/amadeus/doc.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/connectors/azureblob/connector.go
+++ b/platform/connectors/azureblob/connector.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/connectors/azureblob/connector_test.go
+++ b/platform/connectors/azureblob/connector_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/connectors/azureblob/doc.go
+++ b/platform/connectors/azureblob/doc.go
@@ -1,5 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0
+// SPDX-License-Identifier: BUSL-1.1
 
 /*
 Package azureblob provides an Azure Blob Storage connector for the AxonFlow MCP

--- a/platform/connectors/base/connector.go
+++ b/platform/connectors/base/connector.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/connectors/base/connector_test.go
+++ b/platform/connectors/base/connector_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/connectors/base/doc.go
+++ b/platform/connectors/base/doc.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/connectors/base/security.go
+++ b/platform/connectors/base/security.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/connectors/base/security_test.go
+++ b/platform/connectors/base/security_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/connectors/cassandra/connector.go
+++ b/platform/connectors/cassandra/connector.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/connectors/cassandra/connector_test.go
+++ b/platform/connectors/cassandra/connector_test.go
@@ -1,6 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
+// SPDX-License-Identifier: BUSL-1.1
 
 package cassandra
 

--- a/platform/connectors/config/cache.go
+++ b/platform/connectors/config/cache.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/connectors/config/cache_test.go
+++ b/platform/connectors/config/cache_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/connectors/config/config.go
+++ b/platform/connectors/config/config.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/connectors/config/config_extended_test.go
+++ b/platform/connectors/config/config_extended_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/connectors/config/config_test.go
+++ b/platform/connectors/config/config_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/connectors/config/doc.go
+++ b/platform/connectors/config/doc.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/connectors/config/file_loader.go
+++ b/platform/connectors/config/file_loader.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/connectors/config/file_loader_test.go
+++ b/platform/connectors/config/file_loader_test.go
@@ -1,6 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
+// SPDX-License-Identifier: BUSL-1.1
 
 package config
 

--- a/platform/connectors/config/runtime_config.go
+++ b/platform/connectors/config/runtime_config.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/connectors/config/runtime_config_integration_test.go
+++ b/platform/connectors/config/runtime_config_integration_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/connectors/config/runtime_config_test.go
+++ b/platform/connectors/config/runtime_config_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/connectors/config/secrets_manager.go
+++ b/platform/connectors/config/secrets_manager.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/connectors/config/secrets_manager_test.go
+++ b/platform/connectors/config/secrets_manager_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/connectors/gcs/connector.go
+++ b/platform/connectors/gcs/connector.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/connectors/gcs/connector_test.go
+++ b/platform/connectors/gcs/connector_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/connectors/gcs/doc.go
+++ b/platform/connectors/gcs/doc.go
@@ -1,5 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0
+// SPDX-License-Identifier: BUSL-1.1
 
 /*
 Package gcs provides a Google Cloud Storage connector for the AxonFlow MCP

--- a/platform/connectors/http/connector.go
+++ b/platform/connectors/http/connector.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/connectors/http/connector_test.go
+++ b/platform/connectors/http/connector_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/connectors/hubspot/connector.go
+++ b/platform/connectors/hubspot/connector.go
@@ -1,0 +1,86 @@
+// Copyright 2025 AxonFlow
+// SPDX-License-Identifier: BUSL-1.1
+
+// Package hubspot provides the HubSpot CRM connector.
+// This is the Community Edition stub - the full HubSpot connector is an enterprise feature.
+package hubspot
+
+import (
+	"context"
+	"errors"
+
+	"axonflow/platform/connectors/base"
+)
+
+// ErrEnterpriseFeature is returned when attempting to use enterprise-only features
+var ErrEnterpriseFeature = errors.New("hubspot connector is an enterprise feature - contact sales@getaxonflow.com")
+
+// HubSpotConnector is the Community stub for the HubSpot CRM connector.
+// The full implementation is available in the enterprise edition.
+type HubSpotConnector struct {
+	config *base.ConnectorConfig
+}
+
+// NewHubSpotConnector creates a new HubSpot connector instance.
+// Community stub: Returns a stub that will error on Connect().
+func NewHubSpotConnector() *HubSpotConnector {
+	return &HubSpotConnector{}
+}
+
+// Connect establishes a connection to HubSpot API.
+// Community stub: Always returns ErrEnterpriseFeature.
+func (c *HubSpotConnector) Connect(ctx context.Context, config *base.ConnectorConfig) error {
+	c.config = config
+	return ErrEnterpriseFeature
+}
+
+// Disconnect closes the connection.
+// Community stub: No-op.
+func (c *HubSpotConnector) Disconnect(ctx context.Context) error {
+	return nil
+}
+
+// HealthCheck verifies the API is accessible.
+// Community stub: Returns unhealthy status indicating enterprise feature.
+func (c *HubSpotConnector) HealthCheck(ctx context.Context) (*base.HealthStatus, error) {
+	return &base.HealthStatus{
+		Healthy: false,
+		Error:   "hubspot connector is an enterprise feature",
+	}, nil
+}
+
+// Query executes a read operation.
+// Community stub: Always returns ErrEnterpriseFeature.
+func (c *HubSpotConnector) Query(ctx context.Context, query *base.Query) (*base.QueryResult, error) {
+	return nil, ErrEnterpriseFeature
+}
+
+// Execute executes a write operation.
+// Community stub: Always returns ErrEnterpriseFeature.
+func (c *HubSpotConnector) Execute(ctx context.Context, cmd *base.Command) (*base.CommandResult, error) {
+	return nil, ErrEnterpriseFeature
+}
+
+// Name returns the connector instance name.
+func (c *HubSpotConnector) Name() string {
+	if c.config != nil {
+		return c.config.Name
+	}
+	return "hubspot"
+}
+
+// Type returns the connector type.
+func (c *HubSpotConnector) Type() string {
+	return "hubspot"
+}
+
+// Version returns the connector version.
+func (c *HubSpotConnector) Version() string {
+	return "community-stub"
+}
+
+// Capabilities returns the list of capabilities.
+// Community stub: Returns empty list (no capabilities in Community mode).
+func (c *HubSpotConnector) Capabilities() []string {
+	return []string{}
+}

--- a/platform/connectors/hubspot/connector_test.go
+++ b/platform/connectors/hubspot/connector_test.go
@@ -1,0 +1,88 @@
+// Copyright 2025 AxonFlow
+// SPDX-License-Identifier: BUSL-1.1
+
+package hubspot
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"axonflow/platform/connectors/base"
+)
+
+func TestNewHubSpotConnector(t *testing.T) {
+	c := NewHubSpotConnector()
+	if c == nil {
+		t.Fatal("expected non-nil connector")
+	}
+}
+
+func TestHubSpotConnector_Connect_ReturnsEnterpriseError(t *testing.T) {
+	c := NewHubSpotConnector()
+	err := c.Connect(context.Background(), &base.ConnectorConfig{Name: "test"})
+	if !errors.Is(err, ErrEnterpriseFeature) {
+		t.Errorf("expected ErrEnterpriseFeature, got %v", err)
+	}
+}
+
+func TestHubSpotConnector_Query_ReturnsEnterpriseError(t *testing.T) {
+	c := NewHubSpotConnector()
+	_, err := c.Query(context.Background(), &base.Query{})
+	if !errors.Is(err, ErrEnterpriseFeature) {
+		t.Errorf("expected ErrEnterpriseFeature, got %v", err)
+	}
+}
+
+func TestHubSpotConnector_Execute_ReturnsEnterpriseError(t *testing.T) {
+	c := NewHubSpotConnector()
+	_, err := c.Execute(context.Background(), &base.Command{})
+	if !errors.Is(err, ErrEnterpriseFeature) {
+		t.Errorf("expected ErrEnterpriseFeature, got %v", err)
+	}
+}
+
+func TestHubSpotConnector_Disconnect_NoError(t *testing.T) {
+	c := NewHubSpotConnector()
+	err := c.Disconnect(context.Background())
+	if err != nil {
+		t.Errorf("expected no error on disconnect, got %v", err)
+	}
+}
+
+func TestHubSpotConnector_HealthCheck_Unhealthy(t *testing.T) {
+	c := NewHubSpotConnector()
+	status, err := c.HealthCheck(context.Background())
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+	if status.Healthy {
+		t.Error("expected unhealthy status for community stub")
+	}
+}
+
+func TestHubSpotConnector_Metadata(t *testing.T) {
+	c := NewHubSpotConnector()
+	if c.Type() != "hubspot" {
+		t.Errorf("expected type hubspot, got %s", c.Type())
+	}
+	if c.Version() != "community-stub" {
+		t.Errorf("expected version community-stub, got %s", c.Version())
+	}
+	if len(c.Capabilities()) != 0 {
+		t.Errorf("expected empty capabilities, got %v", c.Capabilities())
+	}
+}
+
+func TestHubSpotConnector_Name(t *testing.T) {
+	c := NewHubSpotConnector()
+	// Before Connect, name should be default
+	if c.Name() != "hubspot" {
+		t.Errorf("expected default name hubspot, got %s", c.Name())
+	}
+	// After Connect attempt, name should be from config
+	_ = c.Connect(context.Background(), &base.ConnectorConfig{Name: "my-hubspot"})
+	if c.Name() != "my-hubspot" {
+		t.Errorf("expected name my-hubspot, got %s", c.Name())
+	}
+}

--- a/platform/connectors/integration_test.go
+++ b/platform/connectors/integration_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/connectors/jira/connector.go
+++ b/platform/connectors/jira/connector.go
@@ -1,0 +1,86 @@
+// Copyright 2025 AxonFlow
+// SPDX-License-Identifier: BUSL-1.1
+
+// Package jira provides the Jira project management connector.
+// This is the Community Edition stub - the full Jira connector is an enterprise feature.
+package jira
+
+import (
+	"context"
+	"errors"
+
+	"axonflow/platform/connectors/base"
+)
+
+// ErrEnterpriseFeature is returned when attempting to use enterprise-only features
+var ErrEnterpriseFeature = errors.New("jira connector is an enterprise feature - contact sales@getaxonflow.com")
+
+// JiraConnector is the Community stub for the Jira connector.
+// The full implementation is available in the enterprise edition.
+type JiraConnector struct {
+	config *base.ConnectorConfig
+}
+
+// NewJiraConnector creates a new Jira connector instance.
+// Community stub: Returns a stub that will error on Connect().
+func NewJiraConnector() *JiraConnector {
+	return &JiraConnector{}
+}
+
+// Connect establishes a connection to Jira API.
+// Community stub: Always returns ErrEnterpriseFeature.
+func (c *JiraConnector) Connect(ctx context.Context, config *base.ConnectorConfig) error {
+	c.config = config
+	return ErrEnterpriseFeature
+}
+
+// Disconnect closes the connection.
+// Community stub: No-op.
+func (c *JiraConnector) Disconnect(ctx context.Context) error {
+	return nil
+}
+
+// HealthCheck verifies the API is accessible.
+// Community stub: Returns unhealthy status indicating enterprise feature.
+func (c *JiraConnector) HealthCheck(ctx context.Context) (*base.HealthStatus, error) {
+	return &base.HealthStatus{
+		Healthy: false,
+		Error:   "jira connector is an enterprise feature",
+	}, nil
+}
+
+// Query executes a read operation (JQL query).
+// Community stub: Always returns ErrEnterpriseFeature.
+func (c *JiraConnector) Query(ctx context.Context, query *base.Query) (*base.QueryResult, error) {
+	return nil, ErrEnterpriseFeature
+}
+
+// Execute executes a write operation (create/update issue).
+// Community stub: Always returns ErrEnterpriseFeature.
+func (c *JiraConnector) Execute(ctx context.Context, cmd *base.Command) (*base.CommandResult, error) {
+	return nil, ErrEnterpriseFeature
+}
+
+// Name returns the connector instance name.
+func (c *JiraConnector) Name() string {
+	if c.config != nil {
+		return c.config.Name
+	}
+	return "jira"
+}
+
+// Type returns the connector type.
+func (c *JiraConnector) Type() string {
+	return "jira"
+}
+
+// Version returns the connector version.
+func (c *JiraConnector) Version() string {
+	return "community-stub"
+}
+
+// Capabilities returns the list of capabilities.
+// Community stub: Returns empty list (no capabilities in Community mode).
+func (c *JiraConnector) Capabilities() []string {
+	return []string{}
+}

--- a/platform/connectors/jira/connector_test.go
+++ b/platform/connectors/jira/connector_test.go
@@ -1,0 +1,88 @@
+// Copyright 2025 AxonFlow
+// SPDX-License-Identifier: BUSL-1.1
+
+package jira
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"axonflow/platform/connectors/base"
+)
+
+func TestNewJiraConnector(t *testing.T) {
+	c := NewJiraConnector()
+	if c == nil {
+		t.Fatal("expected non-nil connector")
+	}
+}
+
+func TestJiraConnector_Connect_ReturnsEnterpriseError(t *testing.T) {
+	c := NewJiraConnector()
+	err := c.Connect(context.Background(), &base.ConnectorConfig{Name: "test"})
+	if !errors.Is(err, ErrEnterpriseFeature) {
+		t.Errorf("expected ErrEnterpriseFeature, got %v", err)
+	}
+}
+
+func TestJiraConnector_Query_ReturnsEnterpriseError(t *testing.T) {
+	c := NewJiraConnector()
+	_, err := c.Query(context.Background(), &base.Query{})
+	if !errors.Is(err, ErrEnterpriseFeature) {
+		t.Errorf("expected ErrEnterpriseFeature, got %v", err)
+	}
+}
+
+func TestJiraConnector_Execute_ReturnsEnterpriseError(t *testing.T) {
+	c := NewJiraConnector()
+	_, err := c.Execute(context.Background(), &base.Command{})
+	if !errors.Is(err, ErrEnterpriseFeature) {
+		t.Errorf("expected ErrEnterpriseFeature, got %v", err)
+	}
+}
+
+func TestJiraConnector_Disconnect_NoError(t *testing.T) {
+	c := NewJiraConnector()
+	err := c.Disconnect(context.Background())
+	if err != nil {
+		t.Errorf("expected no error on disconnect, got %v", err)
+	}
+}
+
+func TestJiraConnector_HealthCheck_Unhealthy(t *testing.T) {
+	c := NewJiraConnector()
+	status, err := c.HealthCheck(context.Background())
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+	if status.Healthy {
+		t.Error("expected unhealthy status for community stub")
+	}
+}
+
+func TestJiraConnector_Metadata(t *testing.T) {
+	c := NewJiraConnector()
+	if c.Type() != "jira" {
+		t.Errorf("expected type jira, got %s", c.Type())
+	}
+	if c.Version() != "community-stub" {
+		t.Errorf("expected version community-stub, got %s", c.Version())
+	}
+	if len(c.Capabilities()) != 0 {
+		t.Errorf("expected empty capabilities, got %v", c.Capabilities())
+	}
+}
+
+func TestJiraConnector_Name(t *testing.T) {
+	c := NewJiraConnector()
+	// Before Connect, name should be default
+	if c.Name() != "jira" {
+		t.Errorf("expected default name jira, got %s", c.Name())
+	}
+	// After Connect attempt, name should be from config
+	_ = c.Connect(context.Background(), &base.ConnectorConfig{Name: "my-jira"})
+	if c.Name() != "my-jira" {
+		t.Errorf("expected name my-jira, got %s", c.Name())
+	}
+}

--- a/platform/connectors/mongodb/connector.go
+++ b/platform/connectors/mongodb/connector.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/connectors/mongodb/connector_test.go
+++ b/platform/connectors/mongodb/connector_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/connectors/mysql/connector.go
+++ b/platform/connectors/mysql/connector.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/connectors/mysql/connector_test.go
+++ b/platform/connectors/mysql/connector_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/connectors/postgres/connector.go
+++ b/platform/connectors/postgres/connector.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/connectors/postgres/connector_integration_test.go
+++ b/platform/connectors/postgres/connector_integration_test.go
@@ -1,6 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
+// SPDX-License-Identifier: BUSL-1.1
 
 package postgres
 

--- a/platform/connectors/postgres/connector_test.go
+++ b/platform/connectors/postgres/connector_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/connectors/postgres/doc.go
+++ b/platform/connectors/postgres/doc.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/connectors/redis/connector.go
+++ b/platform/connectors/redis/connector.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/connectors/redis/connector_test.go
+++ b/platform/connectors/redis/connector_test.go
@@ -1,6 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
+// SPDX-License-Identifier: BUSL-1.1
 
 package redis
 

--- a/platform/connectors/registry/doc.go
+++ b/platform/connectors/registry/doc.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/connectors/registry/postgres_storage.go
+++ b/platform/connectors/registry/postgres_storage.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/connectors/registry/postgres_storage_integration_test.go
+++ b/platform/connectors/registry/postgres_storage_integration_test.go
@@ -1,6 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
+// SPDX-License-Identifier: BUSL-1.1
 
 package registry
 

--- a/platform/connectors/registry/registry.go
+++ b/platform/connectors/registry/registry.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/connectors/registry/registry_test.go
+++ b/platform/connectors/registry/registry_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/connectors/s3/connector.go
+++ b/platform/connectors/s3/connector.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/connectors/s3/connector_test.go
+++ b/platform/connectors/s3/connector_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/connectors/s3/doc.go
+++ b/platform/connectors/s3/doc.go
@@ -1,5 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0
+// SPDX-License-Identifier: BUSL-1.1
 
 /*
 Package s3 provides an Amazon S3 connector for the AxonFlow MCP (Model Context Protocol) system.

--- a/platform/connectors/salesforce/connector.go
+++ b/platform/connectors/salesforce/connector.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/connectors/salesforce/connector_test.go
+++ b/platform/connectors/salesforce/connector_test.go
@@ -1,6 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
+// SPDX-License-Identifier: BUSL-1.1
 
 package salesforce
 

--- a/platform/connectors/sdk/auth.go
+++ b/platform/connectors/sdk/auth.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/connectors/sdk/auth_test.go
+++ b/platform/connectors/sdk/auth_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/connectors/sdk/base_connector.go
+++ b/platform/connectors/sdk/base_connector.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/connectors/sdk/base_connector_test.go
+++ b/platform/connectors/sdk/base_connector_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/connectors/sdk/doc.go
+++ b/platform/connectors/sdk/doc.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/connectors/sdk/metrics.go
+++ b/platform/connectors/sdk/metrics.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/connectors/sdk/metrics_test.go
+++ b/platform/connectors/sdk/metrics_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/connectors/sdk/rate_limit.go
+++ b/platform/connectors/sdk/rate_limit.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/connectors/sdk/rate_limit_test.go
+++ b/platform/connectors/sdk/rate_limit_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/connectors/sdk/retry.go
+++ b/platform/connectors/sdk/retry.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/connectors/sdk/retry_test.go
+++ b/platform/connectors/sdk/retry_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/connectors/sdk/sdk.go
+++ b/platform/connectors/sdk/sdk.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/connectors/sdk/sdk_test.go
+++ b/platform/connectors/sdk/sdk_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/connectors/sdk/testing.go
+++ b/platform/connectors/sdk/testing.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/connectors/sdk/testing_test.go
+++ b/platform/connectors/sdk/testing_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/connectors/servicenow/connector.go
+++ b/platform/connectors/servicenow/connector.go
@@ -1,0 +1,86 @@
+// Copyright 2025 AxonFlow
+// SPDX-License-Identifier: BUSL-1.1
+
+// Package servicenow provides the ServiceNow ITSM connector.
+// This is the Community Edition stub - the full ServiceNow connector is an enterprise feature.
+package servicenow
+
+import (
+	"context"
+	"errors"
+
+	"axonflow/platform/connectors/base"
+)
+
+// ErrEnterpriseFeature is returned when attempting to use enterprise-only features
+var ErrEnterpriseFeature = errors.New("servicenow connector is an enterprise feature - contact sales@getaxonflow.com")
+
+// ServiceNowConnector is the Community stub for the ServiceNow ITSM connector.
+// The full implementation is available in the enterprise edition.
+type ServiceNowConnector struct {
+	config *base.ConnectorConfig
+}
+
+// NewServiceNowConnector creates a new ServiceNow connector instance.
+// Community stub: Returns a stub that will error on Connect().
+func NewServiceNowConnector() *ServiceNowConnector {
+	return &ServiceNowConnector{}
+}
+
+// Connect establishes a connection to ServiceNow API.
+// Community stub: Always returns ErrEnterpriseFeature.
+func (c *ServiceNowConnector) Connect(ctx context.Context, config *base.ConnectorConfig) error {
+	c.config = config
+	return ErrEnterpriseFeature
+}
+
+// Disconnect closes the connection.
+// Community stub: No-op.
+func (c *ServiceNowConnector) Disconnect(ctx context.Context) error {
+	return nil
+}
+
+// HealthCheck verifies the API is accessible.
+// Community stub: Returns unhealthy status indicating enterprise feature.
+func (c *ServiceNowConnector) HealthCheck(ctx context.Context) (*base.HealthStatus, error) {
+	return &base.HealthStatus{
+		Healthy: false,
+		Error:   "servicenow connector is an enterprise feature",
+	}, nil
+}
+
+// Query executes a read operation (table query).
+// Community stub: Always returns ErrEnterpriseFeature.
+func (c *ServiceNowConnector) Query(ctx context.Context, query *base.Query) (*base.QueryResult, error) {
+	return nil, ErrEnterpriseFeature
+}
+
+// Execute executes a write operation (create/update record).
+// Community stub: Always returns ErrEnterpriseFeature.
+func (c *ServiceNowConnector) Execute(ctx context.Context, cmd *base.Command) (*base.CommandResult, error) {
+	return nil, ErrEnterpriseFeature
+}
+
+// Name returns the connector instance name.
+func (c *ServiceNowConnector) Name() string {
+	if c.config != nil {
+		return c.config.Name
+	}
+	return "servicenow"
+}
+
+// Type returns the connector type.
+func (c *ServiceNowConnector) Type() string {
+	return "servicenow"
+}
+
+// Version returns the connector version.
+func (c *ServiceNowConnector) Version() string {
+	return "community-stub"
+}
+
+// Capabilities returns the list of capabilities.
+// Community stub: Returns empty list (no capabilities in Community mode).
+func (c *ServiceNowConnector) Capabilities() []string {
+	return []string{}
+}

--- a/platform/connectors/servicenow/connector_test.go
+++ b/platform/connectors/servicenow/connector_test.go
@@ -1,0 +1,88 @@
+// Copyright 2025 AxonFlow
+// SPDX-License-Identifier: BUSL-1.1
+
+package servicenow
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"axonflow/platform/connectors/base"
+)
+
+func TestNewServiceNowConnector(t *testing.T) {
+	c := NewServiceNowConnector()
+	if c == nil {
+		t.Fatal("expected non-nil connector")
+	}
+}
+
+func TestServiceNowConnector_Connect_ReturnsEnterpriseError(t *testing.T) {
+	c := NewServiceNowConnector()
+	err := c.Connect(context.Background(), &base.ConnectorConfig{Name: "test"})
+	if !errors.Is(err, ErrEnterpriseFeature) {
+		t.Errorf("expected ErrEnterpriseFeature, got %v", err)
+	}
+}
+
+func TestServiceNowConnector_Query_ReturnsEnterpriseError(t *testing.T) {
+	c := NewServiceNowConnector()
+	_, err := c.Query(context.Background(), &base.Query{})
+	if !errors.Is(err, ErrEnterpriseFeature) {
+		t.Errorf("expected ErrEnterpriseFeature, got %v", err)
+	}
+}
+
+func TestServiceNowConnector_Execute_ReturnsEnterpriseError(t *testing.T) {
+	c := NewServiceNowConnector()
+	_, err := c.Execute(context.Background(), &base.Command{})
+	if !errors.Is(err, ErrEnterpriseFeature) {
+		t.Errorf("expected ErrEnterpriseFeature, got %v", err)
+	}
+}
+
+func TestServiceNowConnector_Disconnect_NoError(t *testing.T) {
+	c := NewServiceNowConnector()
+	err := c.Disconnect(context.Background())
+	if err != nil {
+		t.Errorf("expected no error on disconnect, got %v", err)
+	}
+}
+
+func TestServiceNowConnector_HealthCheck_Unhealthy(t *testing.T) {
+	c := NewServiceNowConnector()
+	status, err := c.HealthCheck(context.Background())
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+	if status.Healthy {
+		t.Error("expected unhealthy status for community stub")
+	}
+}
+
+func TestServiceNowConnector_Metadata(t *testing.T) {
+	c := NewServiceNowConnector()
+	if c.Type() != "servicenow" {
+		t.Errorf("expected type servicenow, got %s", c.Type())
+	}
+	if c.Version() != "community-stub" {
+		t.Errorf("expected version community-stub, got %s", c.Version())
+	}
+	if len(c.Capabilities()) != 0 {
+		t.Errorf("expected empty capabilities, got %v", c.Capabilities())
+	}
+}
+
+func TestServiceNowConnector_Name(t *testing.T) {
+	c := NewServiceNowConnector()
+	// Before Connect, name should be default
+	if c.Name() != "servicenow" {
+		t.Errorf("expected default name servicenow, got %s", c.Name())
+	}
+	// After Connect attempt, name should be from config
+	_ = c.Connect(context.Background(), &base.ConnectorConfig{Name: "my-servicenow"})
+	if c.Name() != "my-servicenow" {
+		t.Errorf("expected name my-servicenow, got %s", c.Name())
+	}
+}

--- a/platform/connectors/slack/connector.go
+++ b/platform/connectors/slack/connector.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/connectors/slack/connector_test.go
+++ b/platform/connectors/slack/connector_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/connectors/snowflake/connector.go
+++ b/platform/connectors/snowflake/connector.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/connectors/snowflake/connector_test.go
+++ b/platform/connectors/snowflake/connector_test.go
@@ -1,6 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
+// SPDX-License-Identifier: BUSL-1.1
 
 package snowflake
 

--- a/platform/examples/demo/01_unprotected_call.py
+++ b/platform/examples/demo/01_unprotected_call.py
@@ -1,0 +1,22 @@
+"""
+Unprotected AI Call - The Problem
+
+Most AI apps send user input directly to an LLM.
+No checks, no rate limits, no audit trail.
+"""
+
+import openai
+
+# Direct call to LLM - no governance
+user_input = "What's the weather in London?"
+
+response = openai.chat.completions.create(
+    model="gpt-4",
+    messages=[{"role": "user", "content": user_input}]
+    # No policy checks
+    # No PII detection
+    # No audit trail
+    # No rate limiting
+)
+
+print(response.choices[0].message.content)

--- a/platform/examples/demo/02_governed_call.py
+++ b/platform/examples/demo/02_governed_call.py
@@ -1,0 +1,27 @@
+"""
+AxonFlow Governed Call - The Solution
+
+Same query, but now with real-time governance:
+policies, rate limits, and audit logs - all automatic.
+"""
+
+import asyncio
+import os
+
+from axonflow import AxonFlow
+
+async def main():
+    async with AxonFlow(
+        agent_url=os.getenv("AXONFLOW_AGENT_URL", "http://localhost:8080"),
+        client_id=os.getenv("AXONFLOW_CLIENT_ID", "demo-client"),
+        client_secret=os.getenv("AXONFLOW_CLIENT_SECRET", "demo-secret"),
+    ) as ax:
+        response = await ax.execute_query(
+            user_token="demo-user",
+            query="What's the weather in London?",
+            request_type="chat",
+        )
+        print(response.data)
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/platform/examples/demo/03_pii_demo.py
+++ b/platform/examples/demo/03_pii_demo.py
@@ -1,0 +1,38 @@
+"""
+PII Detection Demo - Hero Moment
+
+AxonFlow detects the SSN, blocks the request,
+and logs exactly what happened.
+"""
+
+import asyncio
+import os
+
+from axonflow import AxonFlow
+from axonflow.exceptions import PolicyViolationError
+
+async def main():
+    async with AxonFlow(
+        agent_url=os.getenv("AXONFLOW_AGENT_URL", "http://localhost:8080"),
+        client_id=os.getenv("AXONFLOW_CLIENT_ID", "demo-client"),
+        client_secret=os.getenv("AXONFLOW_CLIENT_SECRET", "demo-secret"),
+    ) as ax:
+        try:
+            response = await ax.execute_query(
+                user_token="demo-user",
+                query="My SSN is 123-45-6789. Can you check my taxes?",
+                request_type="chat",
+            )
+            print(response.data)
+        except PolicyViolationError as e:
+            print(f"PolicyViolationError: {e.message}")
+            print(f"Policy: {e.policy}")
+            print(f"Reason: {e.block_reason}")
+
+if __name__ == "__main__":
+    asyncio.run(main())
+
+# Expected output:
+# PolicyViolationError: Request blocked (SSN detected)
+# Policy: pii-ssn
+# Reason: SSN pattern detected in request

--- a/platform/examples/demo/04_gateway_mode.py
+++ b/platform/examples/demo/04_gateway_mode.py
@@ -1,0 +1,57 @@
+"""
+Gateway Mode - Keep Your Existing LLM Calls
+
+Already using LangChain or CrewAI? Keep your existing LLM calls.
+AxonFlow adds governance around them. No rewrite required.
+"""
+
+import asyncio
+import os
+import time
+
+import openai
+from axonflow import AxonFlow
+from axonflow.types import TokenUsage
+
+async def main():
+    async with AxonFlow(
+        agent_url=os.getenv("AXONFLOW_AGENT_URL", "http://localhost:8080"),
+        client_id=os.getenv("AXONFLOW_CLIENT_ID", "demo-client"),
+        client_secret=os.getenv("AXONFLOW_CLIENT_SECRET", "demo-secret"),
+    ) as ax:
+        # Step 1: Pre-check (policy evaluation)
+        ctx = await ax.get_policy_approved_context(
+            user_token="demo-user",
+            query="What's the weather in London?",
+        )
+
+        if not ctx.approved:
+            print(f"Blocked: {ctx.block_reason}")
+            return
+
+        # Step 2: Your existing LLM call (your API key, your control)
+        start = time.time()
+        response = openai.chat.completions.create(
+            model="gpt-4",
+            messages=[{"role": "user", "content": "What's the weather in London?"}]
+        )
+        latency_ms = int((time.time() - start) * 1000)
+
+        # Step 3: Audit the call
+        await ax.audit_llm_call(
+            context_id=ctx.context_id,
+            response_summary=response.choices[0].message.content[:100],
+            provider="openai",
+            model="gpt-4",
+            token_usage=TokenUsage(
+                prompt_tokens=response.usage.prompt_tokens,
+                completion_tokens=response.usage.completion_tokens,
+                total_tokens=response.usage.total_tokens,
+            ),
+            latency_ms=latency_ms,
+        )
+
+        print(response.choices[0].message.content)
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/platform/examples/demo/05_map.yaml
+++ b/platform/examples/demo/05_map.yaml
@@ -1,0 +1,10 @@
+# Multi-Agent Planning - Define agents in YAML
+# AxonFlow turns this into an executable workflow
+
+agents:
+  - name: flight_search
+    type: connector-call
+    connector: amadeus
+  - name: itinerary_builder
+    type: llm-call
+    prompt_template: "Build a 3-day itinerary for {{.destination}}"

--- a/platform/examples/demo/06_map_call.py
+++ b/platform/examples/demo/06_map_call.py
@@ -1,0 +1,36 @@
+"""
+Multi-Agent Planning (MAP) Demo
+
+A single natural-language request becomes an executable workflow
+with governance applied at every step.
+"""
+
+import asyncio
+import os
+
+from axonflow import AxonFlow
+
+async def main():
+    async with AxonFlow(
+        agent_url=os.getenv("AXONFLOW_AGENT_URL", "http://localhost:8080"),
+        client_id=os.getenv("AXONFLOW_CLIENT_ID", "demo-client"),
+        client_secret=os.getenv("AXONFLOW_CLIENT_SECRET", "demo-secret"),
+    ) as ax:
+        # Generate a plan from natural language
+        plan = await ax.generate_plan(
+            query="Book a flight to London and build an itinerary",
+            domain="travel",
+        )
+
+        print(f"Plan ID: {plan.plan_id}")
+        print(f"Steps: {len(plan.steps)}")
+        for step in plan.steps:
+            print(f"  - {step.name}: {step.type}")
+
+        # Execute the plan
+        result = await ax.execute_plan(plan.plan_id)
+        print(f"\nStatus: {result.status}")
+        print(f"Result: {result.result}")
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/platform/examples/demo/README.md
+++ b/platform/examples/demo/README.md
@@ -6,6 +6,7 @@ A quick interactive demo that showcases AxonFlow's governance capabilities in ac
 
 - AxonFlow platform running via `docker-compose up -d`
 - Services healthy (check with `docker-compose ps`)
+- Python SDK installed (for Python examples): `pip install axonflow`
 
 ## Quick Start
 
@@ -42,6 +43,44 @@ Demo 3: Credit Card Detection
 
 Demo 4: Sub-10ms Policy Evaluation
 ⚡ Average latency: 4ms
+```
+
+## Python SDK Examples
+
+These Python files are **runnable** demos of AxonFlow integration patterns:
+
+| File | Description | Runnable |
+|------|-------------|----------|
+| `01_unprotected_call.py` | Typical unprotected LLM call (the problem) | Yes (needs OpenAI key) |
+| `02_governed_call.py` | Same call with AxonFlow governance | Yes |
+| `03_pii_demo.py` | PII detection blocking SSN in prompts | Yes |
+| `04_gateway_mode.py` | Gateway mode for existing LLM integrations | Yes (needs OpenAI key) |
+| `05_map.yaml` | Multi-Agent Planning workflow definition | Config file |
+| `06_map_call.py` | Executing a MAP workflow | Yes |
+
+### Running the Python Demos
+
+```bash
+# 1. Install dependencies
+pip install axonflow openai
+
+# 2. Set environment variables
+export AXONFLOW_AGENT_URL=http://localhost:8080
+export AXONFLOW_CLIENT_ID=demo-client
+export AXONFLOW_CLIENT_SECRET=demo-secret
+export OPENAI_API_KEY=sk-your-key  # for 01 and 04
+
+# 3. Run any example
+python 02_governed_call.py
+python 03_pii_demo.py  # See PII blocking in action!
+```
+
+### Expected Output (03_pii_demo.py)
+
+```
+PolicyViolationError: Request blocked (SSN detected)
+Policy: pii-ssn
+Reason: SSN pattern detected in request
 ```
 
 ## Next Steps

--- a/platform/examples/support-demo/backend/llm_router.go
+++ b/platform/examples/support-demo/backend/llm_router.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/examples/support-demo/backend/llm_router_test.go
+++ b/platform/examples/support-demo/backend/llm_router_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/examples/support-demo/backend/main.go
+++ b/platform/examples/support-demo/backend/main.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/examples/support-demo/backend/policy_defaults.go
+++ b/platform/examples/support-demo/backend/policy_defaults.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/examples/support-demo/backend/policy_engine.go
+++ b/platform/examples/support-demo/backend/policy_engine.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/examples/support-demo/backend/policy_engine_test.go
+++ b/platform/examples/support-demo/backend/policy_engine_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/agent_config.go
+++ b/platform/orchestrator/agent_config.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/agent_config_test.go
+++ b/platform/orchestrator/agent_config_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/agent_registry.go
+++ b/platform/orchestrator/agent_registry.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/agent_registry_db.go
+++ b/platform/orchestrator/agent_registry_db.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/agent_registry_db_test.go
+++ b/platform/orchestrator/agent_registry_db_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/agent_registry_test.go
+++ b/platform/orchestrator/agent_registry_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/agents_api_handler.go
+++ b/platform/orchestrator/agents_api_handler.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/agents_api_handler_test.go
+++ b/platform/orchestrator/agents_api_handler_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/agents_api_types.go
+++ b/platform/orchestrator/agents_api_types.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/amadeus_client.go
+++ b/platform/orchestrator/amadeus_client.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/amadeus_client_test.go
+++ b/platform/orchestrator/amadeus_client_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/amadeus_connector.go
+++ b/platform/orchestrator/amadeus_connector.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/amadeus_connector_test.go
+++ b/platform/orchestrator/amadeus_connector_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/amadeus_integration_test.go
+++ b/platform/orchestrator/amadeus_integration_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/api_call_processor.go
+++ b/platform/orchestrator/api_call_processor.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/api_call_processor_test.go
+++ b/platform/orchestrator/api_call_processor_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/audit_logger.go
+++ b/platform/orchestrator/audit_logger.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/audit_logger_test.go
+++ b/platform/orchestrator/audit_logger_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/connector_marketplace_handlers.go
+++ b/platform/orchestrator/connector_marketplace_handlers.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/connector_marketplace_handlers_integration_test.go
+++ b/platform/orchestrator/connector_marketplace_handlers_integration_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/connector_marketplace_handlers_test.go
+++ b/platform/orchestrator/connector_marketplace_handlers_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/db_dynamic_policies.go
+++ b/platform/orchestrator/db_dynamic_policies.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/db_dynamic_policies_test.go
+++ b/platform/orchestrator/db_dynamic_policies_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/db_policy_engine_integration_test.go
+++ b/platform/orchestrator/db_policy_engine_integration_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/doc.go
+++ b/platform/orchestrator/doc.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/dynamic_policy_engine.go
+++ b/platform/orchestrator/dynamic_policy_engine.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/dynamic_policy_engine_test.go
+++ b/platform/orchestrator/dynamic_policy_engine_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/integration_test.go
+++ b/platform/orchestrator/integration_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/llm/adapter.go
+++ b/platform/orchestrator/llm/adapter.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/llm/adapter_test.go
+++ b/platform/orchestrator/llm/adapter_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/llm/anthropic/adapter.go
+++ b/platform/orchestrator/llm/anthropic/adapter.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/llm/anthropic/adapter_test.go
+++ b/platform/orchestrator/llm/anthropic/adapter_test.go
@@ -1,5 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0
+// SPDX-License-Identifier: BUSL-1.1
 
 package anthropic
 

--- a/platform/orchestrator/llm/anthropic/provider.go
+++ b/platform/orchestrator/llm/anthropic/provider.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/llm/anthropic/provider_test.go
+++ b/platform/orchestrator/llm/anthropic/provider_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/llm/bootstrap.go
+++ b/platform/orchestrator/llm/bootstrap.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/llm/bootstrap_test.go
+++ b/platform/orchestrator/llm/bootstrap_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/llm/doc.go
+++ b/platform/orchestrator/llm/doc.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/llm/factories.go
+++ b/platform/orchestrator/llm/factories.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/llm/factories_test.go
+++ b/platform/orchestrator/llm/factories_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/llm/factory.go
+++ b/platform/orchestrator/llm/factory.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/llm/factory_test.go
+++ b/platform/orchestrator/llm/factory_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/llm/license_gating.go
+++ b/platform/orchestrator/llm/license_gating.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/llm/license_gating_test.go
+++ b/platform/orchestrator/llm/license_gating_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/llm/provider.go
+++ b/platform/orchestrator/llm/provider.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/llm/provider_test.go
+++ b/platform/orchestrator/llm/provider_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/llm/registry.go
+++ b/platform/orchestrator/llm/registry.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/llm/registry_test.go
+++ b/platform/orchestrator/llm/registry_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/llm/router.go
+++ b/platform/orchestrator/llm/router.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/llm/router_test.go
+++ b/platform/orchestrator/llm/router_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/llm/sdk/auth.go
+++ b/platform/orchestrator/llm/sdk/auth.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/llm/sdk/doc.go
+++ b/platform/orchestrator/llm/sdk/doc.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/llm/sdk/rate_limit.go
+++ b/platform/orchestrator/llm/sdk/rate_limit.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/llm/sdk/retry.go
+++ b/platform/orchestrator/llm/sdk/retry.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/llm/sdk/sdk.go
+++ b/platform/orchestrator/llm/sdk/sdk.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/llm/sdk/sdk_test.go
+++ b/platform/orchestrator/llm/sdk/sdk_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/llm/storage.go
+++ b/platform/orchestrator/llm/storage.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/llm/storage_integration_test.go
+++ b/platform/orchestrator/llm/storage_integration_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/llm/storage_test.go
+++ b/platform/orchestrator/llm/storage_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/llm/types.go
+++ b/platform/orchestrator/llm/types.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/llm/types_test.go
+++ b/platform/orchestrator/llm/types_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/llm_provider_api_handlers.go
+++ b/platform/orchestrator/llm_provider_api_handlers.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/llm_provider_api_handlers_test.go
+++ b/platform/orchestrator/llm_provider_api_handlers_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/llm_provider_api_types.go
+++ b/platform/orchestrator/llm_provider_api_types.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/llm_providers_test.go
+++ b/platform/orchestrator/llm_providers_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/llm_router.go
+++ b/platform/orchestrator/llm_router.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/llm_router_test.go
+++ b/platform/orchestrator/llm_router_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/mcp_connector_processor.go
+++ b/platform/orchestrator/mcp_connector_processor.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/mcp_connector_processor_additional_test.go
+++ b/platform/orchestrator/mcp_connector_processor_additional_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/mcp_connector_processor_test.go
+++ b/platform/orchestrator/mcp_connector_processor_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/mcp_query_router.go
+++ b/platform/orchestrator/mcp_query_router.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/mcp_query_router_test.go
+++ b/platform/orchestrator/mcp_query_router_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/metrics_collector.go
+++ b/platform/orchestrator/metrics_collector.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/phase7_test.go
+++ b/platform/orchestrator/phase7_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/pii_detector.go
+++ b/platform/orchestrator/pii_detector.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/pii_detector_bench_test.go
+++ b/platform/orchestrator/pii_detector_bench_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/pii_detector_test.go
+++ b/platform/orchestrator/pii_detector_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/planning_engine.go
+++ b/platform/orchestrator/planning_engine.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/planning_engine_test.go
+++ b/platform/orchestrator/planning_engine_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/policy_api_handlers.go
+++ b/platform/orchestrator/policy_api_handlers.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/policy_api_handlers_test.go
+++ b/platform/orchestrator/policy_api_handlers_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/policy_api_repository.go
+++ b/platform/orchestrator/policy_api_repository.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/policy_api_repository_integration_test.go
+++ b/platform/orchestrator/policy_api_repository_integration_test.go
@@ -1,5 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0
+// SPDX-License-Identifier: BUSL-1.1
 
 package orchestrator
 

--- a/platform/orchestrator/policy_api_service.go
+++ b/platform/orchestrator/policy_api_service.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/policy_api_service_integration_test.go
+++ b/platform/orchestrator/policy_api_service_integration_test.go
@@ -1,5 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0
+// SPDX-License-Identifier: BUSL-1.1
 
 package orchestrator
 

--- a/platform/orchestrator/policy_api_types.go
+++ b/platform/orchestrator/policy_api_types.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/policy_defaults.go
+++ b/platform/orchestrator/policy_defaults.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/response_processor.go
+++ b/platform/orchestrator/response_processor.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/response_processor_test.go
+++ b/platform/orchestrator/response_processor_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/result_aggregator.go
+++ b/platform/orchestrator/result_aggregator.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/result_aggregator_additional_test.go
+++ b/platform/orchestrator/result_aggregator_additional_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/rls.go
+++ b/platform/orchestrator/rls.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/rls_test.go
+++ b/platform/orchestrator/rls_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/run.go
+++ b/platform/orchestrator/run.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/runtime_config_integration.go
+++ b/platform/orchestrator/runtime_config_integration.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/runtime_config_integration_test.go
+++ b/platform/orchestrator/runtime_config_integration_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/template_api_handlers.go
+++ b/platform/orchestrator/template_api_handlers.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/template_api_handlers_test.go
+++ b/platform/orchestrator/template_api_handlers_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/template_api_repository.go
+++ b/platform/orchestrator/template_api_repository.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/template_api_service.go
+++ b/platform/orchestrator/template_api_service.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/template_api_service_test.go
+++ b/platform/orchestrator/template_api_service_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/template_api_types.go
+++ b/platform/orchestrator/template_api_types.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/workflow_engine.go
+++ b/platform/orchestrator/workflow_engine.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/workflow_engine_additional_test.go
+++ b/platform/orchestrator/workflow_engine_additional_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/orchestrator/workflow_engine_test.go
+++ b/platform/orchestrator/workflow_engine_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/shared/logger/doc.go
+++ b/platform/shared/logger/doc.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/shared/logger/logger.go
+++ b/platform/shared/logger/logger.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/shared/logger/logger_test.go
+++ b/platform/shared/logger/logger_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/shared/types/deployment.go
+++ b/platform/shared/types/deployment.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/shared/types/deployment_test.go
+++ b/platform/shared/types/deployment_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/shared/types/doc.go
+++ b/platform/shared/types/doc.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //

--- a/platform/test/integration/usage_recording_test.go
+++ b/platform/test/integration/usage_recording_test.go
@@ -1,7 +1,5 @@
 // Copyright 2025 AxonFlow
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// SPDX-License-Identifier: BUSL-1.1
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //


### PR DESCRIPTION
## Summary

- **BSL 1.1 License Headers**: SPDX identifiers added to all Go files
- **Connector Stubs**: Added HubSpot, Jira, ServiceNow stubs for Community edition
- **Community Stubs**: Circuit breaker and HITL community implementations
- **Python Demo Files**: SDK demo examples for video tutorials

## Source PRs
- #608: Wire missing enterprise features and connector stubs
- #609: Python SDK demo files
- #611: BSL 1.1 license headers (258 files)