### PR TITLE
fix: remove internal repo reference from lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,7 +33,6 @@ permissions:
 
 # Consolidated lint job to reduce CI costs
 # Reduced from 6 parallel matrix jobs to 1 sequential job (~80% reduction in billable minutes)
-# See: https://github.com/getaxonflow/axonflow-enterprise/issues/305
 
 jobs:
   # =============================================================================


### PR DESCRIPTION
## Summary
- Removes reference to private `axonflow-enterprise` repo from workflow comment

This internal issue reference should not be in the public repo.

## Test plan
- [x] No functional changes, comment only