### PR TITLE
docs: add v1.0.1 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,18 @@ This is the first public release of AxonFlow, a self-hosted governance and orche
 
 ---
 
+## [1.0.1] - 2025-12-16
+
+### Added
+
+- **Internal Service Authentication**: Shared secret authentication for secure agent↔orchestrator communication via `AXONFLOW_INTERNAL_SERVICE_SECRET`
+
+### Changed
+
+- **PII Detection**: Made critical PII blocking configurable per-policy (Aadhaar, PAN patterns)
+
+---
+
 ## Pre-release Development History
 
 The following versions were internal development milestones leading up to v1.0.0.


### PR DESCRIPTION
## Summary

Adds changelog entry for v1.0.1 documenting post-launch improvements:

- **Internal Service Authentication**: Shared secret authentication for secure agent↔orchestrator communication
- **PII Detection**: Configurable critical PII blocking per-policy

## Changes

- Added `## [1.0.1] - 2025-12-16` section to CHANGELOG.md