### PR TITLE
feat: Gemini LLM Provider + Community Terminology Update

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -18,18 +18,20 @@ jobs:
           echo "Checking PR title: $PR_TITLE"
 
           # Check if PR title follows Conventional Commits format
-          if ! echo "$PR_TITLE" | grep -qE '^(feat|fix|docs|style|refactor|test|chore|perf)(\(.+\))?: .{1,72}$'; then
+          if ! echo "$PR_TITLE" | grep -qE '^(feat|fix|build|chore|ci|docs|perf|refactor|style|test)(\(.+\))?: .{1,72}$'; then
             echo ""
             echo "❌ Invalid PR title: $PR_TITLE"
             echo ""
             echo "PR titles must follow Conventional Commits format:"
             echo "  Format: <type>(<scope>): <subject>"
-            echo "  Types: feat, fix, docs, style, refactor, test, chore, perf"
+            echo "  Types: feat, fix, build, chore, ci, docs, perf, refactor, style, test"
             echo "  Max length: 72 characters"
             echo ""
             echo "Examples:"
-            echo "  ✅ fix: resolve authentication bug"
             echo "  ✅ feat(api): add user endpoint"
+            echo "  ✅ fix: resolve authentication bug"
+            echo "  ✅ build: update Go version to 1.23"
+            echo "  ✅ ci: add code coverage reporting"
             echo "  ✅ refactor(agent): improve error handling"
             echo ""
             echo "Why: PR title becomes the commit message when using 'Squash and merge'"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -89,35 +89,71 @@ jobs:
         run: |
           curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.0.2
 
-      - name: Lint Agent
+      - name: Lint All Modules (Parallel)
+        shell: bash
         run: |
-          echo "🔍 Linting platform/agent..."
-          cd platform/agent
-          golangci-lint run --timeout=5m --config=${{ github.workspace }}/.golangci.yml
+          set -euo pipefail
+          echo "🔍 Linting all modules in parallel..."
+          GOLANGCI_CONFIG="${{ github.workspace }}/.golangci.yml"
 
-      - name: Lint Orchestrator
-        run: |
-          echo "🔍 Linting platform/orchestrator..."
-          cd platform/orchestrator
-          golangci-lint run --timeout=5m --config=${{ github.workspace }}/.golangci.yml
+          # Create temp directory for status and output tracking
+          WORKDIR=$(mktemp -d)
+          trap "rm -rf $WORKDIR" EXIT
 
-      - name: Lint Connectors
-        run: |
-          echo "🔍 Linting platform/connectors..."
-          cd platform/connectors
-          golangci-lint run --timeout=5m --config=${{ github.workspace }}/.golangci.yml
+          # Define modules to lint with their paths
+          declare -A MODULES=(
+            ["agent"]="platform/agent"
+            ["orchestrator"]="platform/orchestrator"
+            ["connectors"]="platform/connectors"
+            ["shared"]="platform/shared"
+            ["sdk"]="sdk/golang"
+          )
 
-      - name: Lint Shared
-        run: |
-          echo "🔍 Linting platform/shared..."
-          cd platform/shared
-          golangci-lint run --timeout=5m --config=${{ github.workspace }}/.golangci.yml
+          # Run all lint jobs in parallel, capturing output
+          for name in "${!MODULES[@]}"; do
+            path="${MODULES[$name]}"
+            (
+              if [ ! -d "$path" ]; then
+                echo "ERROR: Directory $path does not exist" > "$WORKDIR/${name}.out"
+                echo "1" > "$WORKDIR/${name}.status"
+              else
+                cd "$path"
+                if golangci-lint run --timeout=5m --config="$GOLANGCI_CONFIG" > "$WORKDIR/${name}.out" 2>&1; then
+                  echo "0" > "$WORKDIR/${name}.status"
+                else
+                  echo "1" > "$WORKDIR/${name}.status"
+                fi
+              fi
+            ) &
+          done
 
-      - name: Lint Go SDK
-        run: |
-          echo "🔍 Linting sdk/golang..."
-          cd sdk/golang
-          golangci-lint run --timeout=5m --config=${{ github.workspace }}/.golangci.yml
+          # Wait for all to complete
+          wait
+
+          # Check results and display output for failures
+          FAILED=0
+          for name in "${!MODULES[@]}"; do
+            if [ "$(cat "$WORKDIR/${name}.status" 2>/dev/null || echo "1")" = "1" ]; then
+              echo ""
+              echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+              echo "❌ $name lint FAILED (${MODULES[$name]})"
+              echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+              cat "$WORKDIR/${name}.out" 2>/dev/null || echo "(no output captured)"
+              echo ""
+              FAILED=1
+            else
+              echo "✅ $name lint passed"
+            fi
+          done
+
+          if [ "$FAILED" = "1" ]; then
+            echo ""
+            echo "❌ One or more modules failed linting. See details above."
+            exit 1
+          fi
+
+          echo ""
+          echo "✅ All modules passed linting!"
 
   lint-summary:
     name: Lint Summary

--- a/.github/workflows/sdk-smoke-tests.yml
+++ b/.github/workflows/sdk-smoke-tests.yml
@@ -1,0 +1,280 @@
+name: SDK Smoke Tests
+
+# Validates that SDK examples and README curl commands work against the stack.
+# Catches broken documentation before merge.
+#
+# Runtime: ~4-5 minutes
+# Trigger: Changes to agent, orchestrator, demo examples, docker-compose, or enterprise code
+
+on:
+  pull_request:
+    branches:
+      - main
+      - develop
+  merge_group:
+    branches:
+      - main
+      - develop
+  push:
+    branches:
+      - main
+      - develop
+    paths:
+      - 'platform/agent/**'
+      - 'platform/orchestrator/**'
+      - 'platform/connectors/**'
+      - 'ee/platform/agent/**'
+      - 'ee/platform/orchestrator/**'
+      - 'ee/platform/connectors/**'
+      - 'examples/demo/**'
+      - 'docker-compose.yml'
+      - 'migrations/**'
+      - '.github/workflows/sdk-smoke-tests.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+env:
+  # Timeouts and retry configuration
+  HEALTH_CHECK_RETRIES: 30
+  HEALTH_CHECK_INTERVAL: 2
+  DOCKER_WAIT_TIMEOUT: 180
+
+jobs:
+  # =============================================================================
+  # Change Detection (PR and merge_group only)
+  # =============================================================================
+  detect-changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      sdk-relevant: ${{ steps.filter.outputs.sdk-relevant }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Detect SDK-relevant changes
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            sdk-relevant:
+              - 'platform/agent/**'
+              - 'platform/orchestrator/**'
+              - 'platform/connectors/**'
+              - 'ee/platform/agent/**'
+              - 'ee/platform/orchestrator/**'
+              - 'ee/platform/connectors/**'
+              - 'examples/demo/**'
+              - 'docker-compose.yml'
+              - 'migrations/**'
+              - '.github/workflows/sdk-smoke-tests.yml'
+
+  smoke-tests:
+    name: SDK Smoke Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: [detect-changes]
+    # Run if: push/workflow_dispatch OR (PR/merge_group with SDK-relevant changes)
+    if: |
+      always() &&
+      (github.event_name == 'push' ||
+       github.event_name == 'workflow_dispatch' ||
+       (needs.detect-changes.result == 'success' && needs.detect-changes.outputs.sdk-relevant == 'true'))
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          pip install requests
+          # jq is pre-installed on GitHub runners, but verify
+          jq --version
+
+      - name: Start AxonFlow stack
+        id: start-stack
+        run: |
+          echo "🚀 Starting AxonFlow stack..."
+          docker compose up -d --wait --wait-timeout ${{ env.DOCKER_WAIT_TIMEOUT }} || {
+            echo "❌ Docker compose failed to start"
+            echo "📋 Docker compose logs:"
+            docker compose logs
+            exit 1
+          }
+          echo "✅ Docker compose started"
+
+      - name: Wait for services to be healthy
+        shell: bash
+        run: |
+          echo "⏳ Waiting for services to be healthy..."
+
+          # Function to check health with retries
+          wait_for_health() {
+            local url=$1
+            local name=$2
+            local retries=${{ env.HEALTH_CHECK_RETRIES }}
+            local interval=${{ env.HEALTH_CHECK_INTERVAL }}
+
+            for i in $(seq 1 $retries); do
+              if curl -sf "$url" > /dev/null 2>&1; then
+                echo "✅ $name is healthy"
+                return 0
+              fi
+              echo "⏳ Waiting for $name... (attempt $i/$retries)"
+              sleep $interval
+            done
+
+            echo "❌ $name failed to become healthy after $retries attempts"
+            return 1
+          }
+
+          # Check both services
+          wait_for_health "http://localhost:8080/health" "Agent" || exit 1
+          wait_for_health "http://localhost:8081/health" "Orchestrator" || exit 1
+
+          echo ""
+          echo "✅ All services are healthy!"
+
+      - name: Test PII Detection (SSN - Monitoring Mode)
+        shell: bash
+        run: |
+          echo "🧪 Testing PII detection (SSN - monitoring mode)..."
+          response=$(curl -s -X POST http://localhost:8080/api/policy/pre-check \
+            -H "Content-Type: application/json" \
+            -d '{"user_token": "test-user", "client_id": "smoke-test", "query": "Look up customer with SSN 123-45-6789"}')
+
+          echo "Response: $response"
+
+          # SSN detection is in monitoring mode (approved=true but detected)
+          # Verify the policy was triggered even though request is approved
+          if echo "$response" | jq -e '.policies | length > 0' > /dev/null 2>&1; then
+            policy=$(echo "$response" | jq -r '.policies[0]')
+            echo "✅ SSN detected by policy: $policy"
+          else
+            echo "❌ SSN not detected - no policies triggered"
+            exit 1
+          fi
+
+      - name: Test PII Detection (Credit Card)
+        shell: bash
+        run: |
+          echo "🧪 Testing PII detection (Credit Card)..."
+          response=$(curl -s -X POST http://localhost:8080/api/policy/pre-check \
+            -H "Content-Type: application/json" \
+            -d '{"user_token": "test-user", "client_id": "smoke-test", "query": "Process payment for card 4111-1111-1111-1111"}')
+
+          echo "Response: $response"
+
+          if echo "$response" | jq -e '.approved == false or .policyApproved == false or .blocked == true' > /dev/null 2>&1; then
+            echo "✅ Credit card correctly blocked"
+          else
+            echo "❌ Credit card not blocked"
+            echo "Expected: approved=false or blocked=true"
+            exit 1
+          fi
+
+      - name: Test SQL Injection Blocking
+        shell: bash
+        run: |
+          echo "🧪 Testing SQL injection blocking..."
+          response=$(curl -s -X POST http://localhost:8080/api/policy/pre-check \
+            -H "Content-Type: application/json" \
+            -d '{"user_token": "test-user", "client_id": "smoke-test", "query": "SELECT * FROM users UNION SELECT * FROM passwords"}')
+
+          echo "Response: $response"
+
+          if echo "$response" | jq -e '.approved == false or .policyApproved == false or .blocked == true' > /dev/null 2>&1; then
+            echo "✅ SQL injection correctly blocked"
+          else
+            echo "❌ SQL injection not blocked"
+            echo "Expected: approved=false or blocked=true"
+            exit 1
+          fi
+
+      - name: Test Safe Query (Baseline)
+        shell: bash
+        run: |
+          echo "🧪 Testing safe query passes..."
+          response=$(curl -s -X POST http://localhost:8080/api/policy/pre-check \
+            -H "Content-Type: application/json" \
+            -d '{"user_token": "test-user", "client_id": "smoke-test", "query": "What is the weather today?"}')
+
+          echo "Response: $response"
+
+          # Safe query should be approved
+          if echo "$response" | jq -e '.approved == true or .policyApproved == true or .blocked == false' > /dev/null 2>&1; then
+            echo "✅ Safe query correctly approved"
+          else
+            echo "❌ Safe query incorrectly blocked"
+            echo "Expected: approved=true or blocked=false"
+            exit 1
+          fi
+
+      - name: Collect logs on failure
+        if: failure()
+        run: |
+          echo "📋 Collecting diagnostic logs..."
+          echo ""
+          echo "=== Docker Compose Status ==="
+          docker compose ps
+          echo ""
+          echo "=== Agent Logs (last 100 lines) ==="
+          docker compose logs --tail=100 agent 2>/dev/null || echo "(no agent logs)"
+          echo ""
+          echo "=== Orchestrator Logs (last 100 lines) ==="
+          docker compose logs --tail=100 orchestrator 2>/dev/null || echo "(no orchestrator logs)"
+          echo ""
+          echo "=== PostgreSQL Logs (last 50 lines) ==="
+          docker compose logs --tail=50 postgres 2>/dev/null || echo "(no postgres logs)"
+
+      - name: Cleanup
+        if: always()
+        run: |
+          docker compose down -v --remove-orphans 2>/dev/null || true
+
+  smoke-test-summary:
+    name: Smoke Test Summary
+    runs-on: ubuntu-latest
+    needs: [detect-changes, smoke-tests]
+    if: always()
+
+    steps:
+      - name: Check results
+        run: |
+          echo "🧪 SDK Smoke Tests Complete"
+          echo ""
+          echo "Results:"
+          echo "  Detect Changes: ${{ needs.detect-changes.result }}"
+          echo "  Smoke Tests: ${{ needs.smoke-tests.result }}"
+
+      - name: Fail if tests failed
+        # Accept 'success' or 'skipped' (skipped = no SDK-relevant changes)
+        if: |
+          needs.detect-changes.result == 'failure' ||
+          (needs.smoke-tests.result != 'success' && needs.smoke-tests.result != 'skipped')
+        run: |
+          echo "❌ SDK smoke tests failed"
+          exit 1
+
+      - name: Success message
+        if: success()
+        run: |
+          echo "✅ SDK smoke tests passed!"
+          echo ""
+          echo "Validated:"
+          echo "  - PII Detection (SSN - monitoring mode)"
+          echo "  - PII Blocking (Credit Card)"
+          echo "  - SQL Injection Blocking"
+          echo "  - Safe Query Approval"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -282,7 +282,7 @@ The following versions were internal development milestones leading up to v1.0.0
 
 ### Added
 
-- **OSS Launch Preparation**: Docker Compose quickstart for local development
+- **Community Launch Preparation**: Docker Compose quickstart for local development
   - README overhaul with competitive positioning
   - Quick start guide (<5 minutes setup)
   - Self-hosted mode documentation
@@ -297,7 +297,7 @@ The following versions were internal development milestones leading up to v1.0.0
 
 ### Changed
 
-- **Roadmap**: Updated master roadmap with OSS launch status
+- **Roadmap**: Updated master roadmap with Community launch status
 - **Test Coverage**: Updated documentation with orchestrator integration tests (70.4%)
 
 ---

--- a/COMMUNITY_CONTENT_ANALYSIS.md
+++ b/COMMUNITY_CONTENT_ANALYSIS.md
@@ -1,0 +1,242 @@
+# Community Content Analysis - What Should Be Public vs Private
+
+## Executive Summary
+
+The current sync workflow only excludes `ee/` directory, but many other directories contain sensitive business information that should NOT be public.
+
+---
+
+## Classification Legend
+
+| Symbol | Meaning |
+|--------|---------|
+| ✅ | **INCLUDE in Community** - Public, open source |
+| ❌ | **EXCLUDE from Community** - Private, enterprise-only |
+| ⚠️ | **PARTIAL** - Some content OK, some should be excluded |
+
+---
+
+## Top-Level Directories
+
+| Directory | Decision | Reason |
+|-----------|----------|--------|
+| `ee/` | ❌ EXCLUDE | Enterprise code (already excluded) |
+| `platform/` | ⚠️ PARTIAL | Core code YES, demo-portal NO |
+| `migrations/core/` | ✅ INCLUDE | Community database schema |
+| `migrations/enterprise/` | ❌ EXCLUDE | Enterprise migrations (already excluded) |
+| `migrations/industry/` | ❌ EXCLUDE | Industry migrations (already excluded) |
+| `docs/` | ✅ INCLUDE | Public documentation |
+| `sdk/` | ✅ INCLUDE | Public SDKs |
+| `examples/` | ✅ INCLUDE | Public examples |
+| `tutorials/` | ✅ INCLUDE | Public tutorials |
+| `tests/` | ✅ INCLUDE | Public tests |
+| `.github/workflows/` | ⚠️ PARTIAL | Community workflows YES, deploy workflows NO |
+| `config/` | ❌ EXCLUDE | AWS accounts, environment configs |
+| `configs/` | ❌ EXCLUDE | Client-specific configs |
+| `scripts/` | ❌ EXCLUDE | Internal deployment scripts |
+| `technical-docs/` | ❌ EXCLUDE | Internal architecture docs |
+| `client-workflows/` | ❌ EXCLUDE | Client-specific workflows |
+| `demo-workflows/` | ❌ EXCLUDE | Internal demo workflows |
+| `grafana/` | ❌ EXCLUDE | Internal monitoring configs |
+| `docker/` | ⚠️ PARTIAL | docker-compose.yml YES, internal configs NO |
+| `nginx/` | ❌ EXCLUDE | Internal nginx configs |
+| `init-db/` | ❌ EXCLUDE | Internal database init |
+| `code-docs/` | ❌ EXCLUDE | Internal code documentation |
+| `archive/` | ❌ EXCLUDE | Internal archives |
+| `.claude/` | ❌ EXCLUDE | Claude Code configs |
+
+---
+
+## Platform Directory Breakdown
+
+| Path | Decision | Reason |
+|------|----------|--------|
+| `platform/agent/` | ✅ INCLUDE | Core agent (with Community stubs) |
+| `platform/orchestrator/` | ✅ INCLUDE | Core orchestrator |
+| `platform/connectors/` | ✅ INCLUDE | Connector framework + stubs |
+| `platform/shared/` | ✅ INCLUDE | Shared utilities |
+| `platform/cmd/` | ✅ INCLUDE | CLI tools |
+| `platform/common/` | ✅ INCLUDE | Common utilities |
+| `platform/database/` | ✅ INCLUDE | Database utilities |
+| `platform/test/` | ✅ INCLUDE | Test utilities |
+| `platform/demo-portal/` | ❌ EXCLUDE | Contains investor.html, advisor.html |
+| `platform/monitoring/` | ❌ EXCLUDE | Internal monitoring |
+| `platform/observability/` | ❌ EXCLUDE | Internal observability |
+| `platform/scripts/` | ❌ EXCLUDE | Internal scripts |
+| `platform/archive/` | ❌ EXCLUDE | Internal archives |
+| `platform/go.mod` | ✅ INCLUDE | Go module definition |
+| `platform/go.sum` | ✅ INCLUDE | Go dependencies |
+| `platform/*.md` | ✅ INCLUDE | Public documentation |
+| `platform/deploy-all-demos.sh` | ❌ EXCLUDE | Internal deployment |
+| `platform/brand-system.css` | ❌ EXCLUDE | Brand assets |
+
+---
+
+## GitHub Workflows
+
+| Workflow | Decision | Reason |
+|----------|----------|--------|
+| `sync-community-repo.yml` | ❌ EXCLUDE | Internal sync process |
+| `accept-community-pr.yml` | ❌ EXCLUDE | Internal contribution process |
+| `deploy-*.yml` | ❌ EXCLUDE | Internal deployment |
+| `build-*.yml` | ❌ EXCLUDE | Internal build |
+| `test.yml` | ✅ INCLUDE | Public CI testing |
+| `lint.yml` | ✅ INCLUDE | Public linting |
+| `release.yml` | ✅ INCLUDE | Public releases |
+
+---
+
+## Files to Exclude (Patterns)
+
+```
+# Enterprise code
+ee/
+
+# Internal configurations
+config/
+configs/
+client-workflows/
+demo-workflows/
+
+# Internal documentation
+technical-docs/
+code-docs/
+archive/
+
+# Internal scripts
+scripts/
+
+# Internal infrastructure
+grafana/
+nginx/
+init-db/
+docker/
+
+# Platform internals
+platform/demo-portal/
+platform/monitoring/
+platform/observability/
+platform/scripts/
+platform/archive/
+platform/deploy-all-demos.sh
+platform/brand-system.css
+
+# Migrations (keep only core)
+migrations/enterprise/
+migrations/industry/
+
+# Claude Code configs
+.claude/
+
+# Internal workflows
+.github/workflows/deploy-*.yml
+.github/workflows/build-*.yml
+.github/workflows/sync-community-repo.yml
+.github/workflows/accept-community-pr.yml
+.github/workflows/update-stack.yml
+.github/workflows/delete-stack.yml
+.github/workflows/setup-*.yml
+.github/workflows/manage-*.yml
+```
+
+---
+
+## What SHOULD Be in Community
+
+```
+# Core platform
+platform/agent/
+platform/orchestrator/
+platform/connectors/
+platform/shared/
+platform/cmd/
+platform/common/
+platform/database/
+platform/test/
+platform/go.mod
+platform/go.sum
+platform/ARCHITECTURE_SUMMARY.md
+platform/BACKEND_ARCHITECTURE_AND_TESTING_GUIDE.md
+platform/FILE_MANIFEST.md
+
+# SDKs
+sdk/
+
+# Public docs
+docs/
+
+# Examples and tutorials
+examples/
+tutorials/
+
+# Tests
+tests/
+
+# Core migrations only
+migrations/core/
+
+# Root files
+README.md
+LICENSE
+CONTRIBUTING.md
+SECURITY.md
+CODE_OF_CONDUCT.md
+Makefile
+docker-compose.yml (simplified version)
+.gitignore
+.golangci.yml
+
+# Community workflows only
+.github/workflows/test.yml
+.github/workflows/lint.yml
+.github/workflows/release.yml
+.github/ISSUE_TEMPLATE/
+.github/PULL_REQUEST_TEMPLATE.md
+```
+
+---
+
+## Recommended Sync Exclusions
+
+Add these to `sync-community-repo.yml`:
+
+```yaml
+rsync -av \
+  --exclude='ee/' \
+  --exclude='.git' \
+  --exclude='.claude/' \
+  --exclude='config/' \
+  --exclude='configs/' \
+  --exclude='scripts/' \
+  --exclude='technical-docs/' \
+  --exclude='client-workflows/' \
+  --exclude='demo-workflows/' \
+  --exclude='grafana/' \
+  --exclude='nginx/' \
+  --exclude='init-db/' \
+  --exclude='docker/' \
+  --exclude='code-docs/' \
+  --exclude='archive/' \
+  --exclude='migrations/enterprise/' \
+  --exclude='migrations/industry/' \
+  --exclude='platform/demo-portal/' \
+  --exclude='platform/monitoring/' \
+  --exclude='platform/observability/' \
+  --exclude='platform/scripts/' \
+  --exclude='platform/archive/' \
+  --exclude='platform/deploy-all-demos.sh' \
+  --exclude='platform/brand-system.css' \
+  --exclude='.github/workflows/deploy-*.yml' \
+  --exclude='.github/workflows/build-*.yml' \
+  --exclude='.github/workflows/sync-community-repo.yml' \
+  --exclude='.github/workflows/accept-community-pr.yml' \
+  --exclude='.github/workflows/update-stack.yml' \
+  --exclude='.github/workflows/delete-stack.yml' \
+  --exclude='.github/workflows/setup-*.yml' \
+  --exclude='.github/workflows/manage-*.yml' \
+  --exclude='axonflow-worktree-*' \
+  --exclude='*.pem' \
+  --exclude='*.key' \
+  --exclude='.env*' \
+  . /tmp/oss-sync/
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -174,7 +174,7 @@ Found a bug? We'd love your help fixing it:
 ### New Features
 Want to add functionality? Great!
 1. Open an issue to discuss the feature first
-2. Ensure it fits the OSS scope (see [OSS vs Enterprise](#oss-vs-enterprise))
+2. Ensure it fits the Community scope (see [Community vs Enterprise](#community-vs-enterprise))
 3. Implement with tests and documentation
 4. Submit a PR
 
@@ -199,14 +199,14 @@ Make AxonFlow faster:
 - Reduce memory usage
 - Improve startup time
 
-### OSS vs Enterprise
+### Community vs Enterprise
 
-AxonFlow follows an open-core model:
+AxonFlow follows a source-available model:
 
-**OSS (Open Source) - Contributions Welcome:**
+**Community (Source-Available) - Contributions Welcome:**
 - `platform/agent/` - Core agent functionality
 - `platform/orchestrator/` - Policy engine and LLM routing
-- `platform/connectors/` - OSS connectors (postgres, redis, http, cassandra)
+- `platform/connectors/` - Community connectors (postgres, redis, http, cassandra)
 - `platform/connectors/community/` - Community-contributed connectors
 - `platform/shared/` - Shared utilities
 - `docs/` - Documentation
@@ -217,7 +217,7 @@ AxonFlow follows an open-core model:
 - `ee/platform/agent/license/` - License validation
 - `ee/platform/customers/` - Customer demos
 
-Contributions to the OSS codebase are synced from the OSS repo to the enterprise repo, ensuring your work benefits all users.
+Contributions to the Community codebase are synced from the Community repo to the enterprise repo, ensuring your work benefits all users.
 
 ## Contributing Connectors
 
@@ -235,16 +235,16 @@ platform/connectors/
 │       └── connector_test.go
 ├── config/            # Configuration loading
 ├── registry/          # Connector registry
-├── postgres/          # OSS connector example
-├── cassandra/         # OSS connector example
-├── redis/             # OSS connector example
-└── http/              # OSS connector example
+├── postgres/          # Community connector example
+├── cassandra/         # Community connector example
+├── redis/             # Community connector example
+└── http/              # Community connector example
 ```
 
-**OSS vs Enterprise Connectors:**
-- **OSS connectors** (`postgres`, `cassandra`, `redis`, `http`): Full implementations, included in open source
-- **Community connectors** (`community/*`): Contributed by the community, included in open source
-- **Enterprise connectors** (`ee/platform/connectors/*`): Commercial features with OSS stubs
+**Community vs Enterprise Connectors:**
+- **Community connectors** (`postgres`, `cassandra`, `redis`, `http`): Full implementations, included in source-available release
+- **Community-contributed connectors** (`community/*`): Contributed by the community, included in source-available release
+- **Enterprise connectors** (`ee/platform/connectors/*`): Commercial features with Community stubs
 
 ### Creating a New Connector
 
@@ -427,7 +427,7 @@ connectors:
 
 ### Example Community Connectors
 
-See existing OSS connectors for reference:
+See existing Community connectors for reference:
 - `platform/connectors/postgres/` - PostgreSQL connector
 - `platform/connectors/http/` - Generic HTTP connector
 - `platform/connectors/redis/` - Redis connector

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ curl http://localhost:8081/health
 | **Anthropic** | ✅ | ✅ | Claude 3.5 Sonnet, Claude 3 Opus |
 | **Ollama** | ✅ | ✅ | Local/air-gapped deployments |
 | **AWS Bedrock** | ❌ | ✅ | HIPAA-compliant, data residency |
-| **Google Gemini** | ❌ | ✅ | Gemini Pro, Gemini Ultra |
+| **Google Gemini** | ✅ | ✅ | Gemini Pro, Gemini Ultra |
 
 → **[Provider configuration guide](https://docs.getaxonflow.com/docs/llm/overview)**
 
@@ -161,7 +161,7 @@ Policy checks add single-digit millisecond overhead.
 | Anthropic (Claude) | ✅ | ✅ |
 | Ollama (local/air-gapped) | ✅ | ✅ |
 | AWS Bedrock | ❌ | ✅ |
-| Google Gemini | ❌ | ✅ |
+| Google Gemini | ✅ | ✅ |
 | Multi-provider routing & failover | ✅ | ✅ |
 | Customer Portal provider UI | ❌ | ✅ |
 | **MCP Connectors** | | |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,12 +3,12 @@
 # Replaces 2-4 hour AWS test cycle with 5-10 minute local cycle
 #
 # Usage:
-#   docker-compose up -d                              # Start OSS services (agent, orchestrator)
+#   docker-compose up -d                              # Start Community services (agent, orchestrator)
 #   docker-compose --profile enterprise up -d         # Start all services including enterprise
 #   docker-compose logs -f axonflow-agent             # Follow agent logs
 #   docker-compose down -v                            # Stop and remove volumes
 #
-# OSS Services (always started):
+# Community Services (always started):
 #   - PostgreSQL: localhost:5432 (axonflow, grafana databases)
 #   - Redis: localhost:6379 (caching)
 #   - Agent: localhost:8080
@@ -22,8 +22,8 @@
 services:
   # PostgreSQL Database - Core platform storage
   # Creates both 'axonflow' and 'grafana' databases on first run
-  # The grafana user/database is created via POSTGRES_INITDB_ARGS for OSS compatibility
-  # (Enterprise uses migration 107 instead, but OSS needs inline setup)
+  # The grafana user/database is created via POSTGRES_INITDB_ARGS for Community compatibility
+  # (Enterprise uses migration 107 instead, but Community needs inline setup)
   postgres:
     image: postgres:15-alpine
     container_name: axonflow-postgres
@@ -90,13 +90,15 @@ services:
       # Optional: LLM API Keys (can be set in .env file)
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      GOOGLE_API_KEY: ${GOOGLE_API_KEY:-}
+      GOOGLE_MODEL: ${GOOGLE_MODEL:-}
 
       # Service configuration
       PORT: 8080
       SELF_HOSTED_MODE: "true"
       SELF_HOSTED_MODE_ACKNOWLEDGED: "I_UNDERSTAND_NO_AUTH"
       ENVIRONMENT: "development"
-      # DEPLOYMENT_MODE defaults to "oss" - enterprise deployments set via GitHub workflow
+      # DEPLOYMENT_MODE defaults to "community" - enterprise deployments set via GitHub workflow
       LOG_LEVEL: debug
 
       # Redis (optional)
@@ -149,6 +151,8 @@ services:
       # LLM API Keys
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      GOOGLE_API_KEY: ${GOOGLE_API_KEY:-}
+      GOOGLE_MODEL: ${GOOGLE_MODEL:-}
       LOCAL_LLM_ENDPOINT: ${LOCAL_LLM_ENDPOINT:-}
 
       # Service configuration

--- a/docs/RBI_FREE_AI_COMPLIANCE.md
+++ b/docs/RBI_FREE_AI_COMPLIANCE.md
@@ -242,9 +242,9 @@ RBI_EXPORT_PATH=/tmp/rbi-exports   # Export directory
 RBI_PII_MIN_CONFIDENCE=0.5         # PII detection threshold
 ```
 
-### OSS vs Enterprise
+### Community vs Enterprise
 
-| Feature | OSS | Enterprise |
+| Feature | Community | Enterprise |
 |---------|-----|------------|
 | PII Detection (Aadhaar, PAN) | Included | Included |
 | Policy Templates | Included | Included |

--- a/docs/api/agent-api.yaml
+++ b/docs/api/agent-api.yaml
@@ -2354,7 +2354,7 @@ components:
           description: Whether client is active
         license_tier:
           type: string
-          enum: [OSS, starter, professional, enterprise]
+          enum: [Community, starter, professional, enterprise]
           description: License tier
         license_expiry:
           type: string

--- a/docs/compliance/rbi-free-ai.md
+++ b/docs/compliance/rbi-free-ai.md
@@ -18,7 +18,7 @@ The RBI FREE-AI Framework (August 2025) establishes governance requirements for 
 
 | Feature | Community | Enterprise |
 |---------|:---------:|:----------:|
-| India PII detection (Aadhaar, PAN) | OSS patterns | Full validation |
+| India PII detection (Aadhaar, PAN) | Basic patterns | Full validation |
 | AI System Registry API | - | Full CRUD |
 | Model Validation tracking | - | Full workflow |
 | Incident Management | - | Full workflow |

--- a/docs/compliance/sebi-ai-ml.md
+++ b/docs/compliance/sebi-ai-ml.md
@@ -15,8 +15,8 @@ SEBI's AI/ML Framework establishes governance requirements for AI systems used b
 
 | Feature | Community | Enterprise |
 |---------|:---------:|:----------:|
-| PAN detection | OSS patterns | Full validation |
-| Aadhaar detection | OSS patterns | Full validation |
+| PAN detection | Basic patterns | Full validation |
+| Aadhaar detection | Basic patterns | Full validation |
 | Audit Export API | - | Full workflow |
 | 5-year Retention | - | Configurable |
 | SEBI Export Format | - | Compliant |

--- a/docs/guides/llm-providers.md
+++ b/docs/guides/llm-providers.md
@@ -43,8 +43,10 @@ AxonFlow Enterprise Edition supports multiple LLM providers to meet diverse oper
 | Provider | Type | Use Cases | Availability |
 |----------|------|-----------|--------------|
 | **OpenAI** | Cloud API | General purpose, rapid development | Community + Enterprise |
+| **Anthropic** | Cloud API | Safety-focused, Claude models | Community + Enterprise |
+| **Google Gemini** | Cloud API | Multimodal, fast inference | Community + Enterprise |
+| **Ollama** | Self-hosted | Air-gapped, on-premise, cost optimization | Community + Enterprise |
 | **AWS Bedrock** | Cloud API (AWS) | HIPAA compliance, data residency, enterprise | Enterprise Only |
-| **Ollama** | Self-hosted | Air-gapped, on-premise, cost optimization | Enterprise Only |
 
 ### OpenAI Configuration
 
@@ -309,6 +311,7 @@ Use `EnabledLLMProviders` parameter for these AI model providers:
 |-------------|---------|-------------|--------|
 | `openai` | OpenAI GPT models | `openai-api-key` | (plain string) |
 | `anthropic` | Anthropic Claude models | `anthropic-api-key` | (plain string) |
+| `gemini` | Google Gemini models | `gemini-api-key` | (plain string) |
 | `bedrock` | AWS Bedrock (IAM auth) | N/A | Uses IAM role |
 | `ollama` | Self-hosted Ollama | N/A | Uses endpoint URL |
 

--- a/docs/llm/gemini.md
+++ b/docs/llm/gemini.md
@@ -1,0 +1,265 @@
+# Google Gemini Provider
+
+AxonFlow supports Google's Gemini models for LLM routing and orchestration. This guide covers configuration, supported models, and usage.
+
+## Quick Start
+
+### 1. Get API Key
+
+1. Go to [Google AI Studio](https://aistudio.google.com/apikey)
+2. Create or select a Google Cloud project
+3. Click "Create API Key"
+4. Copy the generated key
+
+### 2. Configure Environment
+
+```bash
+# Required
+export GOOGLE_API_KEY=your-api-key-here
+
+# Optional: Specify model (default: gemini-2.0-flash)
+export GOOGLE_MODEL=gemini-2.5-flash
+```
+
+### 3. Start AxonFlow
+
+```bash
+docker-compose up -d
+```
+
+## Supported Models
+
+| Model | Context Window | Best For |
+|-------|---------------|----------|
+| `gemini-2.5-flash` | 1M tokens | Latest, fastest model |
+| `gemini-2.5-pro` | 2M tokens | Latest, highest quality |
+| `gemini-2.0-flash` | 1M tokens | Fast, general-purpose tasks (default) |
+| `gemini-2.0-flash-lite` | 1M tokens | Cost-optimized, simple tasks |
+| `gemini-1.5-pro` | 2M tokens | Complex reasoning, long context (legacy) |
+| `gemini-1.5-flash` | 1M tokens | Balanced speed/quality (legacy) |
+
+## Configuration Options
+
+### Provider Configuration
+
+```yaml
+# In your provider configuration
+providers:
+  - name: gemini-primary
+    type: gemini
+    api_key: ${GOOGLE_API_KEY}
+    model: gemini-2.0-flash
+    timeout_seconds: 120
+    enabled: true
+    priority: 100
+```
+
+### Environment Variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `GOOGLE_API_KEY` | Yes | - | Google AI API key |
+| `GOOGLE_MODEL` | No | `gemini-2.0-flash` | Default model |
+| `GOOGLE_ENDPOINT` | No | `https://generativelanguage.googleapis.com` | API endpoint |
+| `GOOGLE_TIMEOUT_SECONDS` | No | `120` | Request timeout (seconds) |
+
+## Capabilities
+
+The Gemini provider supports:
+
+- **Chat completions** - Conversational AI
+- **Streaming responses** - Real-time token streaming
+- **Long context** - Up to 2M tokens (Gemini 2.5 Pro)
+- **Vision** - Image understanding
+- **Function calling** - Tool use
+- **Code generation** - Programming assistance
+
+## Usage Examples
+
+### Proxy Mode (Python SDK)
+
+Proxy mode routes requests through AxonFlow for simple integration:
+
+```python
+from axonflow import AxonFlow
+
+async with AxonFlow(agent_url="http://localhost:8080") as client:
+    # Execute query through AxonFlow (routes to configured Gemini provider)
+    response = await client.execute_query(
+        user_token="user-123",
+        query="Explain quantum computing",
+        request_type="chat",
+        context={"provider": "gemini", "model": "gemini-2.0-flash"}
+    )
+    print(response.content)
+```
+
+### Proxy Mode (cURL)
+
+```bash
+curl -X POST http://localhost:8080/api/request \
+  -H "Content-Type: application/json" \
+  -H "X-User-Token: user-123" \
+  -d '{
+    "query": "What is machine learning?",
+    "provider": "gemini",
+    "model": "gemini-2.0-flash",
+    "max_tokens": 500
+  }'
+```
+
+### Gateway Mode (TypeScript SDK)
+
+Gateway mode gives you full control over the LLM call while AxonFlow handles policy enforcement and audit logging:
+
+```typescript
+import { AxonFlow } from '@axonflow/sdk';
+import { GoogleGenerativeAI } from '@google/generative-ai';
+
+const axonflow = new AxonFlow({
+  endpoint: 'http://localhost:8080',
+  apiKey: 'your-axonflow-key'
+});
+
+// 1. Pre-check: Get policy approval
+const ctx = await axonflow.getPolicyApprovedContext({
+  userToken: 'user-123',
+  query: 'Explain quantum computing'
+});
+
+if (!ctx.approved) {
+  throw new Error(`Blocked: ${ctx.blockReason}`);
+}
+
+// 2. Call Gemini directly
+const genAI = new GoogleGenerativeAI(process.env.GOOGLE_API_KEY);
+const model = genAI.getGenerativeModel({ model: 'gemini-2.0-flash' });
+const result = await model.generateContent(ctx.approvedData.query);
+const response = result.response.text();
+
+// 3. Audit the call
+await axonflow.auditLLMCall(
+  ctx.contextId,
+  response.substring(0, 100),  // Summary
+  'gemini',
+  'gemini-2.0-flash',
+  { promptTokens: 50, completionTokens: 100, totalTokens: 150 },
+  250  // latency ms
+);
+```
+
+## Streaming
+
+Gemini supports server-sent events (SSE) for streaming responses. Use the Gemini SDK directly:
+
+```typescript
+import { GoogleGenerativeAI } from '@google/generative-ai';
+
+const genAI = new GoogleGenerativeAI(process.env.GOOGLE_API_KEY);
+const model = genAI.getGenerativeModel({ model: 'gemini-2.0-flash' });
+
+const result = await model.generateContentStream('Write a long story');
+
+for await (const chunk of result.stream) {
+  const text = chunk.text();
+  process.stdout.write(text);
+}
+```
+
+## Pricing
+
+Gemini pricing (as of January 2025):
+
+| Model | Input (per 1M tokens) | Output (per 1M tokens) |
+|-------|----------------------|------------------------|
+| Gemini 2.0 Flash | $0.10 | $0.40 |
+| Gemini 1.5 Pro (≤128K) | $1.25 | $5.00 |
+| Gemini 1.5 Pro (>128K) | $2.50 | $10.00 |
+| Gemini 1.5 Flash | $0.075 | $0.30 |
+
+AxonFlow provides cost estimation via the `/api/cost/estimate` endpoint.
+
+## Error Handling
+
+Common error codes from Gemini:
+
+| Status | Reason | Action |
+|--------|--------|--------|
+| 400 | Invalid request | Check request format |
+| 401 | Invalid API key | Verify `GOOGLE_API_KEY` |
+| 403 | Permission denied | Check API key permissions |
+| 429 | Rate limit | Implement backoff/retry |
+| 500 | Server error | Retry with exponential backoff |
+
+AxonFlow automatically handles retries for transient errors (429, 500, 503).
+
+## Health Checks
+
+The Gemini provider reports health status at:
+
+```bash
+curl http://localhost:8081/health
+```
+
+Response includes Gemini provider status:
+
+```json
+{
+  "status": "healthy",
+  "providers": {
+    "gemini": {
+      "status": "healthy",
+      "latency_ms": 45
+    }
+  }
+}
+```
+
+## Multi-Provider Routing
+
+Configure Gemini alongside other providers for intelligent routing:
+
+```yaml
+providers:
+  - name: gemini-primary
+    type: gemini
+    priority: 100
+    enabled: true
+
+  - name: openai-fallback
+    type: openai
+    priority: 50
+    enabled: true
+
+routing:
+  strategy: priority
+  fallback_enabled: true
+```
+
+## Best Practices
+
+1. **Use appropriate models** - Gemini Flash for speed, Pro for quality
+2. **Set reasonable timeouts** - 120s default is good for most use cases
+3. **Enable fallback providers** - Configure OpenAI/Anthropic as backup
+4. **Monitor costs** - Use AxonFlow's cost dashboard to track usage
+5. **Handle rate limits** - Implement client-side retry logic for high-volume apps
+
+## Troubleshooting
+
+### "API key not valid"
+- Verify the key at [Google AI Studio](https://aistudio.google.com/apikey)
+- Ensure the key has Generative Language API enabled
+
+### "Model not found"
+- Check model name spelling
+- Verify model availability in your region
+
+### "Quota exceeded"
+- Check usage at [Google Cloud Console](https://console.cloud.google.com)
+- Consider upgrading to a paid plan
+
+## See Also
+
+- [LLM Provider Overview](./overview.md)
+- [Multi-Model Routing](./routing.md)
+- [Cost Optimization](../guides/cost-optimization.md)

--- a/docs/reference/llm-architecture.md
+++ b/docs/reference/llm-architecture.md
@@ -374,8 +374,8 @@ if err != nil {
 }
 
 // Get available providers for current tier
-ossProviders := GetOSSProviders()       // [ollama, openai, anthropic]
-entProviders := GetEnterpriseProviders() // [bedrock, gemini, custom]
+communityProviders := GetCommunityProviders() // [ollama, openai, anthropic, gemini]
+entProviders := GetEnterpriseProviders()       // [bedrock, custom]
 ```
 
 ### Implementing Custom Validator
@@ -644,7 +644,7 @@ Ensure enterprise features are properly gated:
 
 ```go
 func TestEnterpriseProviderRequiresLicense(t *testing.T) {
-    registry := NewRegistry(WithLicenseValidator(NewOSSLicenseValidator()))
+    registry := NewRegistry(WithLicenseValidator(NewCommunityLicenseValidator()))
 
     err := registry.Register(ctx, &ProviderConfig{
         Name: "bedrock-test",
@@ -652,7 +652,7 @@ func TestEnterpriseProviderRequiresLicense(t *testing.T) {
     })
 
     if err == nil {
-        t.Fatal("Expected license error for enterprise provider in OSS mode")
+        t.Fatal("Expected license error for enterprise provider in Community mode")
     }
 }
 ```

--- a/docs/sdk/llm-sdk-guide.md
+++ b/docs/sdk/llm-sdk-guide.md
@@ -465,18 +465,18 @@ llm.RegisterFactory(llm.ProviderTypeCustom, func(config llm.ProviderConfig) (llm
 ### Check Provider Availability
 
 ```go
-// Check if provider is available in OSS
-if llm.IsOSSProvider(llm.ProviderTypeOpenAI) {
-    fmt.Println("OpenAI is available in OSS")
+// Check if provider is available in Community edition
+if llm.IsCommunityProvider(llm.ProviderTypeOpenAI) {
+    fmt.Println("OpenAI is available in Community edition")
 }
 
-// Get all OSS providers
-ossProviders := llm.GetOSSProviders()
-// Returns: [ollama, openai, anthropic]
+// Get all Community providers
+communityProviders := llm.GetCommunityProviders()
+// Returns: [ollama, openai, anthropic, gemini]
 
 // Get enterprise-only providers
 entProviders := llm.GetEnterpriseProviders()
-// Returns: [bedrock, gemini, custom]
+// Returns: [bedrock, custom]
 ```
 
 ### Validate Provider Access
@@ -485,7 +485,7 @@ entProviders := llm.GetEnterpriseProviders()
 err := llm.ValidateProviderAccess(ctx, llm.ProviderTypeBedrock)
 if err != nil {
     log.Printf("Cannot use Bedrock: %v", err)
-    // Fall back to OSS provider
+    // Fall back to Community provider
 }
 ```
 

--- a/examples/workflows/README.md
+++ b/examples/workflows/README.md
@@ -13,7 +13,7 @@ cp .env.example .env
 go run main.go
 ```
 
-## Basic Patterns (OSS Features)
+## Basic Patterns (Community Features)
 
 ### 1. Simple Sequential
 **File:** `01-simple-sequential/`

--- a/platform/agent/connector_factory.go
+++ b/platform/agent/connector_factory.go
@@ -41,11 +41,11 @@ var defaultConnectorFactory *ConnectorFactoryRegistry
 var defaultConnectorFactoryOnce sync.Once
 
 // GetDefaultConnectorFactory returns the singleton ConnectorFactoryRegistry.
-// It initializes the factory with all OSS connectors on first call.
+// It initializes the factory with all Community connectors on first call.
 func GetDefaultConnectorFactory() *ConnectorFactoryRegistry {
 	defaultConnectorFactoryOnce.Do(func() {
 		defaultConnectorFactory = NewConnectorFactoryRegistry()
-		defaultConnectorFactory.RegisterOSSConnectors()
+		defaultConnectorFactory.RegisterCommunityConnectors()
 	})
 	return defaultConnectorFactory
 }
@@ -138,10 +138,10 @@ func (f *ConnectorFactoryRegistry) Clear() {
 	f.creators = make(map[string]ConnectorCreator)
 }
 
-// RegisterOSSConnectors registers all open-source connector creators.
-// These are the connectors available in the OSS version.
-func (f *ConnectorFactoryRegistry) RegisterOSSConnectors() {
-	f.logger.Println("Registering OSS connectors...")
+// RegisterCommunityConnectors registers all Community connector creators.
+// These are the connectors available in the Community version.
+func (f *ConnectorFactoryRegistry) RegisterCommunityConnectors() {
+	f.logger.Println("Registering Community connectors...")
 
 	// Database connectors
 	f.RegisterOrReplace(ConnectorPostgres, func() base.Connector {
@@ -169,7 +169,7 @@ func (f *ConnectorFactoryRegistry) RegisterOSSConnectors() {
 		return httpconnector.NewHTTPConnector()
 	})
 
-	f.logger.Printf("Registered %d OSS connectors", f.Count())
+	f.logger.Printf("Registered %d Community connectors", f.Count())
 }
 
 // DefaultConnectorFactory returns a ConnectorFactory function for use with TenantConnectorRegistry.

--- a/platform/agent/connector_factory_test.go
+++ b/platform/agent/connector_factory_test.go
@@ -225,12 +225,12 @@ func TestConnectorFactoryRegistry_Clear(t *testing.T) {
 	}
 }
 
-func TestConnectorFactoryRegistry_RegisterOSSConnectors(t *testing.T) {
+func TestConnectorFactoryRegistry_RegisterCommunityConnectors(t *testing.T) {
 	factory := NewConnectorFactoryRegistry()
-	factory.RegisterOSSConnectors()
+	factory.RegisterCommunityConnectors()
 
-	// OSS connectors: postgres, mysql, mongodb, cassandra, redis, http
-	expectedOSSConnectors := []string{
+	// Community connectors: postgres, mysql, mongodb, cassandra, redis, http
+	expectedCommunityConnectors := []string{
 		ConnectorPostgres,
 		ConnectorMySQL,
 		ConnectorMongoDB,
@@ -239,14 +239,14 @@ func TestConnectorFactoryRegistry_RegisterOSSConnectors(t *testing.T) {
 		ConnectorHTTP,
 	}
 
-	for _, ct := range expectedOSSConnectors {
+	for _, ct := range expectedCommunityConnectors {
 		if !factory.IsRegistered(ct) {
-			t.Errorf("Expected OSS connector '%s' to be registered", ct)
+			t.Errorf("Expected Community connector '%s' to be registered", ct)
 		}
 	}
 
 	// Verify we can create each one
-	for _, ct := range expectedOSSConnectors {
+	for _, ct := range expectedCommunityConnectors {
 		conn, err := factory.Create(ct)
 		if err != nil {
 			t.Errorf("Failed to create '%s' connector: %v", ct, err)
@@ -265,9 +265,9 @@ func TestGetDefaultConnectorFactory(t *testing.T) {
 		t.Fatal("Expected non-nil default factory")
 	}
 
-	// Should have OSS connectors registered
+	// Should have Community connectors registered
 	if factory.Count() < 6 {
-		t.Errorf("Expected at least 6 OSS connectors, got %d", factory.Count())
+		t.Errorf("Expected at least 6 Community connectors, got %d", factory.Count())
 	}
 
 	// Verify singleton behavior

--- a/platform/agent/db_auth_test.go
+++ b/platform/agent/db_auth_test.go
@@ -107,7 +107,7 @@ func TestValidateViaOrganizations_V2LicenseIsAuthority(t *testing.T) {
 }
 
 // TestValidateViaOrganizations_ExpiredOrg tests organization with expired license
-// Note: In OSS mode, expired licenses are accepted (lenient mode)
+// Note: In Community mode, expired licenses are accepted (lenient mode)
 // In Enterprise mode, expired licenses are rejected after grace period
 func TestValidateViaOrganizations_ExpiredOrg(t *testing.T) {
 	db, _, err := sqlmock.New() // mock not used - license validation fails first
@@ -122,7 +122,7 @@ func TestValidateViaOrganizations_ExpiredOrg(t *testing.T) {
 	ctx := context.Background()
 	client, err := validateViaOrganizations(ctx, db, "test-client", testLicenseKey)
 
-	// In OSS mode, expired licenses are accepted (lenient)
+	// In Community mode, expired licenses are accepted (lenient)
 	// In Enterprise mode, this would fail after grace period
 	if err != nil {
 		// Enterprise behavior: expired license rejected
@@ -130,9 +130,9 @@ func TestValidateViaOrganizations_ExpiredOrg(t *testing.T) {
 		return
 	}
 
-	// OSS behavior: expired license accepted
+	// Community behavior: expired license accepted
 	if client == nil {
-		t.Error("OSS mode: expected client for expired license, got nil")
+		t.Error("Community mode: expected client for expired license, got nil")
 	}
 }
 
@@ -556,10 +556,10 @@ func TestGetCustomerUsageForMonth_NoData(t *testing.T) {
 
 // TestCreateAPIKey_Success tests successful API key creation
 func TestCreateAPIKey_Success(t *testing.T) {
-	// Skip this test in OSS builds as it requires GenerateLicenseKey
+	// Skip this test in Community builds as it requires GenerateLicenseKey
 	_, err := license.GenerateLicenseKey(license.TierProfessional, "test", 1)
 	if err != nil {
-		t.Skip("GenerateLicenseKey not available in OSS builds")
+		t.Skip("GenerateLicenseKey not available in Community builds")
 	}
 
 	db, mock, err := sqlmock.New()

--- a/platform/agent/doc.go
+++ b/platform/agent/doc.go
@@ -59,7 +59,7 @@ The Agent supports multiple authentication strategies:
   - License key validation (X-License-Key header)
   - JWT token validation for user identity
   - Database-backed client registration
-  - Self-hosted mode for OSS deployments
+  - Self-hosted mode for Community deployments
 
 # Gateway Mode API
 

--- a/platform/agent/gateway_handlers_test.go
+++ b/platform/agent/gateway_handlers_test.go
@@ -2507,21 +2507,21 @@ func TestFetchApprovedData_MCPQueryPermission(t *testing.T) {
 }
 
 // ==================================================================
-// RBI Kill Switch Tests (OSS stub behavior)
+// RBI Kill Switch Tests (Community stub behavior)
 // ==================================================================
 
-// TestCheckRBIKillSwitch_OSS tests that kill switch returns not blocked in OSS mode
-func TestCheckRBIKillSwitch_OSS(t *testing.T) {
+// TestCheckRBIKillSwitch_Community tests that kill switch returns not blocked in Community mode
+func TestCheckRBIKillSwitch_Community(t *testing.T) {
 	ctx := context.Background()
 
-	// In OSS mode, kill switch should always return not blocked
+	// In Community mode, kill switch should always return not blocked
 	result := checkRBIKillSwitch(ctx, "org-123", "system-456")
 
 	if result == nil {
 		t.Fatal("Expected non-nil result")
 	}
 	if result.IsBlocked {
-		t.Error("OSS stub should never block (expected IsBlocked=false)")
+		t.Error("Community stub should never block (expected IsBlocked=false)")
 	}
 }
 
@@ -2533,7 +2533,7 @@ func TestGetRBIKillSwitchChecker(t *testing.T) {
 	// Second call should return the same instance
 	checker2 := getRBIKillSwitchChecker()
 
-	// In OSS mode, checker will be nil because KillSwitchEnabled() returns false
+	// In Community mode, checker will be nil because KillSwitchEnabled() returns false
 	// But the function should be consistent
 	if checker != checker2 {
 		t.Error("getRBIKillSwitchChecker should return the same instance on subsequent calls")
@@ -2541,7 +2541,7 @@ func TestGetRBIKillSwitchChecker(t *testing.T) {
 }
 
 // TestPreCheckHandler_KillSwitchIntegration tests that kill switch check is integrated into pre-check flow
-// In OSS mode, kill switch is not enforced, so requests pass through. In enterprise mode, active kill switches block requests.
+// In Community mode, kill switch is not enforced, so requests pass through. In enterprise mode, active kill switches block requests.
 func TestPreCheckHandler_KillSwitchIntegration(t *testing.T) {
 	os.Setenv("SELF_HOSTED_MODE", "true")
 	os.Setenv("SELF_HOSTED_MODE_ACKNOWLEDGED", "I_UNDERSTAND_NO_AUTH")
@@ -2552,7 +2552,7 @@ func TestPreCheckHandler_KillSwitchIntegration(t *testing.T) {
 
 	staticPolicyEngine = NewStaticPolicyEngine()
 
-	// Normal request - should pass in OSS mode (kill switch not enforced)
+	// Normal request - should pass in Community mode (kill switch not enforced)
 	reqBody := PreCheckRequest{
 		UserToken: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoxfQ.test",
 		ClientID:  "test-client",
@@ -2577,9 +2577,9 @@ func TestPreCheckHandler_KillSwitchIntegration(t *testing.T) {
 		t.Fatalf("Failed to unmarshal response: %v", err)
 	}
 
-	// In OSS mode, kill switch check always returns not blocked
+	// In Community mode, kill switch check always returns not blocked
 	if !resp.Approved {
-		t.Errorf("Expected Approved=true (OSS mode doesn't enforce kill switch), got Approved=false. BlockReason: %s",
+		t.Errorf("Expected Approved=true (Community mode doesn't enforce kill switch), got Approved=false. BlockReason: %s",
 			resp.BlockReason)
 	}
 }

--- a/platform/agent/license/license_community_test.go
+++ b/platform/agent/license/license_community_test.go
@@ -32,27 +32,27 @@ func TestValidateLicense(t *testing.T) {
 		expectedMsg    string
 	}{
 		{
-			name:          "empty license key - OSS mode",
+			name:          "empty license key - Community mode",
 			licenseKey:    "",
 			expectedValid: true,
-			expectedTier:  TierOSS,
-			expectedOrgID: "oss",
+			expectedTier:  TierCommunity,
+			expectedOrgID: "community",
 			checkMessage:  true,
-			expectedMsg:   "OSS mode - no license required",
+			expectedMsg:   "Community mode - no license required",
 		},
 		{
-			name:          "invalid format - falls back to OSS",
+			name:          "invalid format - falls back to Community",
 			licenseKey:    "INVALID-LICENSE-KEY",
 			expectedValid: true,
-			expectedTier:  TierOSS,
-			expectedOrgID: "oss",
+			expectedTier:  TierCommunity,
+			expectedOrgID: "community",
 		},
 		{
-			name:          "V1 format - falls back to OSS",
+			name:          "V1 format - falls back to Community",
 			licenseKey:    "AXON-V1-something",
 			expectedValid: true,
-			expectedTier:  TierOSS,
-			expectedOrgID: "oss",
+			expectedTier:  TierCommunity,
+			expectedOrgID: "community",
 		},
 	}
 
@@ -77,12 +77,12 @@ func TestValidateLicense(t *testing.T) {
 				t.Errorf("ValidateLicense() Message = %v, want %v", result.Message, tt.expectedMsg)
 			}
 
-			// Verify OSS features
+			// Verify Community features
 			if result.Features == nil {
 				t.Error("ValidateLicense() Features = nil, want non-nil map")
 			}
-			if ossMode, ok := result.Features["oss_mode"]; !ok || !ossMode {
-				t.Error("ValidateLicense() Features['oss_mode'] should be true")
+			if communityMode, ok := result.Features["community_mode"]; !ok || !communityMode {
+				t.Error("ValidateLicense() Features['community_mode'] should be true")
 			}
 		})
 	}
@@ -90,19 +90,19 @@ func TestValidateLicense(t *testing.T) {
 
 func TestValidateLicense_ValidV2License(t *testing.T) {
 	// This test requires GenerateLicenseKey which is enterprise-only
-	// Skip in OSS builds
+	// Skip in Community builds
 	_, err := GenerateLicenseKey(TierEnterprise, "test-org", 365)
 	if err != nil {
-		t.Skip("GenerateLicenseKey not available in OSS builds")
+		t.Skip("GenerateLicenseKey not available in Community builds")
 	}
 }
 
 func TestValidateLicense_ExpiredV2License(t *testing.T) {
 	// This test requires GenerateLicenseKey which is enterprise-only
-	// Skip in OSS builds
+	// Skip in Community builds
 	_, err := GenerateLicenseKey(TierProfessional, "expired-org", -30)
 	if err != nil {
-		t.Skip("GenerateLicenseKey not available in OSS builds")
+		t.Skip("GenerateLicenseKey not available in Community builds")
 	}
 }
 
@@ -175,10 +175,10 @@ func TestVerifyV2Signature(t *testing.T) {
 
 func TestVerifyV2Signature_GeneratedLicense(t *testing.T) {
 	// This test requires GenerateLicenseKey which is enterprise-only
-	// Skip in OSS builds
+	// Skip in Community builds
 	_, err := GenerateLicenseKey(TierEnterprise, "test", 365)
 	if err != nil {
-		t.Skip("GenerateLicenseKey not available in OSS builds")
+		t.Skip("GenerateLicenseKey not available in Community builds")
 	}
 }
 
@@ -197,14 +197,14 @@ func TestValidateWithRetry(t *testing.T) {
 			licenseKey:    "",
 			maxAttempts:   1,
 			expectedValid: true,
-			expectedTier:  TierOSS,
+			expectedTier:  TierCommunity,
 		},
 		{
 			name:          "valid license - multiple attempts",
 			licenseKey:    "",
 			maxAttempts:   3,
 			expectedValid: true,
-			expectedTier:  TierOSS,
+			expectedTier:  TierCommunity,
 		},
 	}
 
@@ -226,11 +226,11 @@ func TestValidateWithRetry(t *testing.T) {
 	}
 }
 
-func TestGetOSSFeatures(t *testing.T) {
-	features := getOSSFeatures()
+func TestGetCommunityFeatures(t *testing.T) {
+	features := getCommunityFeatures()
 
 	if features == nil {
-		t.Fatal("getOSSFeatures() returned nil, want non-nil map")
+		t.Fatal("getCommunityFeatures() returned nil, want non-nil map")
 	}
 
 	expectedFeatures := map[string]bool{
@@ -239,48 +239,48 @@ func TestGetOSSFeatures(t *testing.T) {
 		"sla_guarantee":     false,
 		"audit_logging":     true,
 		"basic_support":     false,
-		"oss_mode":          true,
+		"community_mode":    true,
 	}
 
 	for key, expectedValue := range expectedFeatures {
 		if value, ok := features[key]; !ok {
-			t.Errorf("getOSSFeatures() missing key %q", key)
+			t.Errorf("getCommunityFeatures() missing key %q", key)
 		} else if value != expectedValue {
-			t.Errorf("getOSSFeatures()[%q] = %v, want %v", key, value, expectedValue)
+			t.Errorf("getCommunityFeatures()[%q] = %v, want %v", key, value, expectedValue)
 		}
 	}
 
 	// Verify no extra keys
 	if len(features) != len(expectedFeatures) {
-		t.Errorf("getOSSFeatures() has %d features, want %d", len(features), len(expectedFeatures))
+		t.Errorf("getCommunityFeatures() has %d features, want %d", len(features), len(expectedFeatures))
 	}
 }
 
 func TestGenerateLicenseKey(t *testing.T) {
 	// This test requires GenerateLicenseKey which is enterprise-only
-	// The error behavior is tested in TestLicenseKey_GenerationNotAvailableInOSS
+	// The error behavior is tested in TestLicenseKey_GenerationNotAvailableInCommunity
 	_, err := GenerateLicenseKey(TierProfessional, "test-org", 365)
 	if err != nil {
-		t.Skip("GenerateLicenseKey not available in OSS builds")
+		t.Skip("GenerateLicenseKey not available in Community builds")
 	}
 }
 
 func TestGenerateLicenseKey_RoundTrip(t *testing.T) {
 	// This test requires GenerateLicenseKey which is enterprise-only
-	// Skip in OSS builds
+	// Skip in Community builds
 	_, err := GenerateLicenseKey(TierProfessional, "test-org", 365)
 	if err != nil {
-		t.Skip("GenerateLicenseKey not available in OSS builds")
+		t.Skip("GenerateLicenseKey not available in Community builds")
 	}
 }
 
-func TestLicenseKey_GenerationNotAvailableInOSS(t *testing.T) {
-	// In OSS builds, license generation is not available
+func TestLicenseKey_GenerationNotAvailableInCommunity(t *testing.T) {
+	// In Community builds, license generation is not available
 	// This is a security feature to prevent exposure of the license format
 
 	_, err := GenerateLicenseKey(TierEnterprise, "healthcare", 365)
 	if err == nil {
-		t.Error("GenerateLicenseKey() should return error in OSS builds")
+		t.Error("GenerateLicenseKey() should return error in Community builds")
 	}
 
 	// Check for enterprise upgrade messaging (includes link to getaxonflow.com/enterprise)
@@ -291,7 +291,7 @@ func TestLicenseKey_GenerationNotAvailableInOSS(t *testing.T) {
 	// Also test GenerateServiceLicenseKey
 	_, err = GenerateServiceLicenseKey(TierEnterprise, "test", "service", "backend-service", []string{"perm"}, 365)
 	if err == nil {
-		t.Error("GenerateServiceLicenseKey() should return error in OSS builds")
+		t.Error("GenerateServiceLicenseKey() should return error in Community builds")
 	}
 }
 
@@ -301,10 +301,10 @@ func TestTierConstants(t *testing.T) {
 		TierProfessional,
 		TierEnterprise,
 		TierEnterprisePlus,
-		TierOSS,
+		TierCommunity,
 	}
 
-	expectedValues := []string{"PRO", "ENT", "PLUS", "OSS"}
+	expectedValues := []string{"PRO", "ENT", "PLUS", "Community"}
 
 	for i, tier := range tiers {
 		if string(tier) != expectedValues[i] {
@@ -314,7 +314,7 @@ func TestTierConstants(t *testing.T) {
 }
 
 func TestValidateLicense_UnknownTier(t *testing.T) {
-	// Test license with unknown tier - should default to OSS
+	// Test license with unknown tier - should default to Community
 	ctx := context.Background()
 
 	// This would require manually crafting a license with an invalid tier
@@ -324,33 +324,33 @@ func TestValidateLicense_UnknownTier(t *testing.T) {
 		t.Errorf("ValidateLicense() error = %v, want nil", err)
 	}
 
-	if result.Tier != TierOSS {
-		t.Errorf("ValidateLicense() with empty key should default to TierOSS, got %v", result.Tier)
+	if result.Tier != TierCommunity {
+		t.Errorf("ValidateLicense() with empty key should default to TierCommunity, got %v", result.Tier)
 	}
 }
 
-func TestValidationResult_OSSMode(t *testing.T) {
+func TestValidationResult_CommunityMode(t *testing.T) {
 	ctx := context.Background()
 
-	// In OSS mode, validating any license returns OSS tier result
-	// Test with empty license key (should return OSS result)
+	// In Community mode, validating any license returns Community tier result
+	// Test with empty license key (should return Community tier result)
 	result, err := ValidateLicense(ctx, "any-license-key")
 	if err != nil {
 		t.Fatalf("ValidateLicense() error = %v", err)
 	}
 
-	// In OSS mode, all licenses are valid (permissive validation)
+	// In Community mode, all licenses are valid (permissive validation)
 	if !result.Valid {
-		t.Error("ValidationResult.Valid should be true in OSS mode")
+		t.Error("ValidationResult.Valid should be true in Community mode")
 	}
-	if result.Tier != TierOSS {
-		t.Errorf("ValidationResult.Tier should be OSS in OSS mode, got %v", result.Tier)
+	if result.Tier != TierCommunity {
+		t.Errorf("ValidationResult.Tier should be Community in Community mode, got %v", result.Tier)
 	}
-	if result.OrgID != "oss" {
-		t.Errorf("ValidationResult.OrgID should be 'oss' in OSS mode, got %v", result.OrgID)
+	if result.OrgID != "community" {
+		t.Errorf("ValidationResult.OrgID should be 'community' in Community mode, got %v", result.OrgID)
 	}
 	if result.MaxNodes != 9999 {
-		t.Errorf("ValidationResult.MaxNodes should be 9999 (unlimited) in OSS mode, got %v", result.MaxNodes)
+		t.Errorf("ValidationResult.MaxNodes should be 9999 (unlimited) in Community mode, got %v", result.MaxNodes)
 	}
 	if result.ExpiresAt.IsZero() {
 		t.Error("ValidationResult.ExpiresAt should not be zero")

--- a/platform/agent/marketplace/marketplace_community.go
+++ b/platform/agent/marketplace/marketplace_community.go
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 // Package marketplace provides AWS Marketplace metering integration.
-// This is the OSS stub - metering is disabled in OSS mode.
+// This is the Community stub - metering is disabled in Community mode.
 package marketplace
 
 import (
@@ -22,9 +22,9 @@ import (
 )
 
 // MeteringService handles AWS Marketplace metering for container products.
-// OSS stub: No-op implementation - metering is disabled in OSS mode.
+// Community stub: No-op implementation - metering is disabled in Community mode.
 type MeteringService struct {
-	// No fields needed for OSS stub
+	// No fields needed for Community stub
 }
 
 // UsageRecord represents a metering record
@@ -39,33 +39,33 @@ type UsageRecord struct {
 }
 
 // NewMeteringService creates a new AWS Marketplace metering service.
-// OSS stub: Returns a no-op service.
+// Community stub: Returns a no-op service.
 func NewMeteringService(db *sql.DB, productCode string) (*MeteringService, error) {
 	return &MeteringService{}, nil
 }
 
 // Start begins hourly metering.
-// OSS stub: No-op - metering is disabled in OSS mode.
+// Community stub: No-op - metering is disabled in Community mode.
 func (s *MeteringService) Start(ctx context.Context) error {
-	// No-op in OSS mode - AWS Marketplace metering is an enterprise feature
+	// No-op in Community mode - AWS Marketplace metering is an enterprise feature
 	return nil
 }
 
 // Stop stops the metering service.
-// OSS stub: No-op.
+// Community stub: No-op.
 func (s *MeteringService) Stop() {
-	// No-op in OSS mode
+	// No-op in Community mode
 }
 
 // RetryFailedRecords attempts to resend failed metering records.
-// OSS stub: No-op - always returns nil.
+// Community stub: No-op - always returns nil.
 func (s *MeteringService) RetryFailedRecords(ctx context.Context) error {
-	// No-op in OSS mode
+	// No-op in Community mode
 	return nil
 }
 
 // GetUsageHistory returns usage history for analytics.
-// OSS stub: Returns empty slice.
+// Community stub: Returns empty slice.
 func GetUsageHistory(ctx context.Context, db *sql.DB, days int) ([]UsageRecord, error) {
 	return []UsageRecord{}, nil
 }

--- a/platform/agent/marketplace/marketplace_community_test.go
+++ b/platform/agent/marketplace/marketplace_community_test.go
@@ -37,7 +37,7 @@ func TestNewMeteringService(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			service, err := NewMeteringService(nil, tt.productCode)
 			if err != nil {
-				t.Errorf("NewMeteringService() error = %v, want nil (OSS stub)", err)
+				t.Errorf("NewMeteringService() error = %v, want nil (Community stub)", err)
 			}
 			if service == nil {
 				t.Error("NewMeteringService() returned nil service, want non-nil stub")
@@ -55,7 +55,7 @@ func TestMeteringService_Start(t *testing.T) {
 	ctx := context.Background()
 	err = service.Start(ctx)
 	if err != nil {
-		t.Errorf("Start() error = %v, want nil (OSS no-op)", err)
+		t.Errorf("Start() error = %v, want nil (Community no-op)", err)
 	}
 }
 
@@ -78,7 +78,7 @@ func TestMeteringService_RetryFailedRecords(t *testing.T) {
 	ctx := context.Background()
 	err = service.RetryFailedRecords(ctx)
 	if err != nil {
-		t.Errorf("RetryFailedRecords() error = %v, want nil (OSS no-op)", err)
+		t.Errorf("RetryFailedRecords() error = %v, want nil (Community no-op)", err)
 	}
 }
 
@@ -107,13 +107,13 @@ func TestGetUsageHistory(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			records, err := GetUsageHistory(ctx, nil, tt.days)
 			if err != nil {
-				t.Errorf("GetUsageHistory() error = %v, want nil (OSS stub)", err)
+				t.Errorf("GetUsageHistory() error = %v, want nil (Community stub)", err)
 			}
 			if records == nil {
 				t.Error("GetUsageHistory() returned nil, want empty slice")
 			}
 			if len(records) != 0 {
-				t.Errorf("GetUsageHistory() returned %d records, want 0 (OSS stub)", len(records))
+				t.Errorf("GetUsageHistory() returned %d records, want 0 (Community stub)", len(records))
 			}
 		})
 	}
@@ -231,14 +231,14 @@ func TestMeteringService_ContextCancellation(t *testing.T) {
 
 	service, _ := NewMeteringService(nil, "cancelled-ctx")
 
-	// Should handle cancelled context gracefully (no-op in OSS)
+	// Should handle cancelled context gracefully (no-op in Community)
 	err := service.Start(ctx)
 	if err != nil {
-		t.Errorf("Start() with cancelled context error = %v, want nil (OSS no-op)", err)
+		t.Errorf("Start() with cancelled context error = %v, want nil (Community no-op)", err)
 	}
 
 	err = service.RetryFailedRecords(ctx)
 	if err != nil {
-		t.Errorf("RetryFailedRecords() with cancelled context error = %v, want nil (OSS no-op)", err)
+		t.Errorf("RetryFailedRecords() with cancelled context error = %v, want nil (Community no-op)", err)
 	}
 }

--- a/platform/agent/mcp_handler.go
+++ b/platform/agent/mcp_handler.go
@@ -91,7 +91,7 @@ func logInternalServiceAuthWarning() {
 
 // isValidInternalServiceRequest checks if the request is from a trusted internal service.
 // If AXONFLOW_INTERNAL_SERVICE_SECRET is configured, validates the token against it.
-// Otherwise falls back to checking the hardcoded token (for OSS/dev environments).
+// Otherwise falls back to checking the hardcoded token (for Community/dev environments).
 func isValidInternalServiceRequest(clientID, userToken string) bool {
 	if clientID != internalServiceClientID {
 		return false
@@ -102,7 +102,7 @@ func isValidInternalServiceRequest(clientID, userToken string) bool {
 		return userToken == secret
 	}
 
-	// Fallback for OSS/dev: accept hardcoded token
+	// Fallback for Community/dev: accept hardcoded token
 	return userToken == internalServiceTokenFallback
 }
 
@@ -121,7 +121,7 @@ func InitializeMCPRegistryWithDB(db *sql.DB) error {
 	mcpRegistry = registry.NewRegistry()
 	log.Println("[MCP] Initializing connector registry...")
 
-	// Check for config file (OSS mode)
+	// Check for config file (Community mode)
 	configFilePath := os.Getenv("AXONFLOW_CONFIG_FILE")
 	if configFilePath == "" {
 		// Check default locations

--- a/platform/agent/migration_helpers.go
+++ b/platform/agent/migration_helpers.go
@@ -42,7 +42,7 @@ import (
 // because dependencies (like static_policies) won't exist yet.
 //
 // DEPLOYMENT_MODE controls which paths are included:
-//   - oss:               core/
+//   - community:         core/
 //   - saas:              core/ + enterprise/ + industry/*
 //   - in-vpc-healthcare: core/ + enterprise/ + industry/healthcare/
 //   - in-vpc-banking:    core/ + enterprise/ + industry/banking/
@@ -62,7 +62,7 @@ type MigrationFile struct {
 func getMigrationPaths(basePath string) []string {
 	mode := os.Getenv("DEPLOYMENT_MODE")
 	if mode == "" {
-		mode = "oss" // Default to OSS mode for local development and docker-compose
+		mode = "community" // Default to Community mode for local development and docker-compose
 	}
 
 	// Handle legacy 'invpc' value (backwards compatibility)
@@ -77,9 +77,9 @@ func getMigrationPaths(basePath string) []string {
 	paths = append(paths, filepath.Join(basePath, "core"))
 
 	switch mode {
-	case "oss":
-		// OSS only runs core migrations
-		log.Println("📦 DEPLOYMENT_MODE=oss: Running core migrations only")
+	case "community":
+		// Community only runs core migrations
+		log.Println("📦 DEPLOYMENT_MODE=community: Running core migrations only")
 
 	case "saas":
 		// SaaS runs everything

--- a/platform/agent/migration_helpers_test.go
+++ b/platform/agent/migration_helpers_test.go
@@ -386,8 +386,8 @@ func TestGetMigrationPaths(t *testing.T) {
 		expectedPaths []string
 	}{
 		{
-			name:       "OSS mode",
-			deployMode: "oss",
+			name:       "Community mode",
+			deployMode: "community",
 			expectedPaths: []string{
 				"/test/migrations/core",
 			},
@@ -489,10 +489,10 @@ func TestGetMigrationPaths_DefaultMode(t *testing.T) {
 	basePath := "/test/migrations"
 	paths := getMigrationPaths(basePath)
 
-	// Should default to oss mode (core only) for docker-compose and OSS users
+	// Should default to community mode (core only) for docker-compose and Community users
 	expectedCount := 1 // core only
 	if len(paths) != expectedCount {
-		t.Errorf("Expected %d paths for default mode (oss), got %d", expectedCount, len(paths))
+		t.Errorf("Expected %d paths for default mode (community), got %d", expectedCount, len(paths))
 	}
 
 	// First path should be core
@@ -597,7 +597,7 @@ func TestCollectMigrations_SkipDownMigrations(t *testing.T) {
 		}
 	}
 
-	os.Setenv("DEPLOYMENT_MODE", "oss")
+	os.Setenv("DEPLOYMENT_MODE", "community")
 	defer os.Unsetenv("DEPLOYMENT_MODE")
 
 	migrations, err := collectMigrations(tmpDir)
@@ -619,7 +619,7 @@ func TestCollectMigrations_SkipDownMigrations(t *testing.T) {
 func TestCollectMigrations_NonexistentDirectory(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	os.Setenv("DEPLOYMENT_MODE", "oss")
+	os.Setenv("DEPLOYMENT_MODE", "community")
 	defer os.Unsetenv("DEPLOYMENT_MODE")
 
 	// Should not error, just log and skip

--- a/platform/agent/node_enforcement/enforcement_community.go
+++ b/platform/agent/node_enforcement/enforcement_community.go
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 // Package node_enforcement provides node count monitoring and enforcement.
-// This is the OSS stub - node enforcement is disabled in OSS mode.
+// This is the Community stub - node enforcement is disabled in Community mode.
 package node_enforcement
 
 import (
@@ -22,9 +22,9 @@ import (
 )
 
 // HeartbeatService manages agent/orchestrator heartbeats for node count tracking.
-// OSS stub: No-op implementation - heartbeat tracking is disabled in OSS mode.
+// Community stub: No-op implementation - heartbeat tracking is disabled in Community mode.
 type HeartbeatService struct {
-	// No fields needed for OSS stub
+	// No fields needed for Community stub
 }
 
 // HostInfo contains system information about the instance
@@ -40,28 +40,28 @@ type HostInfo struct {
 }
 
 // NewHeartbeatService creates a new heartbeat service.
-// OSS stub: Returns a no-op service.
+// Community stub: Returns a no-op service.
 func NewHeartbeatService(db *sql.DB, instanceType, licenseKey, orgID string) *HeartbeatService {
 	return &HeartbeatService{}
 }
 
 // Start begins sending periodic heartbeats.
-// OSS stub: No-op - heartbeat tracking is disabled in OSS mode.
+// Community stub: No-op - heartbeat tracking is disabled in Community mode.
 func (s *HeartbeatService) Start(ctx context.Context) error {
-	// No-op in OSS mode - node tracking is an enterprise feature
+	// No-op in Community mode - node tracking is an enterprise feature
 	return nil
 }
 
 // Stop stops the heartbeat service.
-// OSS stub: No-op.
+// Community stub: No-op.
 func (s *HeartbeatService) Stop() {
-	// No-op in OSS mode
+	// No-op in Community mode
 }
 
 // NodeMonitor monitors node counts against license limits.
-// OSS stub: No-op implementation - node monitoring is disabled in OSS mode.
+// Community stub: No-op implementation - node monitoring is disabled in Community mode.
 type NodeMonitor struct {
-	// No fields needed for OSS stub
+	// No fields needed for Community stub
 }
 
 // ViolationInfo contains details about a node limit violation
@@ -83,69 +83,69 @@ type AlertService interface {
 }
 
 // NewNodeMonitor creates a new node monitor.
-// OSS stub: Returns a no-op monitor.
+// Community stub: Returns a no-op monitor.
 func NewNodeMonitor(db *sql.DB, alerter AlertService) *NodeMonitor {
 	return &NodeMonitor{}
 }
 
 // Start begins monitoring node counts.
-// OSS stub: No-op - node monitoring is disabled in OSS mode.
+// Community stub: No-op - node monitoring is disabled in Community mode.
 func (m *NodeMonitor) Start(ctx context.Context) {
-	// No-op in OSS mode - node monitoring is an enterprise feature
+	// No-op in Community mode - node monitoring is an enterprise feature
 }
 
 // Stop stops the monitor.
-// OSS stub: No-op.
+// Community stub: No-op.
 func (m *NodeMonitor) Stop() {
-	// No-op in OSS mode
+	// No-op in Community mode
 }
 
 // MultiChannelAlerter sends alerts to multiple channels (Slack, email, CloudWatch).
-// OSS stub: No-op implementation - alerting is disabled in OSS mode.
+// Community stub: No-op implementation - alerting is disabled in Community mode.
 type MultiChannelAlerter struct {
-	// No fields needed for OSS stub
+	// No fields needed for Community stub
 }
 
 // NewMultiChannelAlerter creates a new alerter.
-// OSS stub: Returns a no-op alerter.
+// Community stub: Returns a no-op alerter.
 func NewMultiChannelAlerter() *MultiChannelAlerter {
 	return &MultiChannelAlerter{}
 }
 
 // SendNodeViolationAlert sends a critical alert for node limit violations.
-// OSS stub: No-op - always returns nil.
+// Community stub: No-op - always returns nil.
 func (a *MultiChannelAlerter) SendNodeViolationAlert(ctx context.Context, violation *ViolationInfo) error {
-	// No-op in OSS mode - alerting is an enterprise feature
+	// No-op in Community mode - alerting is an enterprise feature
 	return nil
 }
 
 // SendNodeCountWarning sends a warning when node count reaches 80% of limit.
-// OSS stub: No-op - always returns nil.
+// Community stub: No-op - always returns nil.
 func (a *MultiChannelAlerter) SendNodeCountWarning(ctx context.Context, orgID string, usage float64) error {
-	// No-op in OSS mode - alerting is an enterprise feature
+	// No-op in Community mode - alerting is an enterprise feature
 	return nil
 }
 
 // GetActiveNodeCount returns the current active node count for a license.
-// OSS stub: Always returns 0 (no tracking).
+// Community stub: Always returns 0 (no tracking).
 func GetActiveNodeCount(ctx context.Context, db *sql.DB, licenseKeyHash string) (int, error) {
 	return 0, nil
 }
 
 // GetActiveNodesByOrg returns the active node count grouped by organization.
-// OSS stub: Always returns empty map (no tracking).
+// Community stub: Always returns empty map (no tracking).
 func GetActiveNodesByOrg(ctx context.Context, db *sql.DB) (map[string]int, error) {
 	return map[string]int{}, nil
 }
 
 // CleanupStaleHeartbeats removes heartbeats older than 1 hour.
-// OSS stub: No-op - always returns nil.
+// Community stub: No-op - always returns nil.
 func CleanupStaleHeartbeats(ctx context.Context, db *sql.DB) error {
 	return nil
 }
 
 // GetViolationHistory returns all violations for an organization.
-// OSS stub: Always returns empty slice (no violations tracked).
+// Community stub: Always returns empty slice (no violations tracked).
 func GetViolationHistory(ctx context.Context, db *sql.DB, orgID string) ([]*ViolationInfo, error) {
 	return []*ViolationInfo{}, nil
 }

--- a/platform/agent/node_enforcement/enforcement_community_test.go
+++ b/platform/agent/node_enforcement/enforcement_community_test.go
@@ -62,7 +62,7 @@ func TestHeartbeatService_Start(t *testing.T) {
 
 	err := service.Start(ctx)
 	if err != nil {
-		t.Errorf("Start() error = %v, want nil (OSS no-op)", err)
+		t.Errorf("Start() error = %v, want nil (Community no-op)", err)
 	}
 }
 
@@ -192,7 +192,7 @@ func TestMultiChannelAlerter_SendNodeViolationAlert(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			err := alerter.SendNodeViolationAlert(ctx, tt.violation)
 			if err != nil {
-				t.Errorf("SendNodeViolationAlert() error = %v, want nil (OSS no-op)", err)
+				t.Errorf("SendNodeViolationAlert() error = %v, want nil (Community no-op)", err)
 			}
 		})
 	}
@@ -228,7 +228,7 @@ func TestMultiChannelAlerter_SendNodeCountWarning(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			err := alerter.SendNodeCountWarning(ctx, tt.orgID, tt.usage)
 			if err != nil {
-				t.Errorf("SendNodeCountWarning() error = %v, want nil (OSS no-op)", err)
+				t.Errorf("SendNodeCountWarning() error = %v, want nil (Community no-op)", err)
 			}
 		})
 	}
@@ -255,10 +255,10 @@ func TestGetActiveNodeCount(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			count, err := GetActiveNodeCount(ctx, nil, tt.licenseKeyHash)
 			if err != nil {
-				t.Errorf("GetActiveNodeCount() error = %v, want nil (OSS stub)", err)
+				t.Errorf("GetActiveNodeCount() error = %v, want nil (Community stub)", err)
 			}
 			if count != 0 {
-				t.Errorf("GetActiveNodeCount() = %d, want 0 (OSS stub)", count)
+				t.Errorf("GetActiveNodeCount() = %d, want 0 (Community stub)", count)
 			}
 		})
 	}
@@ -269,13 +269,13 @@ func TestGetActiveNodesByOrg(t *testing.T) {
 
 	nodes, err := GetActiveNodesByOrg(ctx, nil)
 	if err != nil {
-		t.Errorf("GetActiveNodesByOrg() error = %v, want nil (OSS stub)", err)
+		t.Errorf("GetActiveNodesByOrg() error = %v, want nil (Community stub)", err)
 	}
 	if nodes == nil {
 		t.Error("GetActiveNodesByOrg() returned nil, want empty map")
 	}
 	if len(nodes) != 0 {
-		t.Errorf("GetActiveNodesByOrg() returned %d nodes, want 0 (OSS stub)", len(nodes))
+		t.Errorf("GetActiveNodesByOrg() returned %d nodes, want 0 (Community stub)", len(nodes))
 	}
 }
 
@@ -284,7 +284,7 @@ func TestCleanupStaleHeartbeats(t *testing.T) {
 
 	err := CleanupStaleHeartbeats(ctx, nil)
 	if err != nil {
-		t.Errorf("CleanupStaleHeartbeats() error = %v, want nil (OSS no-op)", err)
+		t.Errorf("CleanupStaleHeartbeats() error = %v, want nil (Community no-op)", err)
 	}
 }
 
@@ -309,13 +309,13 @@ func TestGetViolationHistory(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			violations, err := GetViolationHistory(ctx, nil, tt.orgID)
 			if err != nil {
-				t.Errorf("GetViolationHistory() error = %v, want nil (OSS stub)", err)
+				t.Errorf("GetViolationHistory() error = %v, want nil (Community stub)", err)
 			}
 			if violations == nil {
 				t.Error("GetViolationHistory() returned nil, want empty slice")
 			}
 			if len(violations) != 0 {
-				t.Errorf("GetViolationHistory() returned %d violations, want 0 (OSS stub)", len(violations))
+				t.Errorf("GetViolationHistory() returned %d violations, want 0 (Community stub)", len(violations))
 			}
 		})
 	}
@@ -358,7 +358,7 @@ func TestHeartbeatService_ContextCancellation(t *testing.T) {
 	// Should handle cancelled context gracefully
 	err := service.Start(ctx)
 	if err != nil {
-		t.Errorf("Start() with cancelled context error = %v, want nil (OSS no-op)", err)
+		t.Errorf("Start() with cancelled context error = %v, want nil (Community no-op)", err)
 	}
 }
 

--- a/platform/agent/rbi/killswitch_community.go
+++ b/platform/agent/rbi/killswitch_community.go
@@ -18,12 +18,12 @@ import (
 	"database/sql"
 )
 
-// KillSwitchChecker is the OSS stub for kill switch checking.
-// In OSS mode, kill switches are not enforced.
+// KillSwitchChecker is the Community stub for kill switch checking.
+// In Community mode, kill switches are not enforced.
 type KillSwitchChecker struct{}
 
 // NewKillSwitchChecker creates a new kill switch checker.
-// In OSS mode, this returns a no-op implementation.
+// In Community mode, this returns a no-op implementation.
 func NewKillSwitchChecker(_ *sql.DB) *KillSwitchChecker {
 	return &KillSwitchChecker{}
 }
@@ -47,7 +47,7 @@ type KillSwitchCheckResult struct {
 }
 
 // CheckKillSwitch checks if any active kill switch applies to the request.
-// In OSS mode, this always returns not blocked.
+// In Community mode, this always returns not blocked.
 func (k *KillSwitchChecker) CheckKillSwitch(_ context.Context, _, _ string) *KillSwitchCheckResult {
 	return &KillSwitchCheckResult{
 		IsBlocked: false,
@@ -56,13 +56,13 @@ func (k *KillSwitchChecker) CheckKillSwitch(_ context.Context, _, _ string) *Kil
 }
 
 // KillSwitchEnabled returns whether kill switch enforcement is enabled.
-// In OSS mode, this returns false.
+// In Community mode, this returns false.
 func KillSwitchEnabled() bool {
 	return false
 }
 
 // ListActiveKillSwitches returns all active kill switches for an org.
-// In OSS mode, this returns an empty slice.
+// In Community mode, this returns an empty slice.
 func (k *KillSwitchChecker) ListActiveKillSwitches(_ context.Context, _ string) ([]*ActiveKillSwitch, error) {
 	return nil, nil
 }

--- a/platform/agent/rbi/killswitch_community_test.go
+++ b/platform/agent/rbi/killswitch_community_test.go
@@ -18,20 +18,20 @@ import (
 	"testing"
 )
 
-func TestKillSwitchEnabled_OSS(t *testing.T) {
+func TestKillSwitchEnabled_Community(t *testing.T) {
 	if KillSwitchEnabled() {
-		t.Error("Expected KillSwitchEnabled() to return false in OSS mode")
+		t.Error("Expected KillSwitchEnabled() to return false in Community mode")
 	}
 }
 
-func TestNewKillSwitchChecker_OSS(t *testing.T) {
+func TestNewKillSwitchChecker_Community(t *testing.T) {
 	checker := NewKillSwitchChecker(nil)
 	if checker == nil {
 		t.Error("Expected NewKillSwitchChecker to return non-nil checker")
 	}
 }
 
-func TestCheckKillSwitch_OSS(t *testing.T) {
+func TestCheckKillSwitch_Community(t *testing.T) {
 	checker := NewKillSwitchChecker(nil)
 	ctx := context.Background()
 
@@ -41,14 +41,14 @@ func TestCheckKillSwitch_OSS(t *testing.T) {
 		t.Fatal("Expected non-nil result")
 	}
 	if result.IsBlocked {
-		t.Error("Expected OSS stub to return IsBlocked=false")
+		t.Error("Expected Community stub to return IsBlocked=false")
 	}
 	if result.Reason != "" {
 		t.Errorf("Expected empty reason, got %q", result.Reason)
 	}
 }
 
-func TestListActiveKillSwitches_OSS(t *testing.T) {
+func TestListActiveKillSwitches_Community(t *testing.T) {
 	checker := NewKillSwitchChecker(nil)
 	ctx := context.Background()
 

--- a/platform/agent/rls.go
+++ b/platform/agent/rls.go
@@ -243,8 +243,8 @@ func RLSHealthCheck(ctx context.Context, db *sql.DB) error {
 		}
 	}
 
-	// Check if RLS is enabled on critical tables (OSS tables only)
-	// Note: enterprise tables (usage_events, agent_heartbeats) are not in OSS builds
+	// Check if RLS is enabled on critical tables (Community tables only)
+	// Note: enterprise tables (usage_events, agent_heartbeats) are not in Community builds
 	criticalTables := []string{
 		"organizations",
 		"user_sessions",

--- a/platform/agent/rls_test.go
+++ b/platform/agent/rls_test.go
@@ -556,19 +556,19 @@ func TestGetRLSStats(t *testing.T) {
 		t.Fatalf("GetRLSStats() failed: %v", err)
 	}
 
-	// Should have at least 15 tables with RLS enabled (OSS minimum)
+	// Should have at least 15 tables with RLS enabled (Community minimum)
 	// Note: enterprise builds have more tables (24+)
 	if stats.TablesWithRLS < 15 {
-		t.Errorf("TablesWithRLS = %d, want >= 15 (OSS minimum)", stats.TablesWithRLS)
+		t.Errorf("TablesWithRLS = %d, want >= 15 (Community minimum)", stats.TablesWithRLS)
 	}
 
-	// Should have at least 60 policies (OSS minimum: 15 tables * 4 policies each)
+	// Should have at least 60 policies (Community minimum: 15 tables * 4 policies each)
 	// Note: enterprise builds have more policies (68+)
 	if stats.PolicyCount < 60 {
-		t.Errorf("PolicyCount = %d, want >= 60 (OSS minimum)", stats.PolicyCount)
+		t.Errorf("PolicyCount = %d, want >= 60 (Community minimum)", stats.PolicyCount)
 	}
 
-	// Should include critical OSS tables (enterprise tables may not exist)
+	// Should include critical Community tables (enterprise tables may not exist)
 	criticalTables := []string{"organizations", "dynamic_policies", "static_policies"}
 	for _, table := range criticalTables {
 		found := false
@@ -670,7 +670,7 @@ func TestRLSPerformance(t *testing.T) {
 	ctx := context.Background()
 	orgID := "rls-test-perf"
 
-	// Insert test data using dynamic_policies (OSS table, not enterprise-only usage_events)
+	// Insert test data using dynamic_policies (Community table, not enterprise-only usage_events)
 	// Schema: policy_id, name, policy_type, conditions, actions, priority
 	err := WithRLS(ctx, db, orgID, func(db *sql.DB) error {
 		for i := 0; i < 100; i++ {

--- a/platform/agent/run.go
+++ b/platform/agent/run.go
@@ -355,14 +355,14 @@ func Run() {
 
 	// License validation (optional for central agent deployments and self-hosted mode)
 	// Central agents validate CLIENT license keys during request processing
-	// Self-hosted mode skips license validation entirely (for OSS/local development)
+	// Self-hosted mode skips license validation entirely (for Community/local development)
 	// This validation is only needed for customer-deployed agents
 	selfHostedMode := os.Getenv("SELF_HOSTED_MODE") == "true"
 	licenseKey := os.Getenv("AXONFLOW_LICENSE_KEY")
 
 	if selfHostedMode {
 		log.Println("🏠 SELF_HOSTED_MODE enabled - skipping license validation")
-		log.Println("   Perfect for OSS contributors and local development")
+		log.Println("   Perfect for Community contributors and local development")
 	} else {
 		// Validate HMAC secret is properly configured before any license operations
 		// This is required for BOTH:
@@ -869,7 +869,7 @@ func clientRequestHandler(w http.ResponseWriter, r *http.Request) {
 			OrgID:       "self-hosted",
 			TenantID:    req.ClientID,
 			Enabled:     true,
-			LicenseTier: "OSS",
+			LicenseTier: "Community",
 			RateLimit:   0,
 			Permissions: []string{},
 		}

--- a/platform/connectors/amadeus/connector.go
+++ b/platform/connectors/amadeus/connector.go
@@ -10,7 +10,7 @@
 // limitations under the License.
 
 // Package amadeus provides the Amadeus Travel API connector.
-// This is the OSS stub - the full Amadeus connector is an enterprise feature.
+// This is the Community stub - the full Amadeus connector is an enterprise feature.
 package amadeus
 
 import (
@@ -23,33 +23,33 @@ import (
 // ErrEnterpriseFeature is returned when attempting to use enterprise-only features
 var ErrEnterpriseFeature = errors.New("amadeus connector is an enterprise feature - contact sales@getaxonflow.com")
 
-// AmadeusConnector is the OSS stub for the Amadeus Travel API connector.
+// AmadeusConnector is the Community stub for the Amadeus Travel API connector.
 // The full implementation is available in the enterprise edition.
 type AmadeusConnector struct {
 	config *base.ConnectorConfig
 }
 
 // NewAmadeusConnector creates a new Amadeus connector instance.
-// OSS stub: Returns a stub that will error on Connect().
+// Community stub: Returns a stub that will error on Connect().
 func NewAmadeusConnector() *AmadeusConnector {
 	return &AmadeusConnector{}
 }
 
 // Connect establishes a connection to Amadeus API.
-// OSS stub: Always returns ErrEnterpriseFeature.
+// Community stub: Always returns ErrEnterpriseFeature.
 func (c *AmadeusConnector) Connect(ctx context.Context, config *base.ConnectorConfig) error {
 	c.config = config
 	return base.NewConnectorError(config.Name, "Connect", "amadeus connector requires enterprise license", ErrEnterpriseFeature)
 }
 
 // Disconnect closes the connection.
-// OSS stub: No-op.
+// Community stub: No-op.
 func (c *AmadeusConnector) Disconnect(ctx context.Context) error {
 	return nil
 }
 
 // HealthCheck verifies the API is accessible.
-// OSS stub: Returns unhealthy status indicating enterprise feature.
+// Community stub: Returns unhealthy status indicating enterprise feature.
 func (c *AmadeusConnector) HealthCheck(ctx context.Context) (*base.HealthStatus, error) {
 	return &base.HealthStatus{
 		Healthy: false,
@@ -58,13 +58,13 @@ func (c *AmadeusConnector) HealthCheck(ctx context.Context) (*base.HealthStatus,
 }
 
 // Query executes a read operation.
-// OSS stub: Always returns ErrEnterpriseFeature.
+// Community stub: Always returns ErrEnterpriseFeature.
 func (c *AmadeusConnector) Query(ctx context.Context, query *base.Query) (*base.QueryResult, error) {
 	return nil, base.NewConnectorError("amadeus", "Query", "amadeus connector requires enterprise license", ErrEnterpriseFeature)
 }
 
 // Execute executes a write operation.
-// OSS stub: Always returns ErrEnterpriseFeature.
+// Community stub: Always returns ErrEnterpriseFeature.
 func (c *AmadeusConnector) Execute(ctx context.Context, cmd *base.Command) (*base.CommandResult, error) {
 	return nil, base.NewConnectorError("amadeus", "Execute", "amadeus connector requires enterprise license", ErrEnterpriseFeature)
 }
@@ -84,11 +84,11 @@ func (c *AmadeusConnector) Type() string {
 
 // Version returns the connector version.
 func (c *AmadeusConnector) Version() string {
-	return "oss-stub"
+	return "community-stub"
 }
 
 // Capabilities returns the list of capabilities.
-// OSS stub: Returns empty list (no capabilities in OSS mode).
+// Community stub: Returns empty list (no capabilities in Community mode).
 func (c *AmadeusConnector) Capabilities() []string {
 	return []string{}
 }

--- a/platform/connectors/amadeus/connector_test.go
+++ b/platform/connectors/amadeus/connector_test.go
@@ -23,7 +23,7 @@ func TestAmadeusConnector_Connect(t *testing.T) {
 	config := &base.ConnectorConfig{Name: "test", Type: "amadeus"}
 	err := conn.Connect(ctx, config)
 	if err == nil {
-		t.Error("expected error for OSS stub")
+		t.Error("expected error for Community stub")
 	}
 }
 
@@ -44,7 +44,7 @@ func TestAmadeusConnector_HealthCheck(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if status.Healthy {
-		t.Error("expected unhealthy status for OSS stub")
+		t.Error("expected unhealthy status for Community stub")
 	}
 }
 
@@ -54,7 +54,7 @@ func TestAmadeusConnector_Query(t *testing.T) {
 	query := &base.Query{Statement: "query"}
 	_, err := conn.Query(ctx, query)
 	if err == nil {
-		t.Error("expected error for OSS stub")
+		t.Error("expected error for Community stub")
 	}
 }
 
@@ -64,7 +64,7 @@ func TestAmadeusConnector_Execute(t *testing.T) {
 	cmd := &base.Command{Action: "execute"}
 	_, err := conn.Execute(ctx, cmd)
 	if err == nil {
-		t.Error("expected error for OSS stub")
+		t.Error("expected error for Community stub")
 	}
 }
 
@@ -88,8 +88,8 @@ func TestAmadeusConnector_Type(t *testing.T) {
 
 func TestAmadeusConnector_Version(t *testing.T) {
 	conn := NewAmadeusConnector()
-	if got := conn.Version(); got != "oss-stub" {
-		t.Errorf("Version() = %q, want %q", got, "oss-stub")
+	if got := conn.Version(); got != "community-stub" {
+		t.Errorf("Version() = %q, want %q", got, "community-stub")
 	}
 }
 

--- a/platform/connectors/amadeus/doc.go
+++ b/platform/connectors/amadeus/doc.go
@@ -14,13 +14,13 @@ Package amadeus provides the Amadeus Travel API connector for AxonFlow.
 
 # Overview
 
-This is the OSS stub for the Amadeus connector. The full implementation
+This is the Community stub for the Amadeus connector. The full implementation
 with flight search, hotel booking, and travel APIs is available in the
 Enterprise edition.
 
-# OSS Limitations
+# Community Limitations
 
-The OSS version of this connector returns ErrEnterpriseFeature for all
+The Community version of this connector returns ErrEnterpriseFeature for all
 operations. To use the Amadeus connector, upgrade to AxonFlow Enterprise.
 
 # Enterprise Features

--- a/platform/connectors/community/README.md
+++ b/platform/connectors/community/README.md
@@ -4,7 +4,7 @@ This directory contains connectors contributed by the AxonFlow community.
 
 ## Overview
 
-Community connectors extend AxonFlow's MCP (Model Context Protocol) capabilities by integrating with additional external services. These connectors are contributed by the community and maintained alongside the core OSS connectors.
+Community connectors extend AxonFlow's MCP (Model Context Protocol) capabilities by integrating with additional external services. These connectors are contributed by the community and maintained alongside the core Community connectors.
 
 ## Directory Structure
 

--- a/platform/connectors/config/file_loader.go
+++ b/platform/connectors/config/file_loader.go
@@ -294,7 +294,7 @@ func ValidateConfigFile(config *ConfigFile) error {
 // GenerateExampleConfigFile generates an example configuration file
 func GenerateExampleConfigFile() string {
 	return `# AxonFlow Runtime Configuration
-# This file configures MCP connectors and LLM providers for OSS deployments
+# This file configures MCP connectors and LLM providers for Community deployments
 # Environment variables can be referenced using ${VAR_NAME} or ${VAR_NAME:-default} syntax
 
 version: "1.0"

--- a/platform/connectors/config/secrets_manager.go
+++ b/platform/connectors/config/secrets_manager.go
@@ -157,7 +157,7 @@ func maskARN(arn string) string {
 }
 
 // LocalSecretsManager implements SecretsManager using local environment variables
-// Useful for development and OSS deployments without AWS Secrets Manager
+// Useful for development and Community deployments without AWS Secrets Manager
 type LocalSecretsManager struct {
 	secrets map[string]map[string]string
 	mu      sync.RWMutex

--- a/platform/connectors/salesforce/connector.go
+++ b/platform/connectors/salesforce/connector.go
@@ -10,7 +10,7 @@
 // limitations under the License.
 
 // Package salesforce provides the Salesforce CRM connector.
-// This is the OSS stub - the full Salesforce connector is an enterprise feature.
+// This is the Community stub - the full Salesforce connector is an enterprise feature.
 package salesforce
 
 import (
@@ -23,33 +23,33 @@ import (
 // ErrEnterpriseFeature is returned when attempting to use enterprise-only features
 var ErrEnterpriseFeature = errors.New("salesforce connector is an enterprise feature - contact sales@getaxonflow.com")
 
-// SalesforceConnector is the OSS stub for the Salesforce CRM connector.
+// SalesforceConnector is the Community stub for the Salesforce CRM connector.
 // The full implementation is available in the enterprise edition.
 type SalesforceConnector struct {
 	config *base.ConnectorConfig
 }
 
 // NewSalesforceConnector creates a new Salesforce connector instance.
-// OSS stub: Returns a stub that will error on Connect().
+// Community stub: Returns a stub that will error on Connect().
 func NewSalesforceConnector() *SalesforceConnector {
 	return &SalesforceConnector{}
 }
 
 // Connect establishes a connection to Salesforce API.
-// OSS stub: Always returns ErrEnterpriseFeature.
+// Community stub: Always returns ErrEnterpriseFeature.
 func (c *SalesforceConnector) Connect(ctx context.Context, config *base.ConnectorConfig) error {
 	c.config = config
 	return base.NewConnectorError(config.Name, "Connect", "salesforce connector requires enterprise license", ErrEnterpriseFeature)
 }
 
 // Disconnect closes the connection.
-// OSS stub: No-op.
+// Community stub: No-op.
 func (c *SalesforceConnector) Disconnect(ctx context.Context) error {
 	return nil
 }
 
 // HealthCheck verifies the API is accessible.
-// OSS stub: Returns unhealthy status indicating enterprise feature.
+// Community stub: Returns unhealthy status indicating enterprise feature.
 func (c *SalesforceConnector) HealthCheck(ctx context.Context) (*base.HealthStatus, error) {
 	return &base.HealthStatus{
 		Healthy: false,
@@ -58,13 +58,13 @@ func (c *SalesforceConnector) HealthCheck(ctx context.Context) (*base.HealthStat
 }
 
 // Query executes a read operation (SOQL query).
-// OSS stub: Always returns ErrEnterpriseFeature.
+// Community stub: Always returns ErrEnterpriseFeature.
 func (c *SalesforceConnector) Query(ctx context.Context, query *base.Query) (*base.QueryResult, error) {
 	return nil, base.NewConnectorError("salesforce", "Query", "salesforce connector requires enterprise license", ErrEnterpriseFeature)
 }
 
 // Execute executes a write operation (create/update/delete).
-// OSS stub: Always returns ErrEnterpriseFeature.
+// Community stub: Always returns ErrEnterpriseFeature.
 func (c *SalesforceConnector) Execute(ctx context.Context, cmd *base.Command) (*base.CommandResult, error) {
 	return nil, base.NewConnectorError("salesforce", "Execute", "salesforce connector requires enterprise license", ErrEnterpriseFeature)
 }
@@ -84,11 +84,11 @@ func (c *SalesforceConnector) Type() string {
 
 // Version returns the connector version.
 func (c *SalesforceConnector) Version() string {
-	return "oss-stub"
+	return "community-stub"
 }
 
 // Capabilities returns the list of capabilities.
-// OSS stub: Returns empty list (no capabilities in OSS mode).
+// Community stub: Returns empty list (no capabilities in Community mode).
 func (c *SalesforceConnector) Capabilities() []string {
 	return []string{}
 }

--- a/platform/connectors/salesforce/connector_test.go
+++ b/platform/connectors/salesforce/connector_test.go
@@ -23,7 +23,7 @@ func TestSalesforceConnector_Connect(t *testing.T) {
 	config := &base.ConnectorConfig{Name: "test", Type: "salesforce"}
 	err := conn.Connect(ctx, config)
 	if err == nil {
-		t.Error("expected error for OSS stub")
+		t.Error("expected error for Community stub")
 	}
 }
 
@@ -44,7 +44,7 @@ func TestSalesforceConnector_HealthCheck(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if status.Healthy {
-		t.Error("expected unhealthy status for OSS stub")
+		t.Error("expected unhealthy status for Community stub")
 	}
 }
 
@@ -54,7 +54,7 @@ func TestSalesforceConnector_Query(t *testing.T) {
 	query := &base.Query{Statement: "query"}
 	_, err := conn.Query(ctx, query)
 	if err == nil {
-		t.Error("expected error for OSS stub")
+		t.Error("expected error for Community stub")
 	}
 }
 
@@ -64,7 +64,7 @@ func TestSalesforceConnector_Execute(t *testing.T) {
 	cmd := &base.Command{Action: "execute"}
 	_, err := conn.Execute(ctx, cmd)
 	if err == nil {
-		t.Error("expected error for OSS stub")
+		t.Error("expected error for Community stub")
 	}
 }
 
@@ -88,8 +88,8 @@ func TestSalesforceConnector_Type(t *testing.T) {
 
 func TestSalesforceConnector_Version(t *testing.T) {
 	conn := NewSalesforceConnector()
-	if got := conn.Version(); got != "oss-stub" {
-		t.Errorf("Version() = %q, want %q", got, "oss-stub")
+	if got := conn.Version(); got != "community-stub" {
+		t.Errorf("Version() = %q, want %q", got, "community-stub")
 	}
 }
 

--- a/platform/connectors/sdk/README.md
+++ b/platform/connectors/sdk/README.md
@@ -169,7 +169,7 @@ results := benchHarness.BenchmarkQuery(b, &base.Query{Statement: "SELECT 1"})
 
 ## Available Connectors
 
-### OSS Connectors (platform/connectors/)
+### Community Connectors (platform/connectors/)
 
 | Connector | Type | Description |
 |-----------|------|-------------|
@@ -197,7 +197,7 @@ results := benchHarness.BenchmarkQuery(b, &base.Query{Statement: "SELECT 1"})
 
 ## Creating a New Connector
 
-1. Create a new package under `platform/connectors/` (OSS) or `ee/platform/connectors/` (Enterprise)
+1. Create a new package under `platform/connectors/` (Community) or `ee/platform/connectors/` (Enterprise)
 
 2. Implement the `base.Connector` interface:
 

--- a/platform/connectors/slack/connector.go
+++ b/platform/connectors/slack/connector.go
@@ -10,7 +10,7 @@
 // limitations under the License.
 
 // Package slack provides the Slack messaging connector.
-// This is the OSS stub - the full Slack connector is an enterprise feature.
+// This is the Community stub - the full Slack connector is an enterprise feature.
 package slack
 
 import (
@@ -23,33 +23,33 @@ import (
 // ErrEnterpriseFeature is returned when attempting to use enterprise-only features
 var ErrEnterpriseFeature = errors.New("slack connector is an enterprise feature - contact sales@getaxonflow.com")
 
-// SlackConnector is the OSS stub for the Slack messaging connector.
+// SlackConnector is the Community stub for the Slack messaging connector.
 // The full implementation is available in the enterprise edition.
 type SlackConnector struct {
 	config *base.ConnectorConfig
 }
 
 // NewSlackConnector creates a new Slack connector instance.
-// OSS stub: Returns a stub that will error on Connect().
+// Community stub: Returns a stub that will error on Connect().
 func NewSlackConnector() *SlackConnector {
 	return &SlackConnector{}
 }
 
 // Connect establishes a connection to Slack API.
-// OSS stub: Always returns ErrEnterpriseFeature.
+// Community stub: Always returns ErrEnterpriseFeature.
 func (c *SlackConnector) Connect(ctx context.Context, config *base.ConnectorConfig) error {
 	c.config = config
 	return base.NewConnectorError(config.Name, "Connect", "slack connector requires enterprise license", ErrEnterpriseFeature)
 }
 
 // Disconnect closes the connection.
-// OSS stub: No-op.
+// Community stub: No-op.
 func (c *SlackConnector) Disconnect(ctx context.Context) error {
 	return nil
 }
 
 // HealthCheck verifies the API is accessible.
-// OSS stub: Returns unhealthy status indicating enterprise feature.
+// Community stub: Returns unhealthy status indicating enterprise feature.
 func (c *SlackConnector) HealthCheck(ctx context.Context) (*base.HealthStatus, error) {
 	return &base.HealthStatus{
 		Healthy: false,
@@ -58,13 +58,13 @@ func (c *SlackConnector) HealthCheck(ctx context.Context) (*base.HealthStatus, e
 }
 
 // Query executes a read operation (list channels, users, messages).
-// OSS stub: Always returns ErrEnterpriseFeature.
+// Community stub: Always returns ErrEnterpriseFeature.
 func (c *SlackConnector) Query(ctx context.Context, query *base.Query) (*base.QueryResult, error) {
 	return nil, base.NewConnectorError("slack", "Query", "slack connector requires enterprise license", ErrEnterpriseFeature)
 }
 
 // Execute executes a write operation (send message, create channel).
-// OSS stub: Always returns ErrEnterpriseFeature.
+// Community stub: Always returns ErrEnterpriseFeature.
 func (c *SlackConnector) Execute(ctx context.Context, cmd *base.Command) (*base.CommandResult, error) {
 	return nil, base.NewConnectorError("slack", "Execute", "slack connector requires enterprise license", ErrEnterpriseFeature)
 }
@@ -84,11 +84,11 @@ func (c *SlackConnector) Type() string {
 
 // Version returns the connector version.
 func (c *SlackConnector) Version() string {
-	return "oss-stub"
+	return "community-stub"
 }
 
 // Capabilities returns the list of capabilities.
-// OSS stub: Returns empty list (no capabilities in OSS mode).
+// Community stub: Returns empty list (no capabilities in Community mode).
 func (c *SlackConnector) Capabilities() []string {
 	return []string{}
 }

--- a/platform/connectors/slack/connector_test.go
+++ b/platform/connectors/slack/connector_test.go
@@ -35,7 +35,7 @@ func TestSlackConnector_Connect(t *testing.T) {
 
 	err := conn.Connect(ctx, config)
 	if err == nil {
-		t.Error("expected error for OSS stub")
+		t.Error("expected error for Community stub")
 	}
 }
 
@@ -58,7 +58,7 @@ func TestSlackConnector_HealthCheck(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if status.Healthy {
-		t.Error("expected unhealthy status for OSS stub")
+		t.Error("expected unhealthy status for Community stub")
 	}
 }
 
@@ -69,7 +69,7 @@ func TestSlackConnector_Query(t *testing.T) {
 
 	_, err := conn.Query(ctx, query)
 	if err == nil {
-		t.Error("expected error for OSS stub")
+		t.Error("expected error for Community stub")
 	}
 }
 
@@ -80,7 +80,7 @@ func TestSlackConnector_Execute(t *testing.T) {
 
 	_, err := conn.Execute(ctx, cmd)
 	if err == nil {
-		t.Error("expected error for OSS stub")
+		t.Error("expected error for Community stub")
 	}
 }
 
@@ -108,8 +108,8 @@ func TestSlackConnector_Type(t *testing.T) {
 
 func TestSlackConnector_Version(t *testing.T) {
 	conn := NewSlackConnector()
-	if got := conn.Version(); got != "oss-stub" {
-		t.Errorf("Version() = %q, want %q", got, "oss-stub")
+	if got := conn.Version(); got != "community-stub" {
+		t.Errorf("Version() = %q, want %q", got, "community-stub")
 	}
 }
 
@@ -117,6 +117,6 @@ func TestSlackConnector_Capabilities(t *testing.T) {
 	conn := NewSlackConnector()
 	caps := conn.Capabilities()
 	if len(caps) != 0 {
-		t.Errorf("expected empty capabilities for OSS stub, got %v", caps)
+		t.Errorf("expected empty capabilities for Community stub, got %v", caps)
 	}
 }

--- a/platform/connectors/snowflake/connector.go
+++ b/platform/connectors/snowflake/connector.go
@@ -10,7 +10,7 @@
 // limitations under the License.
 
 // Package snowflake provides the Snowflake data warehouse connector.
-// This is the OSS stub - the full Snowflake connector is an enterprise feature.
+// This is the Community stub - the full Snowflake connector is an enterprise feature.
 package snowflake
 
 import (
@@ -23,33 +23,33 @@ import (
 // ErrEnterpriseFeature is returned when attempting to use enterprise-only features
 var ErrEnterpriseFeature = errors.New("snowflake connector is an enterprise feature - contact sales@getaxonflow.com")
 
-// SnowflakeConnector is the OSS stub for the Snowflake data warehouse connector.
+// SnowflakeConnector is the Community stub for the Snowflake data warehouse connector.
 // The full implementation is available in the enterprise edition.
 type SnowflakeConnector struct {
 	config *base.ConnectorConfig
 }
 
 // NewSnowflakeConnector creates a new Snowflake connector instance.
-// OSS stub: Returns a stub that will error on Connect().
+// Community stub: Returns a stub that will error on Connect().
 func NewSnowflakeConnector() *SnowflakeConnector {
 	return &SnowflakeConnector{}
 }
 
 // Connect establishes a connection to Snowflake.
-// OSS stub: Always returns ErrEnterpriseFeature.
+// Community stub: Always returns ErrEnterpriseFeature.
 func (c *SnowflakeConnector) Connect(ctx context.Context, config *base.ConnectorConfig) error {
 	c.config = config
 	return base.NewConnectorError(config.Name, "Connect", "snowflake connector requires enterprise license", ErrEnterpriseFeature)
 }
 
 // Disconnect closes the connection.
-// OSS stub: No-op.
+// Community stub: No-op.
 func (c *SnowflakeConnector) Disconnect(ctx context.Context) error {
 	return nil
 }
 
 // HealthCheck verifies the connection is valid.
-// OSS stub: Returns unhealthy status indicating enterprise feature.
+// Community stub: Returns unhealthy status indicating enterprise feature.
 func (c *SnowflakeConnector) HealthCheck(ctx context.Context) (*base.HealthStatus, error) {
 	return &base.HealthStatus{
 		Healthy: false,
@@ -58,13 +58,13 @@ func (c *SnowflakeConnector) HealthCheck(ctx context.Context) (*base.HealthStatu
 }
 
 // Query executes a SQL query against Snowflake.
-// OSS stub: Always returns ErrEnterpriseFeature.
+// Community stub: Always returns ErrEnterpriseFeature.
 func (c *SnowflakeConnector) Query(ctx context.Context, query *base.Query) (*base.QueryResult, error) {
 	return nil, base.NewConnectorError("snowflake", "Query", "snowflake connector requires enterprise license", ErrEnterpriseFeature)
 }
 
 // Execute executes a SQL statement (INSERT, UPDATE, DELETE).
-// OSS stub: Always returns ErrEnterpriseFeature.
+// Community stub: Always returns ErrEnterpriseFeature.
 func (c *SnowflakeConnector) Execute(ctx context.Context, cmd *base.Command) (*base.CommandResult, error) {
 	return nil, base.NewConnectorError("snowflake", "Execute", "snowflake connector requires enterprise license", ErrEnterpriseFeature)
 }
@@ -84,11 +84,11 @@ func (c *SnowflakeConnector) Type() string {
 
 // Version returns the connector version.
 func (c *SnowflakeConnector) Version() string {
-	return "oss-stub"
+	return "community-stub"
 }
 
 // Capabilities returns the list of capabilities.
-// OSS stub: Returns empty list (no capabilities in OSS mode).
+// Community stub: Returns empty list (no capabilities in Community mode).
 func (c *SnowflakeConnector) Capabilities() []string {
 	return []string{}
 }

--- a/platform/connectors/snowflake/connector_test.go
+++ b/platform/connectors/snowflake/connector_test.go
@@ -23,7 +23,7 @@ func TestSnowflakeConnector_Connect(t *testing.T) {
 	config := &base.ConnectorConfig{Name: "test", Type: "snowflake"}
 	err := conn.Connect(ctx, config)
 	if err == nil {
-		t.Error("expected error for OSS stub")
+		t.Error("expected error for Community stub")
 	}
 }
 
@@ -44,7 +44,7 @@ func TestSnowflakeConnector_HealthCheck(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if status.Healthy {
-		t.Error("expected unhealthy status for OSS stub")
+		t.Error("expected unhealthy status for Community stub")
 	}
 }
 
@@ -54,7 +54,7 @@ func TestSnowflakeConnector_Query(t *testing.T) {
 	query := &base.Query{Statement: "query"}
 	_, err := conn.Query(ctx, query)
 	if err == nil {
-		t.Error("expected error for OSS stub")
+		t.Error("expected error for Community stub")
 	}
 }
 
@@ -64,7 +64,7 @@ func TestSnowflakeConnector_Execute(t *testing.T) {
 	cmd := &base.Command{Action: "execute"}
 	_, err := conn.Execute(ctx, cmd)
 	if err == nil {
-		t.Error("expected error for OSS stub")
+		t.Error("expected error for Community stub")
 	}
 }
 
@@ -88,8 +88,8 @@ func TestSnowflakeConnector_Type(t *testing.T) {
 
 func TestSnowflakeConnector_Version(t *testing.T) {
 	conn := NewSnowflakeConnector()
-	if got := conn.Version(); got != "oss-stub" {
-		t.Errorf("Version() = %q, want %q", got, "oss-stub")
+	if got := conn.Version(); got != "community-stub" {
+		t.Errorf("Version() = %q, want %q", got, "community-stub")
 	}
 }
 

--- a/platform/orchestrator/agents_api_handler.go
+++ b/platform/orchestrator/agents_api_handler.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 )
 
-// AgentsAPIHandler handles HTTP requests for agent management (OSS read-only endpoints).
+// AgentsAPIHandler handles HTTP requests for agent management (Community read-only endpoints).
 // This handler provides read access to agents registered in the AgentRegistry.
 type AgentsAPIHandler struct {
 	registry *AgentRegistry
@@ -33,7 +33,7 @@ func NewAgentsAPIHandler(registry *AgentRegistry) *AgentsAPIHandler {
 }
 
 // RegisterRoutes registers agent API routes with the provided mux.
-// OSS Distribution: Read-only endpoints
+// Community Distribution: Read-only endpoints
 //   - GET /api/v1/agents - List all agents
 //   - GET /api/v1/agents/{id} - Get agent by ID
 //   - GET /api/v1/agents/domain/{domain} - List agents by domain

--- a/platform/orchestrator/agents_api_types.go
+++ b/platform/orchestrator/agents_api_types.go
@@ -30,7 +30,7 @@ type AgentResource struct {
 	UpdatedAt   *time.Time       `json:"updated_at,omitempty"`
 }
 
-// AgentListResponse for paginated list of agents (OSS).
+// AgentListResponse for paginated list of agents (Community).
 type AgentListResponse struct {
 	Agents     []AgentResource       `json:"agents"`
 	Pagination AgentPaginationMeta   `json:"pagination"`
@@ -58,7 +58,7 @@ type ListAgentsParams struct {
 	PageSize int    `json:"page_size"`
 }
 
-// ValidateAgentConfigRequest for POST /api/v1/agents/validate (OSS).
+// ValidateAgentConfigRequest for POST /api/v1/agents/validate (Community).
 type ValidateAgentConfigRequest struct {
 	Config AgentConfigSpec `json:"config"`
 	Domain string          `json:"domain,omitempty"`
@@ -90,7 +90,7 @@ type AgentAPIErrorDetail struct {
 	Details []AgentValidationError `json:"details,omitempty"`
 }
 
-// AgentsServicer defines the interface for agent read operations (OSS).
+// AgentsServicer defines the interface for agent read operations (Community).
 // This is a subset of the full enterprise service, providing read-only access.
 type AgentsServicer interface {
 	// ListAgents returns agents from the registry with optional filtering

--- a/platform/orchestrator/llm/bootstrap_test.go
+++ b/platform/orchestrator/llm/bootstrap_test.go
@@ -165,7 +165,7 @@ func TestBootstrapFromEnv(t *testing.T) {
 		// Clear other providers
 		env.Unset(EnvBedrockRegion)
 
-		// Set all OSS providers
+		// Set all Community providers
 		env.Set(EnvAnthropicAPIKey, "test-anthropic-key")
 		env.Set(EnvOpenAIAPIKey, "test-openai-key")
 		env.Set(EnvOllamaEndpoint, "http://localhost:11434")
@@ -220,7 +220,7 @@ func TestBootstrapFromEnv(t *testing.T) {
 		env := newTestEnvHelper(t)
 		defer env.Restore()
 
-		// Set all OSS providers
+		// Set all Community providers
 		env.Set(EnvAnthropicAPIKey, "test-anthropic-key")
 		env.Set(EnvOpenAIAPIKey, "test-openai-key")
 		env.Set(EnvOllamaEndpoint, "http://localhost:11434")
@@ -251,7 +251,7 @@ func TestBootstrapFromEnv(t *testing.T) {
 		env := newTestEnvHelper(t)
 		defer env.Restore()
 
-		// Set all OSS providers
+		// Set all Community providers
 		env.Set(EnvAnthropicAPIKey, "test-anthropic-key")
 		env.Set(EnvOpenAIAPIKey, "test-openai-key")
 		env.Set(EnvOllamaEndpoint, "http://localhost:11434")

--- a/platform/orchestrator/llm/doc.go
+++ b/platform/orchestrator/llm/doc.go
@@ -15,7 +15,7 @@ Package llm provides a unified interface and types for LLM (Large Language Model
 # Overview
 
 This package defines the common abstractions used across all LLM integrations in AxonFlow.
-It enables pluggable provider implementations that work consistently in both OSS and
+It enables pluggable provider implementations that work consistently in both Community and
 Enterprise editions.
 
 # Provider Interface

--- a/platform/orchestrator/llm/gemini/provider.go
+++ b/platform/orchestrator/llm/gemini/provider.go
@@ -1,0 +1,641 @@
+// Copyright 2025 AxonFlow
+// SPDX-License-Identifier: BUSL-1.1
+
+// Package gemini provides an LLM provider implementation for Google's Gemini models.
+// It supports Gemini 1.5 Pro, Gemini 1.5 Flash, and other Gemini models
+// with both streaming and non-streaming completion modes.
+package gemini
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	// DefaultBaseURL is the default Gemini API endpoint.
+	DefaultBaseURL = "https://generativelanguage.googleapis.com"
+
+	// DefaultAPIVersion is the Gemini API version.
+	DefaultAPIVersion = "v1beta"
+
+	// DefaultTimeout is the default HTTP timeout.
+	DefaultTimeout = 120 * time.Second
+
+	// DefaultMaxTokens is the default max output tokens for completions.
+	DefaultMaxTokens = 4096
+
+	// DefaultTemperature is the default temperature for completions.
+	DefaultTemperature = 0.7
+)
+
+// Model constants for supported Gemini models.
+const (
+	// Gemini 2.5 models (latest)
+	ModelGemini25Flash = "gemini-2.5-flash"
+	ModelGemini25Pro   = "gemini-2.5-pro"
+
+	// Gemini 2.0 models
+	ModelGemini2Flash     = "gemini-2.0-flash"
+	ModelGemini2FlashLite = "gemini-2.0-flash-lite"
+
+	// Gemini 1.5 models (legacy, may not be available in all regions)
+	ModelGemini15Pro      = "gemini-1.5-pro"
+	ModelGemini15Flash    = "gemini-1.5-flash"
+	ModelGemini15Flash8B  = "gemini-1.5-flash-8b"
+
+	// Gemini 1.0 models (legacy)
+	ModelGemini10Pro = "gemini-1.0-pro"
+
+	// Default model - use latest Flash for best availability
+	DefaultModel = ModelGemini2Flash
+)
+
+// HTTPClient is an interface for HTTP client operations (enables testing).
+type HTTPClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// Provider implements the LLM provider interface for Google Gemini.
+type Provider struct {
+	apiKey     string
+	baseURL    string
+	apiVersion string
+	model      string
+	timeout    time.Duration
+	client     HTTPClient
+	healthy    bool
+	mu         sync.RWMutex
+}
+
+// Config contains configuration for the Gemini provider.
+type Config struct {
+	APIKey     string        // Required: Google API key
+	BaseURL    string        // Optional: API base URL (default: https://generativelanguage.googleapis.com)
+	APIVersion string        // Optional: API version (default: v1beta)
+	Model      string        // Optional: Default model (default: gemini-1.5-pro)
+	Timeout    time.Duration // Optional: HTTP timeout (default: 120s)
+}
+
+// CompletionRequest represents a completion request to Gemini.
+type CompletionRequest struct {
+	Prompt        string   // The prompt/user message
+	SystemPrompt  string   // Optional system instruction
+	MaxTokens     int      // Maximum tokens to generate
+	Temperature   float64  // Temperature (0.0-2.0)
+	TopP          float64  // Top-p sampling (0.0-1.0)
+	TopK          int      // Top-k sampling
+	Model         string   // Model override
+	StopSequences []string // Stop sequences
+	Stream        bool     // Enable streaming
+}
+
+// CompletionResponse represents a completion response from Gemini.
+type CompletionResponse struct {
+	Content      string
+	Model        string
+	StopReason   string
+	Usage        UsageStats
+	Latency      time.Duration
+}
+
+// UsageStats contains token usage statistics.
+type UsageStats struct {
+	InputTokens  int
+	OutputTokens int
+	TotalTokens  int
+}
+
+// StreamChunk represents a single chunk in a streaming response.
+type StreamChunk struct {
+	Type    string // "content", "done", "error"
+	Content string // The text content
+	Done    bool   // Whether this is the final chunk
+}
+
+// StreamHandler is a callback function for handling stream chunks.
+type StreamHandler func(chunk StreamChunk) error
+
+// NewProvider creates a new Gemini provider instance.
+func NewProvider(cfg Config) (*Provider, error) {
+	if cfg.APIKey == "" {
+		return nil, fmt.Errorf("gemini API key is required")
+	}
+
+	if cfg.BaseURL == "" {
+		cfg.BaseURL = DefaultBaseURL
+	}
+
+	if cfg.APIVersion == "" {
+		cfg.APIVersion = DefaultAPIVersion
+	}
+
+	if cfg.Model == "" {
+		cfg.Model = DefaultModel
+	}
+
+	if cfg.Timeout == 0 {
+		cfg.Timeout = DefaultTimeout
+	}
+
+	return &Provider{
+		apiKey:     cfg.APIKey,
+		baseURL:    cfg.BaseURL,
+		apiVersion: cfg.APIVersion,
+		model:      cfg.Model,
+		timeout:    cfg.Timeout,
+		client:     &http.Client{Timeout: cfg.Timeout},
+		healthy:    true,
+	}, nil
+}
+
+// Name returns the provider name.
+func (p *Provider) Name() string {
+	return "gemini"
+}
+
+// SupportsStreaming indicates if the provider supports streaming.
+func (p *Provider) SupportsStreaming() bool {
+	return true
+}
+
+// GetCapabilities returns the provider's capabilities.
+func (p *Provider) GetCapabilities() []string {
+	return []string{
+		"reasoning",
+		"analysis",
+		"writing",
+		"code_generation",
+		"long_context",
+		"vision",
+		"streaming",
+		"function_calling",
+	}
+}
+
+// IsHealthy returns whether the provider is healthy.
+func (p *Provider) IsHealthy() bool {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.healthy && p.apiKey != ""
+}
+
+// setHealthy updates the provider health status.
+func (p *Provider) setHealthy(healthy bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.healthy = healthy
+}
+
+// EstimateCost estimates the cost for a given number of tokens.
+// Pricing based on Gemini 1.5 Pro: $1.25/1M input, $5/1M output (up to 128K context).
+// Using average estimate: $0.000003125 per token.
+func (p *Provider) EstimateCost(tokens int) float64 {
+	return float64(tokens) * 0.000003125
+}
+
+// Complete generates a completion for the given request.
+func (p *Provider) Complete(ctx context.Context, req CompletionRequest) (*CompletionResponse, error) {
+	start := time.Now()
+
+	// Build request
+	model := req.Model
+	if model == "" {
+		model = p.model
+	}
+
+	maxTokens := req.MaxTokens
+	if maxTokens <= 0 {
+		maxTokens = DefaultMaxTokens
+	}
+
+	// Temperature: 0.0 is valid (deterministic), negative is invalid
+	temperature := req.Temperature
+	if temperature < 0 {
+		temperature = DefaultTemperature
+	}
+
+	// Build API request body
+	apiReq := p.buildAPIRequest(req.Prompt, req.SystemPrompt, maxTokens, temperature, req.TopP, req.TopK, req.StopSequences)
+
+	// Marshal request
+	reqBody, err := json.Marshal(apiReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	// Build URL
+	url := fmt.Sprintf("%s/%s/models/%s:generateContent?key=%s",
+		p.baseURL, p.apiVersion, model, p.apiKey)
+
+	// Create HTTP request
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(reqBody))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	// Set headers
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	// Execute request
+	resp, err := p.client.Do(httpReq)
+	if err != nil {
+		p.setHealthy(false)
+		return nil, fmt.Errorf("gemini API error: %w", err)
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	// Check status code
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		if resp.StatusCode >= 500 {
+			p.setHealthy(false)
+		}
+		return nil, p.parseAPIError(resp.StatusCode, body)
+	}
+
+	p.setHealthy(true)
+
+	// Parse response
+	var apiResp geminiResponse
+	if err := json.NewDecoder(resp.Body).Decode(&apiResp); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	// Extract content
+	content := ""
+	if len(apiResp.Candidates) > 0 && len(apiResp.Candidates[0].Content.Parts) > 0 {
+		content = apiResp.Candidates[0].Content.Parts[0].Text
+	}
+
+	// Determine stop reason
+	stopReason := "unknown"
+	if len(apiResp.Candidates) > 0 {
+		stopReason = mapFinishReason(apiResp.Candidates[0].FinishReason)
+	}
+
+	// Extract usage
+	inputTokens := 0
+	outputTokens := 0
+	if apiResp.UsageMetadata != nil {
+		inputTokens = apiResp.UsageMetadata.PromptTokenCount
+		outputTokens = apiResp.UsageMetadata.CandidatesTokenCount
+	}
+
+	return &CompletionResponse{
+		Content:    content,
+		Model:      model,
+		StopReason: stopReason,
+		Usage: UsageStats{
+			InputTokens:  inputTokens,
+			OutputTokens: outputTokens,
+			TotalTokens:  inputTokens + outputTokens,
+		},
+		Latency: time.Since(start),
+	}, nil
+}
+
+// CompleteStream generates a streaming completion for the given request.
+func (p *Provider) CompleteStream(ctx context.Context, req CompletionRequest, handler StreamHandler) (*CompletionResponse, error) {
+	start := time.Now()
+
+	// Build request
+	model := req.Model
+	if model == "" {
+		model = p.model
+	}
+
+	maxTokens := req.MaxTokens
+	if maxTokens <= 0 {
+		maxTokens = DefaultMaxTokens
+	}
+
+	// Temperature: 0.0 is valid (deterministic), negative is invalid
+	temperature := req.Temperature
+	if temperature < 0 {
+		temperature = DefaultTemperature
+	}
+
+	// Build API request body
+	apiReq := p.buildAPIRequest(req.Prompt, req.SystemPrompt, maxTokens, temperature, req.TopP, req.TopK, req.StopSequences)
+
+	// Marshal request
+	reqBody, err := json.Marshal(apiReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	// Build URL for streaming endpoint
+	url := fmt.Sprintf("%s/%s/models/%s:streamGenerateContent?alt=sse&key=%s",
+		p.baseURL, p.apiVersion, model, p.apiKey)
+
+	// Create HTTP request
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(reqBody))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	// Set headers
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Accept", "text/event-stream")
+
+	// Execute request
+	resp, err := p.client.Do(httpReq)
+	if err != nil {
+		p.setHealthy(false)
+		return nil, fmt.Errorf("gemini API error: %w", err)
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	// Check status code
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		if resp.StatusCode >= 500 {
+			p.setHealthy(false)
+		}
+		return nil, p.parseAPIError(resp.StatusCode, body)
+	}
+
+	p.setHealthy(true)
+
+	// Process SSE stream
+	return p.processStream(resp.Body, handler, start, model)
+}
+
+// buildAPIRequest builds the Gemini API request body.
+func (p *Provider) buildAPIRequest(prompt, systemPrompt string, maxTokens int, temperature, topP float64, topK int, stopSequences []string) map[string]any {
+	// Build contents
+	contents := []map[string]any{
+		{
+			"role": "user",
+			"parts": []map[string]any{
+				{"text": prompt},
+			},
+		},
+	}
+
+	// Build generation config
+	generationConfig := map[string]any{
+		"maxOutputTokens": maxTokens,
+		"temperature":     temperature,
+	}
+
+	if topP > 0 {
+		generationConfig["topP"] = topP
+	}
+
+	if topK > 0 {
+		generationConfig["topK"] = topK
+	}
+
+	if len(stopSequences) > 0 {
+		generationConfig["stopSequences"] = stopSequences
+	}
+
+	apiReq := map[string]any{
+		"contents":         contents,
+		"generationConfig": generationConfig,
+	}
+
+	// Add system instruction if provided
+	if systemPrompt != "" {
+		apiReq["systemInstruction"] = map[string]any{
+			"parts": []map[string]any{
+				{"text": systemPrompt},
+			},
+		}
+	}
+
+	return apiReq
+}
+
+// processStream processes the SSE stream from Gemini.
+func (p *Provider) processStream(body io.Reader, handler StreamHandler, start time.Time, model string) (*CompletionResponse, error) {
+	scanner := bufio.NewScanner(body)
+	var contentBuilder strings.Builder
+	var stopReason string
+	var inputTokens, outputTokens int
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		// Skip empty lines
+		if line == "" {
+			continue
+		}
+
+		// Parse SSE event
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+
+		data := strings.TrimPrefix(line, "data: ")
+
+		// Parse event data
+		var event geminiResponse
+		if err := json.Unmarshal([]byte(data), &event); err != nil {
+			continue // Skip malformed events
+		}
+
+		// Extract content from candidates
+		if len(event.Candidates) > 0 {
+			candidate := event.Candidates[0]
+
+			// Extract text content
+			if len(candidate.Content.Parts) > 0 {
+				text := candidate.Content.Parts[0].Text
+				if text != "" {
+					contentBuilder.WriteString(text)
+					if handler != nil {
+						if err := handler(StreamChunk{
+							Type:    "content",
+							Content: text,
+							Done:    false,
+						}); err != nil {
+							return nil, fmt.Errorf("handler error: %w", err)
+						}
+					}
+				}
+			}
+
+			// Check for finish reason
+			if candidate.FinishReason != "" {
+				stopReason = mapFinishReason(candidate.FinishReason)
+			}
+		}
+
+		// Extract usage metadata
+		if event.UsageMetadata != nil {
+			inputTokens = event.UsageMetadata.PromptTokenCount
+			outputTokens = event.UsageMetadata.CandidatesTokenCount
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("stream read error: %w", err)
+	}
+
+	// Send final done chunk
+	if handler != nil {
+		if err := handler(StreamChunk{Type: "done", Done: true}); err != nil {
+			return nil, fmt.Errorf("handler error: %w", err)
+		}
+	}
+
+	return &CompletionResponse{
+		Content:    contentBuilder.String(),
+		Model:      model,
+		StopReason: stopReason,
+		Usage: UsageStats{
+			InputTokens:  inputTokens,
+			OutputTokens: outputTokens,
+			TotalTokens:  inputTokens + outputTokens,
+		},
+		Latency: time.Since(start),
+	}, nil
+}
+
+// parseAPIError parses an API error response.
+func (p *Provider) parseAPIError(statusCode int, body []byte) error {
+	var errResp struct {
+		Error struct {
+			Code    int    `json:"code"`
+			Message string `json:"message"`
+			Status  string `json:"status"`
+		} `json:"error"`
+	}
+
+	if err := json.Unmarshal(body, &errResp); err != nil {
+		return fmt.Errorf("gemini API error (status %d): %s", statusCode, string(body))
+	}
+
+	return &APIError{
+		StatusCode: statusCode,
+		Code:       errResp.Error.Code,
+		Status:     errResp.Error.Status,
+		Message:    errResp.Error.Message,
+	}
+}
+
+// mapFinishReason maps Gemini finish reasons to standard reasons.
+func mapFinishReason(reason string) string {
+	switch reason {
+	case "STOP":
+		return "stop"
+	case "MAX_TOKENS":
+		return "max_tokens"
+	case "SAFETY":
+		return "content_filter"
+	case "RECITATION":
+		return "content_filter"
+	case "OTHER":
+		return "other"
+	default:
+		return reason
+	}
+}
+
+// APIError represents a Gemini API error.
+type APIError struct {
+	StatusCode int
+	Code       int
+	Status     string
+	Message    string
+}
+
+func (e *APIError) Error() string {
+	return fmt.Sprintf("gemini API error (status %d, code %d, %s): %s",
+		e.StatusCode, e.Code, e.Status, e.Message)
+}
+
+// IsRateLimitError returns true if this is a rate limit error.
+func (e *APIError) IsRateLimitError() bool {
+	return e.StatusCode == http.StatusTooManyRequests || e.Status == "RESOURCE_EXHAUSTED"
+}
+
+// IsAuthError returns true if this is an authentication error.
+func (e *APIError) IsAuthError() bool {
+	return e.StatusCode == http.StatusUnauthorized ||
+		e.StatusCode == http.StatusForbidden ||
+		e.Status == "UNAUTHENTICATED" ||
+		e.Status == "PERMISSION_DENIED"
+}
+
+// IsQuotaExceededError returns true if this is a quota exceeded error.
+func (e *APIError) IsQuotaExceededError() bool {
+	return e.Status == "RESOURCE_EXHAUSTED"
+}
+
+// Internal API types
+
+type geminiResponse struct {
+	Candidates    []geminiCandidate  `json:"candidates,omitempty"`
+	UsageMetadata *geminiUsageMetadata `json:"usageMetadata,omitempty"`
+	PromptFeedback *struct {
+		BlockReason string `json:"blockReason,omitempty"`
+	} `json:"promptFeedback,omitempty"`
+}
+
+type geminiCandidate struct {
+	Content      geminiContent `json:"content"`
+	FinishReason string        `json:"finishReason,omitempty"`
+	Index        int           `json:"index"`
+	SafetyRatings []struct {
+		Category    string `json:"category"`
+		Probability string `json:"probability"`
+	} `json:"safetyRatings,omitempty"`
+}
+
+type geminiContent struct {
+	Parts []geminiPart `json:"parts"`
+	Role  string       `json:"role"`
+}
+
+type geminiPart struct {
+	Text string `json:"text,omitempty"`
+}
+
+type geminiUsageMetadata struct {
+	PromptTokenCount     int `json:"promptTokenCount"`
+	CandidatesTokenCount int `json:"candidatesTokenCount"`
+	TotalTokenCount      int `json:"totalTokenCount"`
+}
+
+// GetSupportedModels returns a list of supported Gemini models.
+func GetSupportedModels() []string {
+	return []string{
+		ModelGemini2Flash,
+		ModelGemini2FlashLite,
+		ModelGemini15Pro,
+		ModelGemini15Flash,
+		ModelGemini15Flash8B,
+		ModelGemini10Pro,
+	}
+}
+
+// IsValidModel checks if the given model is a valid Gemini model.
+func IsValidModel(model string) bool {
+	for _, m := range GetSupportedModels() {
+		if m == model {
+			return true
+		}
+	}
+	// Also allow custom/future models starting with "gemini-"
+	return strings.HasPrefix(model, "gemini-")
+}
+
+// SetHTTPClient sets a custom HTTP client for testing.
+func (p *Provider) SetHTTPClient(client HTTPClient) {
+	p.client = client
+}

--- a/platform/orchestrator/llm/gemini/provider_test.go
+++ b/platform/orchestrator/llm/gemini/provider_test.go
@@ -1,0 +1,999 @@
+// Copyright 2025 AxonFlow
+// SPDX-License-Identifier: BUSL-1.1
+
+package gemini
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+// mockHTTPClient is a mock HTTP client for testing.
+type mockHTTPClient struct {
+	DoFunc func(req *http.Request) (*http.Response, error)
+}
+
+func (m *mockHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	return m.DoFunc(req)
+}
+
+// Helper to create a successful response.
+func successResponse(content string, inputTokens, outputTokens int) *http.Response {
+	resp := geminiResponse{
+		Candidates: []geminiCandidate{
+			{
+				Content: geminiContent{
+					Parts: []geminiPart{{Text: content}},
+					Role:  "model",
+				},
+				FinishReason: "STOP",
+				Index:        0,
+			},
+		},
+		UsageMetadata: &geminiUsageMetadata{
+			PromptTokenCount:     inputTokens,
+			CandidatesTokenCount: outputTokens,
+			TotalTokenCount:      inputTokens + outputTokens,
+		},
+	}
+	body, _ := json.Marshal(resp)
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(bytes.NewReader(body)),
+		Header:     make(http.Header),
+	}
+}
+
+// Helper to create an error response.
+func errorResponse(statusCode int, message, status string) *http.Response {
+	resp := map[string]any{
+		"error": map[string]any{
+			"code":    statusCode,
+			"message": message,
+			"status":  status,
+		},
+	}
+	body, _ := json.Marshal(resp)
+	return &http.Response{
+		StatusCode: statusCode,
+		Body:       io.NopCloser(bytes.NewReader(body)),
+		Header:     make(http.Header),
+	}
+}
+
+// Helper to create a streaming response.
+func streamingResponse(chunks []string) *http.Response {
+	var builder strings.Builder
+	for i, chunk := range chunks {
+		resp := geminiResponse{
+			Candidates: []geminiCandidate{
+				{
+					Content: geminiContent{
+						Parts: []geminiPart{{Text: chunk}},
+						Role:  "model",
+					},
+					Index: 0,
+				},
+			},
+		}
+		// Add finish reason to last chunk
+		if i == len(chunks)-1 {
+			resp.Candidates[0].FinishReason = "STOP"
+			resp.UsageMetadata = &geminiUsageMetadata{
+				PromptTokenCount:     10,
+				CandidatesTokenCount: 20,
+				TotalTokenCount:      30,
+			}
+		}
+		data, _ := json.Marshal(resp)
+		builder.WriteString("data: ")
+		builder.Write(data)
+		builder.WriteString("\n\n")
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(builder.String())),
+		Header:     make(http.Header),
+	}
+}
+
+func TestNewProvider(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     Config
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid config with all fields",
+			cfg: Config{
+				APIKey:     "test-api-key",
+				BaseURL:    "https://custom.api.com",
+				APIVersion: "v1",
+				Model:      ModelGemini15Flash,
+				Timeout:    60 * time.Second,
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid config with minimal fields",
+			cfg: Config{
+				APIKey: "test-api-key",
+			},
+			wantErr: false,
+		},
+		{
+			name:    "missing API key",
+			cfg:     Config{},
+			wantErr: true,
+			errMsg:  "gemini API key is required",
+		},
+		{
+			name: "empty API key",
+			cfg: Config{
+				APIKey: "",
+			},
+			wantErr: true,
+			errMsg:  "gemini API key is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider, err := NewProvider(tt.cfg)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got nil")
+				} else if !strings.Contains(err.Error(), tt.errMsg) {
+					t.Errorf("error message should contain %q, got %q", tt.errMsg, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+			if provider == nil {
+				t.Error("provider should not be nil")
+				return
+			}
+
+			// Verify defaults
+			if tt.cfg.BaseURL == "" && provider.baseURL != DefaultBaseURL {
+				t.Errorf("expected default base URL %q, got %q", DefaultBaseURL, provider.baseURL)
+			}
+			if tt.cfg.APIVersion == "" && provider.apiVersion != DefaultAPIVersion {
+				t.Errorf("expected default API version %q, got %q", DefaultAPIVersion, provider.apiVersion)
+			}
+			if tt.cfg.Model == "" && provider.model != DefaultModel {
+				t.Errorf("expected default model %q, got %q", DefaultModel, provider.model)
+			}
+			if tt.cfg.Timeout == 0 && provider.timeout != DefaultTimeout {
+				t.Errorf("expected default timeout %v, got %v", DefaultTimeout, provider.timeout)
+			}
+		})
+	}
+}
+
+func TestProviderName(t *testing.T) {
+	provider, _ := NewProvider(Config{APIKey: "test-key"})
+	if name := provider.Name(); name != "gemini" {
+		t.Errorf("expected name %q, got %q", "gemini", name)
+	}
+}
+
+func TestProviderSupportsStreaming(t *testing.T) {
+	provider, _ := NewProvider(Config{APIKey: "test-key"})
+	if !provider.SupportsStreaming() {
+		t.Error("provider should support streaming")
+	}
+}
+
+func TestProviderGetCapabilities(t *testing.T) {
+	provider, _ := NewProvider(Config{APIKey: "test-key"})
+	capabilities := provider.GetCapabilities()
+
+	expectedCapabilities := []string{
+		"reasoning",
+		"analysis",
+		"writing",
+		"code_generation",
+		"long_context",
+		"vision",
+		"streaming",
+		"function_calling",
+	}
+
+	if len(capabilities) != len(expectedCapabilities) {
+		t.Errorf("expected %d capabilities, got %d", len(expectedCapabilities), len(capabilities))
+	}
+
+	for _, expected := range expectedCapabilities {
+		found := false
+		for _, cap := range capabilities {
+			if cap == expected {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("missing capability: %s", expected)
+		}
+	}
+}
+
+func TestProviderIsHealthy(t *testing.T) {
+	t.Run("healthy provider", func(t *testing.T) {
+		provider, _ := NewProvider(Config{APIKey: "test-key"})
+		if !provider.IsHealthy() {
+			t.Error("new provider should be healthy")
+		}
+	})
+
+	t.Run("unhealthy after setHealthy(false)", func(t *testing.T) {
+		provider, _ := NewProvider(Config{APIKey: "test-key"})
+		provider.setHealthy(false)
+		if provider.IsHealthy() {
+			t.Error("provider should be unhealthy after setHealthy(false)")
+		}
+	})
+
+	t.Run("healthy after recovery", func(t *testing.T) {
+		provider, _ := NewProvider(Config{APIKey: "test-key"})
+		provider.setHealthy(false)
+		provider.setHealthy(true)
+		if !provider.IsHealthy() {
+			t.Error("provider should be healthy after setHealthy(true)")
+		}
+	})
+}
+
+func TestProviderEstimateCost(t *testing.T) {
+	provider, _ := NewProvider(Config{APIKey: "test-key"})
+
+	tests := []struct {
+		tokens   int
+		expected float64
+	}{
+		{1000, 0.003125},
+		{0, 0},
+		{1, 0.000003125},
+	}
+
+	for _, tt := range tests {
+		cost := provider.EstimateCost(tt.tokens)
+		if cost != tt.expected {
+			t.Errorf("EstimateCost(%d) = %v, want %v", tt.tokens, cost, tt.expected)
+		}
+	}
+}
+
+func TestProviderComplete(t *testing.T) {
+	t.Run("successful completion", func(t *testing.T) {
+		provider, _ := NewProvider(Config{APIKey: "test-key"})
+		mockClient := &mockHTTPClient{
+			DoFunc: func(req *http.Request) (*http.Response, error) {
+				// Verify request
+				if req.Method != "POST" {
+					t.Errorf("expected POST, got %s", req.Method)
+				}
+				if !strings.Contains(req.URL.String(), "generateContent") {
+					t.Error("URL should contain generateContent")
+				}
+				if !strings.Contains(req.URL.String(), "key=test-key") {
+					t.Error("URL should contain API key")
+				}
+				return successResponse("Hello, world!", 10, 5), nil
+			},
+		}
+		provider.SetHTTPClient(mockClient)
+
+		resp, err := provider.Complete(context.Background(), CompletionRequest{
+			Prompt:    "Say hello",
+			MaxTokens: 100,
+		})
+
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.Content != "Hello, world!" {
+			t.Errorf("expected content %q, got %q", "Hello, world!", resp.Content)
+		}
+		if resp.Usage.InputTokens != 10 {
+			t.Errorf("expected input tokens 10, got %d", resp.Usage.InputTokens)
+		}
+		if resp.Usage.OutputTokens != 5 {
+			t.Errorf("expected output tokens 5, got %d", resp.Usage.OutputTokens)
+		}
+		if resp.StopReason != "stop" {
+			t.Errorf("expected stop reason %q, got %q", "stop", resp.StopReason)
+		}
+	})
+
+	t.Run("with system prompt", func(t *testing.T) {
+		provider, _ := NewProvider(Config{APIKey: "test-key"})
+		var capturedBody map[string]any
+		mockClient := &mockHTTPClient{
+			DoFunc: func(req *http.Request) (*http.Response, error) {
+				body, _ := io.ReadAll(req.Body)
+				json.Unmarshal(body, &capturedBody)
+				return successResponse("Response", 10, 5), nil
+			},
+		}
+		provider.SetHTTPClient(mockClient)
+
+		_, err := provider.Complete(context.Background(), CompletionRequest{
+			Prompt:       "Hello",
+			SystemPrompt: "You are helpful",
+			MaxTokens:    100,
+		})
+
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if capturedBody["systemInstruction"] == nil {
+			t.Error("request should contain systemInstruction")
+		}
+	})
+
+	t.Run("with custom model", func(t *testing.T) {
+		provider, _ := NewProvider(Config{APIKey: "test-key"})
+		mockClient := &mockHTTPClient{
+			DoFunc: func(req *http.Request) (*http.Response, error) {
+				if !strings.Contains(req.URL.String(), ModelGemini15Flash) {
+					t.Errorf("URL should contain model %s", ModelGemini15Flash)
+				}
+				return successResponse("Response", 10, 5), nil
+			},
+		}
+		provider.SetHTTPClient(mockClient)
+
+		_, err := provider.Complete(context.Background(), CompletionRequest{
+			Prompt: "Hello",
+			Model:  ModelGemini15Flash,
+		})
+
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("with generation config options", func(t *testing.T) {
+		provider, _ := NewProvider(Config{APIKey: "test-key"})
+		var capturedBody map[string]any
+		mockClient := &mockHTTPClient{
+			DoFunc: func(req *http.Request) (*http.Response, error) {
+				body, _ := io.ReadAll(req.Body)
+				json.Unmarshal(body, &capturedBody)
+				return successResponse("Response", 10, 5), nil
+			},
+		}
+		provider.SetHTTPClient(mockClient)
+
+		_, err := provider.Complete(context.Background(), CompletionRequest{
+			Prompt:        "Hello",
+			MaxTokens:     500,
+			Temperature:   0.5,
+			TopP:          0.9,
+			TopK:          40,
+			StopSequences: []string{"END"},
+		})
+
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		genConfig := capturedBody["generationConfig"].(map[string]any)
+		if genConfig["maxOutputTokens"] != float64(500) {
+			t.Errorf("expected maxOutputTokens 500, got %v", genConfig["maxOutputTokens"])
+		}
+		if genConfig["temperature"] != 0.5 {
+			t.Errorf("expected temperature 0.5, got %v", genConfig["temperature"])
+		}
+		if genConfig["topP"] != 0.9 {
+			t.Errorf("expected topP 0.9, got %v", genConfig["topP"])
+		}
+		if genConfig["topK"] != float64(40) {
+			t.Errorf("expected topK 40, got %v", genConfig["topK"])
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		provider, _ := NewProvider(Config{APIKey: "test-key"})
+		mockClient := &mockHTTPClient{
+			DoFunc: func(req *http.Request) (*http.Response, error) {
+				return nil, errors.New("network error")
+			},
+		}
+		provider.SetHTTPClient(mockClient)
+
+		_, err := provider.Complete(context.Background(), CompletionRequest{
+			Prompt: "Hello",
+		})
+
+		if err == nil {
+			t.Error("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "gemini API error") {
+			t.Errorf("error should mention gemini API error: %v", err)
+		}
+		if provider.IsHealthy() {
+			t.Error("provider should be unhealthy after network error")
+		}
+	})
+
+	t.Run("API error response", func(t *testing.T) {
+		provider, _ := NewProvider(Config{APIKey: "test-key"})
+		mockClient := &mockHTTPClient{
+			DoFunc: func(req *http.Request) (*http.Response, error) {
+				return errorResponse(401, "Invalid API key", "UNAUTHENTICATED"), nil
+			},
+		}
+		provider.SetHTTPClient(mockClient)
+
+		_, err := provider.Complete(context.Background(), CompletionRequest{
+			Prompt: "Hello",
+		})
+
+		if err == nil {
+			t.Error("expected error, got nil")
+		}
+		apiErr, ok := err.(*APIError)
+		if !ok {
+			t.Fatalf("expected *APIError, got %T", err)
+		}
+		if !apiErr.IsAuthError() {
+			t.Error("error should be an auth error")
+		}
+	})
+
+	t.Run("rate limit error", func(t *testing.T) {
+		provider, _ := NewProvider(Config{APIKey: "test-key"})
+		mockClient := &mockHTTPClient{
+			DoFunc: func(req *http.Request) (*http.Response, error) {
+				return errorResponse(429, "Rate limit exceeded", "RESOURCE_EXHAUSTED"), nil
+			},
+		}
+		provider.SetHTTPClient(mockClient)
+
+		_, err := provider.Complete(context.Background(), CompletionRequest{
+			Prompt: "Hello",
+		})
+
+		if err == nil {
+			t.Error("expected error, got nil")
+		}
+		apiErr, ok := err.(*APIError)
+		if !ok {
+			t.Fatalf("expected *APIError, got %T", err)
+		}
+		if !apiErr.IsRateLimitError() {
+			t.Error("error should be a rate limit error")
+		}
+		if !apiErr.IsQuotaExceededError() {
+			t.Error("error should be a quota exceeded error")
+		}
+	})
+
+	t.Run("server error sets unhealthy", func(t *testing.T) {
+		provider, _ := NewProvider(Config{APIKey: "test-key"})
+		mockClient := &mockHTTPClient{
+			DoFunc: func(req *http.Request) (*http.Response, error) {
+				return errorResponse(500, "Internal error", "INTERNAL"), nil
+			},
+		}
+		provider.SetHTTPClient(mockClient)
+
+		_, err := provider.Complete(context.Background(), CompletionRequest{
+			Prompt: "Hello",
+		})
+
+		if err == nil {
+			t.Error("expected error, got nil")
+		}
+		if provider.IsHealthy() {
+			t.Error("provider should be unhealthy after 500 error")
+		}
+	})
+
+	t.Run("default temperature when negative", func(t *testing.T) {
+		provider, _ := NewProvider(Config{APIKey: "test-key"})
+		var capturedBody map[string]any
+		mockClient := &mockHTTPClient{
+			DoFunc: func(req *http.Request) (*http.Response, error) {
+				body, _ := io.ReadAll(req.Body)
+				json.Unmarshal(body, &capturedBody)
+				return successResponse("Response", 10, 5), nil
+			},
+		}
+		provider.SetHTTPClient(mockClient)
+
+		_, _ = provider.Complete(context.Background(), CompletionRequest{
+			Prompt:      "Hello",
+			Temperature: -1, // Invalid, should use default
+		})
+
+		genConfig := capturedBody["generationConfig"].(map[string]any)
+		if genConfig["temperature"] != DefaultTemperature {
+			t.Errorf("expected default temperature %v, got %v", DefaultTemperature, genConfig["temperature"])
+		}
+	})
+
+	t.Run("zero temperature is valid", func(t *testing.T) {
+		provider, _ := NewProvider(Config{APIKey: "test-key"})
+		var capturedBody map[string]any
+		mockClient := &mockHTTPClient{
+			DoFunc: func(req *http.Request) (*http.Response, error) {
+				body, _ := io.ReadAll(req.Body)
+				json.Unmarshal(body, &capturedBody)
+				return successResponse("Response", 10, 5), nil
+			},
+		}
+		provider.SetHTTPClient(mockClient)
+
+		_, _ = provider.Complete(context.Background(), CompletionRequest{
+			Prompt:      "Hello",
+			Temperature: 0, // Valid for deterministic output
+		})
+
+		genConfig := capturedBody["generationConfig"].(map[string]any)
+		if genConfig["temperature"] != float64(0) {
+			t.Errorf("expected temperature 0, got %v", genConfig["temperature"])
+		}
+	})
+}
+
+func TestProviderCompleteStream(t *testing.T) {
+	t.Run("successful streaming", func(t *testing.T) {
+		provider, _ := NewProvider(Config{APIKey: "test-key"})
+		mockClient := &mockHTTPClient{
+			DoFunc: func(req *http.Request) (*http.Response, error) {
+				if !strings.Contains(req.URL.String(), "streamGenerateContent") {
+					t.Error("URL should contain streamGenerateContent")
+				}
+				if !strings.Contains(req.URL.String(), "alt=sse") {
+					t.Error("URL should contain alt=sse")
+				}
+				return streamingResponse([]string{"Hello", ", ", "world", "!"}), nil
+			},
+		}
+		provider.SetHTTPClient(mockClient)
+
+		var chunks []string
+		resp, err := provider.CompleteStream(context.Background(), CompletionRequest{
+			Prompt:    "Say hello",
+			MaxTokens: 100,
+		}, func(chunk StreamChunk) error {
+			if chunk.Content != "" {
+				chunks = append(chunks, chunk.Content)
+			}
+			return nil
+		})
+
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.Content != "Hello, world!" {
+			t.Errorf("expected content %q, got %q", "Hello, world!", resp.Content)
+		}
+		if len(chunks) != 4 {
+			t.Errorf("expected 4 chunks, got %d", len(chunks))
+		}
+	})
+
+	t.Run("handler error stops stream", func(t *testing.T) {
+		provider, _ := NewProvider(Config{APIKey: "test-key"})
+		mockClient := &mockHTTPClient{
+			DoFunc: func(req *http.Request) (*http.Response, error) {
+				return streamingResponse([]string{"Hello", ", ", "world", "!"}), nil
+			},
+		}
+		provider.SetHTTPClient(mockClient)
+
+		handlerErr := errors.New("handler error")
+		_, err := provider.CompleteStream(context.Background(), CompletionRequest{
+			Prompt: "Say hello",
+		}, func(chunk StreamChunk) error {
+			return handlerErr
+		})
+
+		if err == nil {
+			t.Error("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "handler error") {
+			t.Errorf("error should mention handler error: %v", err)
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		provider, _ := NewProvider(Config{APIKey: "test-key"})
+		mockClient := &mockHTTPClient{
+			DoFunc: func(req *http.Request) (*http.Response, error) {
+				return nil, errors.New("network error")
+			},
+		}
+		provider.SetHTTPClient(mockClient)
+
+		_, err := provider.CompleteStream(context.Background(), CompletionRequest{
+			Prompt: "Hello",
+		}, func(chunk StreamChunk) error {
+			return nil
+		})
+
+		if err == nil {
+			t.Error("expected error, got nil")
+		}
+		if provider.IsHealthy() {
+			t.Error("provider should be unhealthy after network error")
+		}
+	})
+
+	t.Run("API error response", func(t *testing.T) {
+		provider, _ := NewProvider(Config{APIKey: "test-key"})
+		mockClient := &mockHTTPClient{
+			DoFunc: func(req *http.Request) (*http.Response, error) {
+				return errorResponse(401, "Invalid API key", "UNAUTHENTICATED"), nil
+			},
+		}
+		provider.SetHTTPClient(mockClient)
+
+		_, err := provider.CompleteStream(context.Background(), CompletionRequest{
+			Prompt: "Hello",
+		}, func(chunk StreamChunk) error {
+			return nil
+		})
+
+		if err == nil {
+			t.Error("expected error, got nil")
+		}
+	})
+
+	t.Run("nil handler", func(t *testing.T) {
+		provider, _ := NewProvider(Config{APIKey: "test-key"})
+		mockClient := &mockHTTPClient{
+			DoFunc: func(req *http.Request) (*http.Response, error) {
+				return streamingResponse([]string{"Hello"}), nil
+			},
+		}
+		provider.SetHTTPClient(mockClient)
+
+		resp, err := provider.CompleteStream(context.Background(), CompletionRequest{
+			Prompt: "Hello",
+		}, nil)
+
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.Content != "Hello" {
+			t.Errorf("expected content %q, got %q", "Hello", resp.Content)
+		}
+	})
+}
+
+func TestAPIError(t *testing.T) {
+	t.Run("error message format", func(t *testing.T) {
+		err := &APIError{
+			StatusCode: 401,
+			Code:       401,
+			Status:     "UNAUTHENTICATED",
+			Message:    "Invalid API key",
+		}
+		expected := "gemini API error (status 401, code 401, UNAUTHENTICATED): Invalid API key"
+		if err.Error() != expected {
+			t.Errorf("expected %q, got %q", expected, err.Error())
+		}
+	})
+
+	t.Run("IsRateLimitError", func(t *testing.T) {
+		tests := []struct {
+			statusCode int
+			status     string
+			expected   bool
+		}{
+			{429, "", true},
+			{429, "RESOURCE_EXHAUSTED", true},
+			{200, "RESOURCE_EXHAUSTED", true},
+			{401, "UNAUTHENTICATED", false},
+			{500, "INTERNAL", false},
+		}
+
+		for _, tt := range tests {
+			err := &APIError{StatusCode: tt.statusCode, Status: tt.status}
+			if err.IsRateLimitError() != tt.expected {
+				t.Errorf("IsRateLimitError(%d, %s) = %v, want %v",
+					tt.statusCode, tt.status, err.IsRateLimitError(), tt.expected)
+			}
+		}
+	})
+
+	t.Run("IsAuthError", func(t *testing.T) {
+		tests := []struct {
+			statusCode int
+			status     string
+			expected   bool
+		}{
+			{401, "", true},
+			{403, "", true},
+			{200, "UNAUTHENTICATED", true},
+			{200, "PERMISSION_DENIED", true},
+			{429, "RESOURCE_EXHAUSTED", false},
+			{500, "INTERNAL", false},
+		}
+
+		for _, tt := range tests {
+			err := &APIError{StatusCode: tt.statusCode, Status: tt.status}
+			if err.IsAuthError() != tt.expected {
+				t.Errorf("IsAuthError(%d, %s) = %v, want %v",
+					tt.statusCode, tt.status, err.IsAuthError(), tt.expected)
+			}
+		}
+	})
+
+	t.Run("IsQuotaExceededError", func(t *testing.T) {
+		tests := []struct {
+			status   string
+			expected bool
+		}{
+			{"RESOURCE_EXHAUSTED", true},
+			{"UNAUTHENTICATED", false},
+			{"", false},
+		}
+
+		for _, tt := range tests {
+			err := &APIError{Status: tt.status}
+			if err.IsQuotaExceededError() != tt.expected {
+				t.Errorf("IsQuotaExceededError(%s) = %v, want %v",
+					tt.status, err.IsQuotaExceededError(), tt.expected)
+			}
+		}
+	})
+}
+
+func TestGetSupportedModels(t *testing.T) {
+	models := GetSupportedModels()
+	if len(models) == 0 {
+		t.Error("should return at least one model")
+	}
+
+	expectedModels := []string{
+		ModelGemini2Flash,
+		ModelGemini15Pro,
+		ModelGemini15Flash,
+	}
+
+	for _, expected := range expectedModels {
+		found := false
+		for _, m := range models {
+			if m == expected {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("missing model: %s", expected)
+		}
+	}
+}
+
+func TestIsValidModel(t *testing.T) {
+	tests := []struct {
+		model    string
+		expected bool
+	}{
+		{ModelGemini15Pro, true},
+		{ModelGemini15Flash, true},
+		{ModelGemini2Flash, true},
+		{"gemini-custom-model", true}, // Custom models starting with gemini-
+		{"gpt-4", false},
+		{"claude-3", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		if IsValidModel(tt.model) != tt.expected {
+			t.Errorf("IsValidModel(%q) = %v, want %v", tt.model, IsValidModel(tt.model), tt.expected)
+		}
+	}
+}
+
+func TestMapFinishReason(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"STOP", "stop"},
+		{"MAX_TOKENS", "max_tokens"},
+		{"SAFETY", "content_filter"},
+		{"RECITATION", "content_filter"},
+		{"OTHER", "other"},
+		{"UNKNOWN", "UNKNOWN"},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		if result := mapFinishReason(tt.input); result != tt.expected {
+			t.Errorf("mapFinishReason(%q) = %q, want %q", tt.input, result, tt.expected)
+		}
+	}
+}
+
+func TestProviderConcurrency(t *testing.T) {
+	provider, _ := NewProvider(Config{APIKey: "test-key"})
+	mockClient := &mockHTTPClient{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			time.Sleep(10 * time.Millisecond) // Simulate latency
+			return successResponse("Response", 10, 5), nil
+		},
+	}
+	provider.SetHTTPClient(mockClient)
+
+	// Run multiple concurrent requests
+	const numRequests = 10
+	done := make(chan bool, numRequests)
+	errs := make(chan error, numRequests)
+
+	for i := 0; i < numRequests; i++ {
+		go func() {
+			_, err := provider.Complete(context.Background(), CompletionRequest{
+				Prompt: "Hello",
+			})
+			if err != nil {
+				errs <- err
+			}
+			done <- true
+		}()
+	}
+
+	// Wait for all requests to complete
+	for i := 0; i < numRequests; i++ {
+		<-done
+	}
+
+	// Check for errors
+	close(errs)
+	for err := range errs {
+		t.Errorf("concurrent request error: %v", err)
+	}
+
+	// Provider should still be healthy
+	if !provider.IsHealthy() {
+		t.Error("provider should be healthy after concurrent requests")
+	}
+}
+
+func TestProviderHealthConcurrency(t *testing.T) {
+	provider, _ := NewProvider(Config{APIKey: "test-key"})
+
+	// Concurrent health status updates
+	const numUpdates = 100
+	done := make(chan bool, numUpdates*2)
+
+	// Writers
+	for i := 0; i < numUpdates; i++ {
+		go func(healthy bool) {
+			provider.setHealthy(healthy)
+			done <- true
+		}(i%2 == 0)
+	}
+
+	// Readers
+	for i := 0; i < numUpdates; i++ {
+		go func() {
+			_ = provider.IsHealthy()
+			done <- true
+		}()
+	}
+
+	// Wait for all goroutines
+	for i := 0; i < numUpdates*2; i++ {
+		<-done
+	}
+}
+
+func TestEmptyResponse(t *testing.T) {
+	provider, _ := NewProvider(Config{APIKey: "test-key"})
+	mockClient := &mockHTTPClient{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			// Response with no candidates
+			resp := geminiResponse{
+				Candidates: []geminiCandidate{},
+			}
+			body, _ := json.Marshal(resp)
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewReader(body)),
+				Header:     make(http.Header),
+			}, nil
+		},
+	}
+	provider.SetHTTPClient(mockClient)
+
+	resp, err := provider.Complete(context.Background(), CompletionRequest{
+		Prompt: "Hello",
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Content != "" {
+		t.Errorf("expected empty content, got %q", resp.Content)
+	}
+}
+
+func TestMalformedResponse(t *testing.T) {
+	provider, _ := NewProvider(Config{APIKey: "test-key"})
+	mockClient := &mockHTTPClient{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("invalid json")),
+				Header:     make(http.Header),
+			}, nil
+		},
+	}
+	provider.SetHTTPClient(mockClient)
+
+	_, err := provider.Complete(context.Background(), CompletionRequest{
+		Prompt: "Hello",
+	})
+
+	if err == nil {
+		t.Error("expected error for malformed response")
+	}
+	if !strings.Contains(err.Error(), "failed to decode") {
+		t.Errorf("error should mention decode failure: %v", err)
+	}
+}
+
+func TestMalformedErrorResponse(t *testing.T) {
+	provider, _ := NewProvider(Config{APIKey: "test-key"})
+	mockClient := &mockHTTPClient{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusBadRequest,
+				Body:       io.NopCloser(strings.NewReader("plain text error")),
+				Header:     make(http.Header),
+			}, nil
+		},
+	}
+	provider.SetHTTPClient(mockClient)
+
+	_, err := provider.Complete(context.Background(), CompletionRequest{
+		Prompt: "Hello",
+	})
+
+	if err == nil {
+		t.Error("expected error")
+	}
+	if !strings.Contains(err.Error(), "plain text error") {
+		t.Errorf("error should contain raw error text: %v", err)
+	}
+}
+
+func BenchmarkProviderComplete(b *testing.B) {
+	provider, _ := NewProvider(Config{APIKey: "test-key"})
+	mockClient := &mockHTTPClient{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			return successResponse("Response", 10, 5), nil
+		},
+	}
+	provider.SetHTTPClient(mockClient)
+
+	ctx := context.Background()
+	req := CompletionRequest{
+		Prompt:    "Hello",
+		MaxTokens: 100,
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = provider.Complete(ctx, req)
+	}
+}

--- a/platform/orchestrator/llm/license_gating_test.go
+++ b/platform/orchestrator/llm/license_gating_test.go
@@ -16,18 +16,18 @@ import (
 	"testing"
 )
 
-func TestOSSLicenseValidator_GetCurrentTier(t *testing.T) {
-	v := NewOSSLicenseValidator()
+func TestCommunityLicenseValidator_GetCurrentTier(t *testing.T) {
+	v := NewCommunityLicenseValidator()
 	ctx := context.Background()
 
 	tier := v.GetCurrentTier(ctx)
-	if tier != LicenseTierOSS {
-		t.Errorf("GetCurrentTier() = %q, want %q", tier, LicenseTierOSS)
+	if tier != LicenseTierCommunity {
+		t.Errorf("GetCurrentTier() = %q, want %q", tier, LicenseTierCommunity)
 	}
 }
 
-func TestOSSLicenseValidator_IsProviderAllowed(t *testing.T) {
-	v := NewOSSLicenseValidator()
+func TestCommunityLicenseValidator_IsProviderAllowed(t *testing.T) {
+	v := NewCommunityLicenseValidator()
 	ctx := context.Background()
 
 	tests := []struct {
@@ -38,8 +38,8 @@ func TestOSSLicenseValidator_IsProviderAllowed(t *testing.T) {
 		{"Ollama allowed", ProviderTypeOllama, true},
 		{"OpenAI allowed", ProviderTypeOpenAI, true},
 		{"Anthropic allowed", ProviderTypeAnthropic, true},
+		{"Gemini allowed", ProviderTypeGemini, true},
 		{"Bedrock not allowed", ProviderTypeBedrock, false},
-		{"Gemini not allowed", ProviderTypeGemini, false},
 		{"Custom not allowed", ProviderTypeCustom, false},
 		{"Unknown not allowed", ProviderType("unknown"), false},
 	}
@@ -54,34 +54,34 @@ func TestOSSLicenseValidator_IsProviderAllowed(t *testing.T) {
 	}
 }
 
-func TestOSSLicenseValidator_ValidateLicense(t *testing.T) {
-	v := NewOSSLicenseValidator()
+func TestCommunityLicenseValidator_ValidateLicense(t *testing.T) {
+	v := NewCommunityLicenseValidator()
 	ctx := context.Background()
 
-	// OSS validator always returns nil (no license required)
+	// Community validator always returns nil (no license required)
 	err := v.ValidateLicense(ctx, "any-key")
 	if err != nil {
 		t.Errorf("ValidateLicense() = %v, want nil", err)
 	}
 }
 
-func TestOSSLicenseValidator_GetFeatures(t *testing.T) {
-	v := NewOSSLicenseValidator()
+func TestCommunityLicenseValidator_GetFeatures(t *testing.T) {
+	v := NewCommunityLicenseValidator()
 	features := v.GetFeatures()
 
-	// Check some expected OSS features
+	// Check some expected Community features
 	expectedEnabled := []string{"multi_provider", "load_balancing", "health_checks", "audit_logging", "metrics_collection"}
 	for _, f := range expectedEnabled {
 		if !features[f] {
-			t.Errorf("Feature %q should be enabled in OSS", f)
+			t.Errorf("Feature %q should be enabled in Community", f)
 		}
 	}
 
 	// Check some expected enterprise-only features
-	expectedDisabled := []string{"bedrock_provider", "gemini_provider", "custom_providers", "advanced_routing"}
+	expectedDisabled := []string{"bedrock_provider", "custom_providers", "advanced_routing"}
 	for _, f := range expectedDisabled {
 		if features[f] {
-			t.Errorf("Feature %q should be disabled in OSS", f)
+			t.Errorf("Feature %q should be disabled in Community", f)
 		}
 	}
 
@@ -98,11 +98,11 @@ func TestGetTierForProvider(t *testing.T) {
 		providerType ProviderType
 		want         LicenseTier
 	}{
-		{ProviderTypeOllama, LicenseTierOSS},
-		{ProviderTypeOpenAI, LicenseTierOSS},
-		{ProviderTypeAnthropic, LicenseTierOSS},
+		{ProviderTypeOllama, LicenseTierCommunity},
+		{ProviderTypeOpenAI, LicenseTierCommunity},
+		{ProviderTypeAnthropic, LicenseTierCommunity},
+		{ProviderTypeGemini, LicenseTierCommunity},
 		{ProviderTypeBedrock, LicenseTierProfessional},
-		{ProviderTypeGemini, LicenseTierProfessional},
 		{ProviderTypeCustom, LicenseTierProfessional},
 		{ProviderType("unknown"), LicenseTierProfessional}, // Unknown defaults to Professional
 	}
@@ -117,7 +117,7 @@ func TestGetTierForProvider(t *testing.T) {
 	}
 }
 
-func TestIsOSSProvider(t *testing.T) {
+func TestIsCommunityProvider(t *testing.T) {
 	tests := []struct {
 		providerType ProviderType
 		want         bool
@@ -125,33 +125,34 @@ func TestIsOSSProvider(t *testing.T) {
 		{ProviderTypeOllama, true},
 		{ProviderTypeOpenAI, true},
 		{ProviderTypeAnthropic, true},
+		{ProviderTypeGemini, true},
 		{ProviderTypeBedrock, false},
-		{ProviderTypeGemini, false},
 		{ProviderTypeCustom, false},
 	}
 
 	for _, tt := range tests {
 		t.Run(string(tt.providerType), func(t *testing.T) {
-			got := IsOSSProvider(tt.providerType)
+			got := IsCommunityProvider(tt.providerType)
 			if got != tt.want {
-				t.Errorf("IsOSSProvider(%q) = %v, want %v", tt.providerType, got, tt.want)
+				t.Errorf("IsCommunityProvider(%q) = %v, want %v", tt.providerType, got, tt.want)
 			}
 		})
 	}
 }
 
-func TestGetOSSProviders(t *testing.T) {
-	providers := GetOSSProviders()
+func TestGetCommunityProviders(t *testing.T) {
+	providers := GetCommunityProviders()
 
-	if len(providers) < 3 {
-		t.Errorf("GetOSSProviders() returned %d providers, want at least 3", len(providers))
+	if len(providers) < 4 {
+		t.Errorf("GetCommunityProviders() returned %d providers, want at least 4", len(providers))
 	}
 
-	// Check that expected OSS providers are in the list
+	// Check that expected Community providers are in the list
 	expected := map[ProviderType]bool{
 		ProviderTypeOllama:    false,
 		ProviderTypeOpenAI:    false,
 		ProviderTypeAnthropic: false,
+		ProviderTypeGemini:    false,
 	}
 
 	for _, p := range providers {
@@ -162,7 +163,7 @@ func TestGetOSSProviders(t *testing.T) {
 
 	for p, found := range expected {
 		if !found {
-			t.Errorf("Expected OSS provider %q not found in GetOSSProviders()", p)
+			t.Errorf("Expected Community provider %q not found in GetCommunityProviders()", p)
 		}
 	}
 }
@@ -170,14 +171,13 @@ func TestGetOSSProviders(t *testing.T) {
 func TestGetEnterpriseProviders(t *testing.T) {
 	providers := GetEnterpriseProviders()
 
-	if len(providers) < 3 {
-		t.Errorf("GetEnterpriseProviders() returned %d providers, want at least 3", len(providers))
+	if len(providers) < 2 {
+		t.Errorf("GetEnterpriseProviders() returned %d providers, want at least 2", len(providers))
 	}
 
 	// Check that expected Enterprise providers are in the list
 	expected := map[ProviderType]bool{
 		ProviderTypeBedrock: false,
-		ProviderTypeGemini:  false,
 		ProviderTypeCustom:  false,
 	}
 
@@ -202,26 +202,26 @@ func TestTierSatisfiesRequirement(t *testing.T) {
 		want         bool
 	}{
 		// Same tier
-		{"OSS meets OSS", LicenseTierOSS, LicenseTierOSS, true},
+		{"Community meets Community", LicenseTierCommunity, LicenseTierCommunity, true},
 		{"PRO meets PRO", LicenseTierProfessional, LicenseTierProfessional, true},
 		{"ENT meets ENT", LicenseTierEnterprise, LicenseTierEnterprise, true},
 		{"PLUS meets PLUS", LicenseTierEnterprisePlus, LicenseTierEnterprisePlus, true},
 
 		// Higher tier meets lower requirement
-		{"PRO meets OSS", LicenseTierProfessional, LicenseTierOSS, true},
-		{"ENT meets OSS", LicenseTierEnterprise, LicenseTierOSS, true},
+		{"PRO meets Community", LicenseTierProfessional, LicenseTierCommunity, true},
+		{"ENT meets Community", LicenseTierEnterprise, LicenseTierCommunity, true},
 		{"ENT meets PRO", LicenseTierEnterprise, LicenseTierProfessional, true},
-		{"PLUS meets all", LicenseTierEnterprisePlus, LicenseTierOSS, true},
+		{"PLUS meets all", LicenseTierEnterprisePlus, LicenseTierCommunity, true},
 
 		// Lower tier doesn't meet higher requirement
-		{"OSS doesn't meet PRO", LicenseTierOSS, LicenseTierProfessional, false},
-		{"OSS doesn't meet ENT", LicenseTierOSS, LicenseTierEnterprise, false},
+		{"Community doesn't meet PRO", LicenseTierCommunity, LicenseTierProfessional, false},
+		{"Community doesn't meet ENT", LicenseTierCommunity, LicenseTierEnterprise, false},
 		{"PRO doesn't meet ENT", LicenseTierProfessional, LicenseTierEnterprise, false},
 		{"ENT doesn't meet PLUS", LicenseTierEnterprise, LicenseTierEnterprisePlus, false},
 
 		// Unknown tier
-		{"Unknown current tier", LicenseTier("unknown"), LicenseTierOSS, false},
-		{"Unknown required tier", LicenseTierOSS, LicenseTier("unknown"), false},
+		{"Unknown current tier", LicenseTier("unknown"), LicenseTierCommunity, false},
+		{"Unknown required tier", LicenseTierCommunity, LicenseTier("unknown"), false},
 	}
 
 	for _, tt := range tests {
@@ -240,7 +240,7 @@ func TestLicenseError_Error(t *testing.T) {
 		err := &LicenseError{
 			ProviderType: ProviderTypeBedrock,
 			RequiredTier: LicenseTierProfessional,
-			CurrentTier:  LicenseTierOSS,
+			CurrentTier:  LicenseTierCommunity,
 			Message:      "upgrade required",
 		}
 
@@ -271,8 +271,8 @@ func TestValidateProviderAccess(t *testing.T) {
 	originalValidator := DefaultValidator
 	defer func() { DefaultValidator = originalValidator }()
 
-	// Use OSS validator for tests
-	DefaultValidator = NewOSSLicenseValidator()
+	// Use Community validator for tests
+	DefaultValidator = NewCommunityLicenseValidator()
 	ctx := context.Background()
 
 	t.Run("allowed provider", func(t *testing.T) {
@@ -299,8 +299,8 @@ func TestValidateProviderAccess(t *testing.T) {
 		if licErr.RequiredTier != LicenseTierProfessional {
 			t.Errorf("RequiredTier = %q, want %q", licErr.RequiredTier, LicenseTierProfessional)
 		}
-		if licErr.CurrentTier != LicenseTierOSS {
-			t.Errorf("CurrentTier = %q, want %q", licErr.CurrentTier, LicenseTierOSS)
+		if licErr.CurrentTier != LicenseTierCommunity {
+			t.Errorf("CurrentTier = %q, want %q", licErr.CurrentTier, LicenseTierCommunity)
 		}
 	})
 }

--- a/platform/orchestrator/llm/provider.go
+++ b/platform/orchestrator/llm/provider.go
@@ -18,7 +18,7 @@ import (
 // Provider is the unified interface for all LLM providers.
 // Implementations must be safe for concurrent use.
 //
-// This interface unifies the previously separate OSS and Enterprise provider
+// This interface unifies the previously separate Community and Enterprise provider
 // interfaces, enabling pluggable providers that work across both editions.
 //
 // Minimal implementation requires: Name(), Type(), Complete(), and HealthCheck().

--- a/platform/orchestrator/llm/registry.go
+++ b/platform/orchestrator/llm/registry.go
@@ -86,7 +86,7 @@ func WithFactoryManager(fm *FactoryManager) RegistryOption {
 }
 
 // WithLicenseValidator sets a custom license validator.
-// If not set, the registry uses the DefaultValidator which enforces OSS restrictions.
+// If not set, the registry uses the DefaultValidator which enforces Community restrictions.
 func WithLicenseValidator(v LicenseValidator) RegistryOption {
 	return func(r *Registry) {
 		r.validator = v

--- a/platform/orchestrator/llm/registry_test.go
+++ b/platform/orchestrator/llm/registry_test.go
@@ -252,9 +252,9 @@ func TestRegistry_Register(t *testing.T) {
 		}
 	})
 
-	t.Run("license gating allows OSS providers", func(t *testing.T) {
-		// OSS validator allows Ollama, OpenAI, Anthropic
-		r := NewRegistry(WithLicenseValidator(NewOSSLicenseValidator()))
+	t.Run("license gating allows Community providers", func(t *testing.T) {
+		// Community validator allows Ollama, OpenAI, Anthropic
+		r := NewRegistry(WithLicenseValidator(NewCommunityLicenseValidator()))
 		r.factory.Register(ProviderTypeOllama, func(config ProviderConfig) (Provider, error) {
 			return NewMockProvider(config.Name, config.Type), nil
 		})
@@ -266,13 +266,13 @@ func TestRegistry_Register(t *testing.T) {
 
 		err := r.Register(ctx, config)
 		if err != nil {
-			t.Errorf("OSS provider should be allowed: %v", err)
+			t.Errorf("Community provider should be allowed: %v", err)
 		}
 	})
 
-	t.Run("license gating blocks enterprise providers in OSS mode", func(t *testing.T) {
-		// OSS validator should block Bedrock, Gemini, Custom
-		r := NewRegistry(WithLicenseValidator(NewOSSLicenseValidator()))
+	t.Run("license gating blocks enterprise providers in Community mode", func(t *testing.T) {
+		// Community validator should block Bedrock, Custom
+		r := NewRegistry(WithLicenseValidator(NewCommunityLicenseValidator()))
 		r.factory.Register(ProviderTypeBedrock, func(config ProviderConfig) (Provider, error) {
 			return NewMockProvider(config.Name, config.Type), nil
 		})
@@ -285,7 +285,7 @@ func TestRegistry_Register(t *testing.T) {
 
 		err := r.Register(ctx, config)
 		if err == nil {
-			t.Fatal("Enterprise provider should be blocked in OSS mode")
+			t.Fatal("Enterprise provider should be blocked in Community mode")
 		}
 
 		var regErr *RegistryError

--- a/platform/orchestrator/llm/sdk/README.md
+++ b/platform/orchestrator/llm/sdk/README.md
@@ -321,14 +321,14 @@ llm_providers:
 
 | Provider | Type | Edition | Description |
 |----------|------|---------|-------------|
-| OpenAI | `openai` | OSS | GPT-4, GPT-3.5-turbo |
-| Anthropic | `anthropic` | OSS | Claude 3.5 Sonnet, Claude 3 Opus |
-| Ollama | `ollama` | OSS | Self-hosted open-source models |
+| OpenAI | `openai` | Community | GPT-4, GPT-3.5-turbo |
+| Anthropic | `anthropic` | Community | Claude 3.5 Sonnet, Claude 3 Opus |
+| Ollama | `ollama` | Community | Self-hosted models |
 | AWS Bedrock | `bedrock` | Enterprise | Claude on AWS, Llama, Titan |
 | Google Gemini | `gemini` | Enterprise | Gemini Pro, Gemini Ultra |
 | Custom | `custom` | Enterprise | Your own implementations |
 
-> **Note:** OSS edition includes OpenAI, Anthropic, and Ollama providers. Enterprise providers (Bedrock, Gemini, Custom) require a license.
+> **Note:** Community edition includes OpenAI, Anthropic, and Ollama providers. Enterprise providers (Bedrock, Gemini, Custom) require a license.
 
 ## Best Practices
 

--- a/platform/orchestrator/llm_provider_api_handlers.go
+++ b/platform/orchestrator/llm_provider_api_handlers.go
@@ -593,8 +593,8 @@ func (h *LLMProviderAPIHandler) handleListProviderTypes(w http.ResponseWriter, r
 	types := make([]map[string]interface{}, 0, len(factories))
 	for _, pt := range factories {
 		info := map[string]interface{}{
-			"type": string(pt),
-			"oss":  llm.IsOSSProvider(pt),
+			"type":      string(pt),
+			"community": llm.IsCommunityProvider(pt),
 		}
 
 		// Add tier info

--- a/platform/orchestrator/llm_provider_api_handlers_test.go
+++ b/platform/orchestrator/llm_provider_api_handlers_test.go
@@ -592,7 +592,7 @@ func TestLLMProviderAPIHandler_ProviderTypes(t *testing.T) {
 			t.Fatal("expected provider_types array in response")
 		}
 
-		// Should have at least OSS providers (anthropic, openai, ollama)
+		// Should have at least Community providers (anthropic, openai, ollama)
 		if len(types) < 3 {
 			t.Errorf("expected at least 3 provider types, got %d", len(types))
 		}

--- a/platform/orchestrator/mcp_connector_processor.go
+++ b/platform/orchestrator/mcp_connector_processor.go
@@ -32,7 +32,7 @@ const (
 	InternalServiceClientID = "orchestrator-internal"
 
 	// InternalServiceTokenFallback is used when AXONFLOW_INTERNAL_SERVICE_SECRET is not configured.
-	// This provides backwards compatibility for OSS/development environments.
+	// This provides backwards compatibility for Community/development environments.
 	// Production deployments should always set AXONFLOW_INTERNAL_SERVICE_SECRET.
 	InternalServiceTokenFallback = "orchestrator-internal-token"
 
@@ -71,7 +71,7 @@ func LogInternalServiceAuthWarning() {
 
 // getInternalServiceToken returns the token to use for internal service auth.
 // If AXONFLOW_INTERNAL_SERVICE_SECRET is set, uses that for secure auth.
-// Otherwise falls back to the hardcoded token for OSS/dev environments.
+// Otherwise falls back to the hardcoded token for Community/dev environments.
 func getInternalServiceToken() string {
 	if secret := os.Getenv(InternalServiceSecretEnvVar); secret != "" {
 		return secret

--- a/platform/orchestrator/rls.go
+++ b/platform/orchestrator/rls.go
@@ -239,8 +239,8 @@ func RLSHealthCheck(ctx context.Context, db *sql.DB) error {
 		}
 	}
 
-	// Check if RLS is enabled on critical tables (OSS tables only)
-	// Note: enterprise tables (usage_events, agent_heartbeats) are not in OSS builds
+	// Check if RLS is enabled on critical tables (Community tables only)
+	// Note: enterprise tables (usage_events, agent_heartbeats) are not in Community builds
 	criticalTables := []string{
 		"organizations",
 		"user_sessions",

--- a/platform/orchestrator/run.go
+++ b/platform/orchestrator/run.go
@@ -35,10 +35,10 @@ import (
 	"github.com/rs/cors"
 
 	"axonflow/platform/agent/node_enforcement"
-	"axonflow/platform/orchestrator/euaiact" // EU AI Act compliance - OSS stub or EE impl
+	"axonflow/platform/orchestrator/euaiact" // EU AI Act compliance - Community stub or EE impl
 	"axonflow/platform/orchestrator/llm"
-	"axonflow/platform/orchestrator/rbi"  // RBI FREE-AI module - OSS stub or EE impl
-	"axonflow/platform/orchestrator/sebi" // SEBI AI/ML module - OSS stub or EE impl
+	"axonflow/platform/orchestrator/rbi"  // RBI FREE-AI module - Community stub or EE impl
+	"axonflow/platform/orchestrator/sebi" // SEBI AI/ML module - Community stub or EE impl
 )
 
 // AxonFlow Orchestrator - Dynamic Policy Enforcement & LLM Routing Engine
@@ -255,6 +255,10 @@ func LoadLLMConfig() LLMRouterConfig {
 	config.OllamaEndpoint = os.Getenv("OLLAMA_ENDPOINT")
 	config.OllamaModel = os.Getenv("OLLAMA_MODEL")
 
+	// Gemini configuration
+	config.GeminiKey = os.Getenv("GOOGLE_API_KEY")
+	config.GeminiModel = os.Getenv("GOOGLE_MODEL")
+
 	// Backward compatibility: LocalEndpoint
 	if config.OllamaEndpoint == "" {
 		config.LocalEndpoint = os.Getenv("LOCAL_LLM_ENDPOINT")
@@ -272,6 +276,9 @@ func LoadLLMConfig() LLMRouterConfig {
 	}
 	if config.OllamaEndpoint != "" {
 		log.Printf("  - Ollama: enabled (endpoint: %s, model: %s)", config.OllamaEndpoint, config.OllamaModel)
+	}
+	if config.GeminiKey != "" {
+		log.Printf("  - Gemini: enabled (key: %s..., model: %s)", config.GeminiKey[:min(10, len(config.GeminiKey))], config.GeminiModel)
 	}
 	if config.LocalEndpoint != "" && config.OllamaEndpoint == "" {
 		log.Printf("  - Local LLM: enabled (endpoint: %s) [deprecated: use OLLAMA_ENDPOINT]", config.LocalEndpoint)
@@ -601,7 +608,7 @@ func initializeComponents() {
 	InitRuntimeConfigService(usageDB, selfHosted)
 	log.Println("RuntimeConfigService initialized (ADR-007 compliant)")
 
-	// Wire config file loader for Priority 2 (OSS config file support)
+	// Wire config file loader for Priority 2 (Community config file support)
 	// Checks AXONFLOW_CONFIG_FILE or AXONFLOW_LLM_CONFIG_FILE env vars
 	SetConfigFileLoaderFromEnv() // Logs its own success/failure messages
 

--- a/platform/orchestrator/runtime_config_integration.go
+++ b/platform/orchestrator/runtime_config_integration.go
@@ -29,6 +29,7 @@ const (
 	ProviderAnthropic = "anthropic"
 	ProviderBedrock   = "bedrock"
 	ProviderOllama    = "ollama"
+	ProviderGemini    = "gemini"
 )
 
 // ValidLLMProviders is the list of supported LLM provider names.
@@ -37,6 +38,7 @@ var ValidLLMProviders = []string{
 	ProviderAnthropic,
 	ProviderBedrock,
 	ProviderOllama,
+	ProviderGemini,
 }
 
 // isValidLLMProvider checks if the given provider name is valid.
@@ -186,6 +188,14 @@ func LoadLLMConfigFromService(ctx context.Context, tenantID string) LLMRouterCon
 				log.Printf("[LLM Config] WARNING: Ollama provider requires endpoint. "+
 					"Got model=%q but no endpoint - provider disabled", model)
 			}
+		case ProviderGemini:
+			if apiKey, ok := credentials["api_key"]; ok && apiKey != "" {
+				routerConfig.GeminiKey = apiKey
+				if model, hasModel := providerConfig["model"].(string); hasModel && model != "" {
+					routerConfig.GeminiModel = model
+				}
+				log.Printf("[LLM Config] Gemini provider loaded from %s", source)
+			}
 		}
 	}
 
@@ -202,6 +212,9 @@ func LoadLLMConfigFromService(ctx context.Context, tenantID string) LLMRouterCon
 	}
 	if routerConfig.OllamaEndpoint != "" {
 		providers = append(providers, ProviderOllama)
+	}
+	if routerConfig.GeminiKey != "" {
+		providers = append(providers, ProviderGemini)
 	}
 
 	if len(providers) == 0 {

--- a/platform/orchestrator/runtime_config_integration_test.go
+++ b/platform/orchestrator/runtime_config_integration_test.go
@@ -279,10 +279,13 @@ func TestProviderConstants(t *testing.T) {
 	if ProviderOllama != "ollama" {
 		t.Errorf("ProviderOllama = %q, want %q", ProviderOllama, "ollama")
 	}
+	if ProviderGemini != "gemini" {
+		t.Errorf("ProviderGemini = %q, want %q", ProviderGemini, "gemini")
+	}
 
 	// Verify ValidLLMProviders contains all constants
-	if len(ValidLLMProviders) != 4 {
-		t.Errorf("ValidLLMProviders has %d entries, want 4", len(ValidLLMProviders))
+	if len(ValidLLMProviders) != 5 {
+		t.Errorf("ValidLLMProviders has %d entries, want 5", len(ValidLLMProviders))
 	}
 }
 


### PR DESCRIPTION
## Community Edition Update

This sync brings two major updates to the Community edition.

### Gemini LLM Provider (New!)

Community users now have access to Google's Gemini models - the fourth LLM provider in the Community tier:

| Provider | Models |
|----------|--------|
| OpenAI | GPT-4, GPT-3.5 |
| Anthropic | Claude 3 |
| Ollama | Local models |
| **Gemini** (NEW) | Gemini Pro, Gemini Ultra |

Setup: [docs/llm/gemini.md](docs/llm/gemini.md)

### OSS → Community Terminology

All OSS references have been renamed to Community throughout the codebase:

| Before | After |
|--------|-------|
| IsOSSProvider() | IsCommunityProvider() |
| GetOSSProviders() | GetCommunityProviders() |
| OSSLicenseValidator | CommunityLicenseValidator |
| TierOSS | TierCommunity |
| DEPLOYMENT_MODE=oss | DEPLOYMENT_MODE=community |

**Why?** AxonFlow uses BSL 1.1 (source-available), not open source. Community better reflects this.