### PR TITLE
fix: replace weather query with relevant AI governance example

### DIFF
--- a/examples/demo/01_unprotected_call.py
+++ b/examples/demo/01_unprotected_call.py
@@ -8,7 +8,7 @@ No checks, no rate limits, no audit trail.
 import openai
 
 # Direct call to LLM - no governance
-user_input = "What's the weather in London?"
+user_input = "Explain AI governance in one sentence"
 
 response = openai.chat.completions.create(
     model="gpt-4",

--- a/examples/demo/02_governed_call.py
+++ b/examples/demo/02_governed_call.py
@@ -18,7 +18,7 @@ async def main():
     ) as ax:
         response = await ax.execute_query(
             user_token="demo-user",
-            query="What's the weather in London?",
+            query="Explain AI governance in one sentence",
             request_type="chat",
         )
         print(response.data)

--- a/examples/demo/04_gateway_mode.py
+++ b/examples/demo/04_gateway_mode.py
@@ -22,7 +22,7 @@ async def main():
         # Step 1: Pre-check (policy evaluation)
         ctx = await ax.get_policy_approved_context(
             user_token="demo-user",
-            query="What's the weather in London?",
+            query="Explain AI governance in one sentence",
         )
 
         if not ctx.approved:
@@ -33,7 +33,7 @@ async def main():
         start = time.time()
         response = openai.chat.completions.create(
             model="gpt-4",
-            messages=[{"role": "user", "content": "What's the weather in London?"}]
+            messages=[{"role": "user", "content": "Explain AI governance in one sentence"}]
         )
         latency_ms = int((time.time() - start) * 1000)
 


### PR DESCRIPTION
Weather query returned unhelpful 'I can't provide real-time info' response.

New query 'Explain AI governance in one sentence' is relevant to AxonFlow and produces a useful demo output.

**Files changed:**
- examples/demo/01_unprotected_call.py
- examples/demo/02_governed_call.py
- examples/demo/04_gateway_mode.py