### PR TITLE
fix(examples): add missing package.json for TypeScript hello-world

### DIFF
--- a/examples/hello-world/typescript/.env.example
+++ b/examples/hello-world/typescript/.env.example
@@ -1,0 +1,11 @@
+# AxonFlow Configuration
+# Copy this file to .env and update with your credentials
+
+# Agent Endpoint (from CloudFormation Outputs)
+AXONFLOW_ENDPOINT=https://your-agent-endpoint
+
+# License Key (from CloudFormation Outputs)
+AXONFLOW_LICENSE_KEY=AXON-V2-your-key-here
+
+# Organization ID
+AXONFLOW_ORG_ID=my-org

--- a/examples/hello-world/typescript/package.json
+++ b/examples/hello-world/typescript/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "axonflow-hello-world",
+  "version": "1.0.0",
+  "description": "Hello World example for AxonFlow",
+  "main": "index.ts",
+  "scripts": {
+    "start": "ts-node index.ts",
+    "build": "tsc",
+    "dev": "ts-node-dev index.ts"
+  },
+  "keywords": ["axonflow", "example", "hello-world"],
+  "author": "AxonFlow",
+  "license": "MIT",
+  "dependencies": {
+    "@axonflow/sdk": "^1.3.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "ts-node": "^10.9.0",
+    "ts-node-dev": "^2.0.0",
+    "typescript": "^5.0.0"
+  }
+}


### PR DESCRIPTION
## Summary

The TypeScript hello-world example was missing essential files needed to run the example:
- `package.json` - Node.js package configuration with @axonflow/sdk dependency
- `.env.example` - Configuration template

Without these files, running `npm install && npm start` as documented in the README would fail.

## Test Plan
- [x] Verified files exist in enterprise repo
- [x] Copied to community repo
- [x] Files match expected structure

## Related
- Found during comprehensive testing of community repo after v1.0.1 release