### PR TITLE
fix: update PII demo expected output with correct policy name

### DIFF
--- a/platform/examples/demo/03_pii_demo.py
+++ b/platform/examples/demo/03_pii_demo.py
@@ -25,14 +25,14 @@ async def main():
             )
             print(response.data)
         except PolicyViolationError as e:
-            print(f"PolicyViolationError: {e.message}")
-            print(f"Policy: {e.policy}")
-            print(f"Reason: {e.block_reason}")
+            print(f"🛡️  REQUEST BLOCKED")
+            print(f"   Reason: {e.block_reason}")
+            print(f"   Policy: {e.policy}")
 
 if __name__ == "__main__":
     asyncio.run(main())
 
 # Expected output:
-# PolicyViolationError: Request blocked by policy
-# Policy: None
-# Reason: US Social Security Number pattern detected
+# 🛡️  REQUEST BLOCKED
+#    Reason: US Social Security Number pattern detected
+#    Policy: pii_ssn_detection


### PR DESCRIPTION
## Summary
- Updated `03_pii_demo.py` expected output to show `pii_ssn_detection` policy name instead of `None`
- Improved print format with emoji and clearer structure

This change reflects the Python SDK fix (PR #4) which now properly extracts policy names from `policy_info.policies_evaluated`.

## Test plan
- [x] Run demo 03 against community stack - verified output matches expected