### PR TITLE
docs: add Gregory Zak contribution for PR #97

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -27,6 +27,7 @@ Contributors are listed here as their PRs are merged.
 | Name | Contribution | PR |
 |------|--------------|-----|
 | [Gregory Zak](https://github.com/gzak) | Self-hosted auth fix | [#89](https://github.com/getaxonflow/axonflow/pull/89) |
+| [Gregory Zak](https://github.com/gzak) | Usage recording Community fix | [#97](https://github.com/getaxonflow/axonflow/pull/97) |
 
 ## Documentation Contributors
 


### PR DESCRIPTION
Add Gregory Zak's second contribution (Usage recording Community fix) to CONTRIBUTORS.md.

## Changes
- Added entry for PR #97 to the Code Contributors table

## Related
- PR #97: fix(agent): usage auditing is a no-op for OSS