### PR TITLE
docs(readme): add Proxy Mode to What AxonFlow Does section

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 ## TL;DR
 
 - **What:** A control plane that sits between your app and LLM providers, applying real-time policy enforcement and orchestration
+- **How it works:** Run AI workflows end-to-end, or plug in via gateway mode to govern existing agent stacks without forcing a rewrite
 - **How it runs:** Docker Compose locally, no signup, no license key required
 - **Core features:** Policy enforcement (PII, injection attacks), audit trails, multi-model routing, multi-agent planning
 - **License:** BSL 1.1 (source-available) — converts to Apache 2.0 after 4 years
@@ -99,9 +100,11 @@ AxonFlow runs inline with LLM traffic, enforcing policies and routing decisions 
 
 **Multi-Agent Planning** — Define agents in YAML, let AxonFlow turn natural language requests into executable workflows.
 
-**Gateway Mode** — Wrap existing LLM calls with governance. Pre-check → your LLM call → audit. Incremental adoption path.
+**Proxy Mode** — Full request lifecycle: policy, planning, routing, audit. Recommended for new projects.
 
-→ **[Architecture deep-dive](https://docs.getaxonflow.com/docs/architecture/overview)**
+**Gateway Mode** — Governance for existing stacks (LangChain, CrewAI). Pre-check → your call → audit.
+
+→ **[Choosing a mode](https://docs.getaxonflow.com/docs/sdk/choosing-a-mode)** · **[Architecture deep-dive](https://docs.getaxonflow.com/docs/architecture/overview)**
 
 ### vs LangChain / LangSmith
 


### PR DESCRIPTION
## Summary

Add Proxy Mode to the "What AxonFlow Does" section (was missing entirely).

**Changes:**
- Add Proxy Mode as recommended approach for new projects
- Clarify Gateway Mode is for existing LangChain/CrewAI stacks  
- Link to choosing-a-mode guide for detailed comparison

## Test plan

- [x] Markdown renders correctly
- [x] Links are valid