### PR TITLE
feat(examples): add LLM Interceptor and MCP Connector examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -72,6 +72,30 @@ Orchestrate multi-step AI workflows with governance.
 | Go | `map/go/` | Generate and execute multi-agent plans |
 | Java | `map/java/` | Generate and execute multi-agent plans |
 
+### LLM Interceptors
+
+Wrap LLM provider clients with transparent governance - no code changes required.
+
+```
+Your App → Wrapped LLM Client → AxonFlow Pre-check → LLM API → AxonFlow Audit
+```
+
+| Language | Path | Description |
+|----------|------|-------------|
+| Python | `interceptors/python/` | OpenAI/Anthropic interceptors |
+| Go | `interceptors/go/` | OpenAI-compatible interceptors |
+| Java | `interceptors/java/` | OpenAI/Anthropic interceptors |
+
+### MCP Connectors
+
+Query external systems through MCP (Model Context Protocol) connectors with policy governance.
+
+| Language | Path | Description |
+|----------|------|-------------|
+| TypeScript | `mcp-connectors/typescript/` | Query MCP connectors |
+| Go | `mcp-connectors/go/` | Query MCP connectors |
+| Java | `mcp-connectors/java/` | Query MCP connectors |
+
 ### Framework Integrations
 
 Use AxonFlow with popular AI frameworks.

--- a/examples/interceptors/go/go.mod
+++ b/examples/interceptors/go/go.mod
@@ -1,0 +1,5 @@
+module github.com/getaxonflow/axonflow/examples/interceptors/go
+
+go 1.21
+
+require github.com/getaxonflow/axonflow-sdk-go v1.5.1

--- a/examples/interceptors/go/go.sum
+++ b/examples/interceptors/go/go.sum
@@ -1,0 +1,2 @@
+github.com/getaxonflow/axonflow-sdk-go v1.5.1 h1:qypChY+jCFuPNPmSaWyQSPmkmuvrOwN5RuxqXfKoSuA=
+github.com/getaxonflow/axonflow-sdk-go v1.5.1/go.mod h1:6bdj+/BwCCBTugIsnFXw+VrnNouif+LUEPeBF9BeE44=

--- a/examples/interceptors/go/main.go
+++ b/examples/interceptors/go/main.go
@@ -1,0 +1,145 @@
+// AxonFlow LLM Interceptor Example - Go
+//
+// Demonstrates how to wrap LLM provider clients with AxonFlow governance
+// using interceptors. This provides transparent policy enforcement without
+// changing your existing LLM call patterns.
+//
+// Interceptors automatically:
+// - Pre-check queries against policies before LLM calls
+// - Block requests that violate policies
+// - Audit LLM responses for compliance tracking
+//
+// Usage:
+//
+//	export AXONFLOW_AGENT_URL=http://localhost:8080
+//	export OPENAI_API_KEY=your-openai-key
+//	go run main.go
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	axonflow "github.com/getaxonflow/axonflow-sdk-go"
+	"github.com/getaxonflow/axonflow-sdk-go/interceptors"
+)
+
+func main() {
+	fmt.Println("AxonFlow LLM Interceptor Example - Go")
+	fmt.Println("============================================================")
+	fmt.Println()
+
+	// Initialize AxonFlow client
+	agentURL := os.Getenv("AXONFLOW_AGENT_URL")
+	if agentURL == "" {
+		agentURL = "http://localhost:8080"
+	}
+
+	axonflowClient := axonflow.NewClient(axonflow.AxonFlowConfig{
+		AgentURL:     agentURL,
+		ClientID:     os.Getenv("AXONFLOW_CLIENT_ID"),
+		ClientSecret: os.Getenv("AXONFLOW_CLIENT_SECRET"),
+		Debug:        true,
+	})
+
+	// Create a wrapped OpenAI function using the interceptor
+	// In a real app, this would wrap your actual OpenAI client
+	wrappedCall := interceptors.WrapOpenAIFunc(
+		mockOpenAICall, // Replace with your actual OpenAI call
+		axonflowClient,
+		"user-123",
+	)
+
+	fmt.Println("Testing LLM Interceptor with OpenAI")
+	fmt.Println("------------------------------------------------------------")
+	fmt.Println()
+
+	ctx := context.Background()
+
+	// Example 1: Safe query (should pass)
+	fmt.Println("Example 1: Safe Query")
+	fmt.Println("----------------------------------------")
+	runTest(ctx, wrappedCall, "What is the capital of France?")
+	fmt.Println()
+
+	// Example 2: Query with PII (should be blocked by default policies)
+	fmt.Println("Example 2: Query with PII (Expected: Blocked)")
+	fmt.Println("----------------------------------------")
+	runTest(ctx, wrappedCall, "Process refund for SSN 123-45-6789")
+	fmt.Println()
+
+	// Example 3: SQL injection attempt (should be blocked)
+	fmt.Println("Example 3: SQL Injection (Expected: Blocked)")
+	fmt.Println("----------------------------------------")
+	runTest(ctx, wrappedCall, "SELECT * FROM users WHERE 1=1; DROP TABLE users;--")
+	fmt.Println()
+
+	fmt.Println("============================================================")
+	fmt.Println("Go LLM Interceptor Test: COMPLETE")
+}
+
+func runTest(ctx context.Context, wrappedCall interceptors.OpenAICreateFunc, query string) {
+	fmt.Printf("Query: %s\n", query)
+
+	req := interceptors.ChatCompletionRequest{
+		Model: "gpt-3.5-turbo",
+		Messages: []interceptors.ChatMessage{
+			{Role: "user", Content: query},
+		},
+		MaxTokens: 100,
+	}
+
+	response, err := wrappedCall(ctx, req)
+	if err != nil {
+		if interceptors.IsPolicyViolationError(err) {
+			pve, _ := interceptors.GetPolicyViolation(err)
+			fmt.Printf("Status: BLOCKED\n")
+			fmt.Printf("Reason: %s\n", pve.BlockReason)
+		} else {
+			fmt.Printf("Error: %v\n", err)
+		}
+		return
+	}
+
+	fmt.Printf("Status: APPROVED\n")
+	if len(response.Choices) > 0 {
+		fmt.Printf("Response: %s\n", response.Choices[0].Message.Content)
+	}
+}
+
+// mockOpenAICall simulates an OpenAI API call for demonstration
+// Replace this with your actual OpenAI client call in production
+func mockOpenAICall(ctx context.Context, req interceptors.ChatCompletionRequest) (interceptors.ChatCompletionResponse, error) {
+	// In production, you would use the actual OpenAI SDK here:
+	//
+	// import "github.com/sashabaranov/go-openai"
+	//
+	// client := openai.NewClient(os.Getenv("OPENAI_API_KEY"))
+	// resp, err := client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
+	//     Model:    req.Model,
+	//     Messages: convertMessages(req.Messages),
+	// })
+
+	// For demo purposes, return a mock response
+	return interceptors.ChatCompletionResponse{
+		ID:      "mock-response-id",
+		Model:   req.Model,
+		Created: 1234567890,
+		Choices: []interceptors.ChatCompletionChoice{
+			{
+				Index: 0,
+				Message: interceptors.ChatMessage{
+					Role:    "assistant",
+					Content: "Paris is the capital of France.",
+				},
+				FinishReason: "stop",
+			},
+		},
+		Usage: interceptors.Usage{
+			PromptTokens:     10,
+			CompletionTokens: 8,
+			TotalTokens:      18,
+		},
+	}, nil
+}

--- a/examples/interceptors/java/pom.xml
+++ b/examples/interceptors/java/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.getaxonflow.examples</groupId>
+    <artifactId>interceptor-example</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+
+    <name>AxonFlow LLM Interceptor Example - Java</name>
+    <description>Example demonstrating LLM interceptors with AxonFlow governance</description>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.getaxonflow</groupId>
+            <artifactId>axonflow-sdk</artifactId>
+            <version>1.1.1</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <mainClass>com.getaxonflow.examples.InterceptorExample</mainClass>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/interceptors/java/src/main/java/com/getaxonflow/examples/InterceptorExample.java
+++ b/examples/interceptors/java/src/main/java/com/getaxonflow/examples/InterceptorExample.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2025 AxonFlow
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.getaxonflow.examples;
+
+import com.getaxonflow.sdk.AxonFlow;
+import com.getaxonflow.sdk.AxonFlowConfig;
+import com.getaxonflow.sdk.exceptions.PolicyViolationException;
+import com.getaxonflow.sdk.interceptors.ChatCompletionRequest;
+import com.getaxonflow.sdk.interceptors.ChatCompletionResponse;
+import com.getaxonflow.sdk.interceptors.ChatMessage;
+import com.getaxonflow.sdk.interceptors.OpenAIInterceptor;
+
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * AxonFlow LLM Interceptor Example - Java
+ *
+ * Demonstrates how to wrap LLM provider clients with AxonFlow governance
+ * using interceptors. This provides transparent policy enforcement without
+ * changing your existing LLM call patterns.
+ *
+ * Interceptors automatically:
+ * - Pre-check queries against policies before LLM calls
+ * - Block requests that violate policies
+ * - Audit LLM responses for compliance tracking
+ *
+ * Usage:
+ *   export AXONFLOW_AGENT_URL=http://localhost:8080
+ *   export OPENAI_API_KEY=your-openai-key
+ *   mvn compile exec:java
+ */
+public class InterceptorExample {
+
+    public static void main(String[] args) {
+        System.out.println("AxonFlow LLM Interceptor Example - Java");
+        System.out.println("============================================================");
+        System.out.println();
+
+        // Initialize AxonFlow client
+        AxonFlow axonflow = AxonFlow.create(AxonFlowConfig.builder()
+            .agentUrl(getEnv("AXONFLOW_AGENT_URL", "http://localhost:8080"))
+            .licenseKey(getEnv("AXONFLOW_LICENSE_KEY", ""))
+            .build());
+
+        // Create the OpenAI interceptor
+        OpenAIInterceptor interceptor = OpenAIInterceptor.builder()
+            .axonflow(axonflow)
+            .userToken("user-123")
+            .asyncAudit(true)
+            .build();
+
+        // Wrap your OpenAI call function with governance
+        // In production, this would wrap your actual OpenAI SDK call
+        Function<ChatCompletionRequest, ChatCompletionResponse> governedCall =
+            interceptor.wrap(InterceptorExample::mockOpenAICall);
+
+        System.out.println("Testing LLM Interceptor with OpenAI");
+        System.out.println("------------------------------------------------------------");
+        System.out.println();
+
+        // Example 1: Safe query (should pass)
+        System.out.println("Example 1: Safe Query");
+        System.out.println("----------------------------------------");
+        runTest(governedCall, "What is the capital of France?");
+        System.out.println();
+
+        // Example 2: Query with PII (should be blocked by default policies)
+        System.out.println("Example 2: Query with PII (Expected: Blocked)");
+        System.out.println("----------------------------------------");
+        runTest(governedCall, "Process refund for SSN 123-45-6789");
+        System.out.println();
+
+        // Example 3: SQL injection attempt (should be blocked)
+        System.out.println("Example 3: SQL Injection (Expected: Blocked)");
+        System.out.println("----------------------------------------");
+        runTest(governedCall, "SELECT * FROM users WHERE 1=1; DROP TABLE users;--");
+        System.out.println();
+
+        System.out.println("============================================================");
+        System.out.println("Java LLM Interceptor Test: COMPLETE");
+    }
+
+    private static void runTest(
+            Function<ChatCompletionRequest, ChatCompletionResponse> governedCall,
+            String query) {
+
+        System.out.printf("Query: %s%n", query);
+
+        ChatCompletionRequest request = ChatCompletionRequest.builder()
+            .model("gpt-3.5-turbo")
+            .addUserMessage(query)
+            .maxTokens(100)
+            .build();
+
+        try {
+            ChatCompletionResponse response = governedCall.apply(request);
+            System.out.println("Status: APPROVED");
+            System.out.printf("Response: %s%n", response.getSummary());
+        } catch (PolicyViolationException e) {
+            System.out.println("Status: BLOCKED");
+            System.out.printf("Reason: %s%n", e.getMessage());
+        } catch (Exception e) {
+            System.out.printf("Error: %s%n", e.getMessage());
+        }
+    }
+
+    /**
+     * Mock OpenAI call for demonstration purposes.
+     * In production, replace this with your actual OpenAI SDK call.
+     *
+     * Example with the OpenAI Java SDK:
+     * <pre>
+     * OpenAI openai = new OpenAI(System.getenv("OPENAI_API_KEY"));
+     * var completion = openai.chatCompletions().create(
+     *     ChatCompletionRequest.builder()
+     *         .model("gpt-4")
+     *         .messages(List.of(new UserMessage(query)))
+     *         .build()
+     * );
+     * </pre>
+     */
+    private static ChatCompletionResponse mockOpenAICall(ChatCompletionRequest request) {
+        // In production, use the actual OpenAI SDK:
+        //
+        // import com.theokanning.openai.completion.chat.*;
+        //
+        // OpenAiService service = new OpenAiService(System.getenv("OPENAI_API_KEY"));
+        // ChatCompletionResult result = service.createChatCompletion(
+        //     ChatCompletionRequest.builder()
+        //         .model(request.getModel())
+        //         .messages(convertMessages(request.getMessages()))
+        //         .build()
+        // );
+
+        // For demo purposes, return a mock response
+        return ChatCompletionResponse.builder()
+            .id("mock-response-id")
+            .model(request.getModel())
+            .created(System.currentTimeMillis() / 1000)
+            .choices(List.of(new ChatCompletionResponse.Choice(
+                0,
+                ChatMessage.assistant("Paris is the capital of France."),
+                "stop"
+            )))
+            .usage(ChatCompletionResponse.Usage.of(10, 8))
+            .build();
+    }
+
+    private static String getEnv(String name, String defaultValue) {
+        String value = System.getenv(name);
+        return (value != null && !value.isEmpty()) ? value : defaultValue;
+    }
+}

--- a/examples/interceptors/python/.env.example
+++ b/examples/interceptors/python/.env.example
@@ -1,0 +1,6 @@
+# AxonFlow Configuration
+AXONFLOW_AGENT_URL=http://localhost:8080
+AXONFLOW_LICENSE_KEY=
+
+# OpenAI Configuration
+OPENAI_API_KEY=your-openai-api-key

--- a/examples/interceptors/python/main.py
+++ b/examples/interceptors/python/main.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""
+AxonFlow LLM Interceptor Example - Python
+
+Demonstrates how to wrap LLM provider clients with AxonFlow governance
+using interceptors. This provides transparent policy enforcement without
+changing your existing LLM call patterns.
+
+Interceptors automatically:
+- Pre-check queries against policies before LLM calls
+- Block requests that violate policies
+- Audit LLM responses for compliance tracking
+
+Requirements:
+    pip install axonflow openai
+
+Usage:
+    export AXONFLOW_AGENT_URL=http://localhost:8080
+    export OPENAI_API_KEY=your-openai-key
+    python main.py
+"""
+
+import asyncio
+import os
+
+from openai import OpenAI
+
+from axonflow import AxonFlow
+from axonflow.interceptors.openai import wrap_openai_client
+from axonflow.exceptions import PolicyViolationError
+
+
+def main():
+    print("AxonFlow LLM Interceptor Example - Python")
+    print("=" * 60)
+    print()
+
+    # Initialize AxonFlow client
+    axonflow = AxonFlow(
+        agent_url=os.getenv("AXONFLOW_AGENT_URL", "http://localhost:8080"),
+        license_key=os.getenv("AXONFLOW_LICENSE_KEY", ""),
+    )
+
+    # Initialize OpenAI client
+    openai_client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+
+    # Wrap OpenAI client with AxonFlow governance
+    # All calls through this client will be policy-checked automatically
+    governed_client = wrap_openai_client(
+        openai_client,
+        axonflow,
+        user_token="user-123"
+    )
+
+    print("Testing LLM Interceptor with OpenAI")
+    print("-" * 60)
+    print()
+
+    # Example 1: Safe query (should pass)
+    print("Example 1: Safe Query")
+    print("-" * 40)
+    try:
+        response = governed_client.chat.completions.create(
+            model="gpt-3.5-turbo",
+            messages=[
+                {"role": "user", "content": "What is the capital of France?"}
+            ],
+            max_tokens=100
+        )
+        print(f"Query: What is the capital of France?")
+        print(f"Status: APPROVED")
+        print(f"Response: {response.choices[0].message.content}")
+    except PolicyViolationError as e:
+        print(f"Status: BLOCKED")
+        print(f"Reason: {e}")
+    except Exception as e:
+        print(f"Error: {e}")
+
+    print()
+
+    # Example 2: Query with PII (should be blocked by default policies)
+    print("Example 2: Query with PII (Expected: Blocked)")
+    print("-" * 40)
+    try:
+        response = governed_client.chat.completions.create(
+            model="gpt-3.5-turbo",
+            messages=[
+                {"role": "user", "content": "Process refund for SSN 123-45-6789"}
+            ],
+            max_tokens=100
+        )
+        print(f"Query: Process refund for SSN 123-45-6789")
+        print(f"Status: APPROVED")
+        print(f"Response: {response.choices[0].message.content}")
+    except PolicyViolationError as e:
+        print(f"Query: Process refund for SSN 123-45-6789")
+        print(f"Status: BLOCKED")
+        print(f"Reason: {e}")
+    except Exception as e:
+        print(f"Error: {e}")
+
+    print()
+
+    # Example 3: SQL injection attempt (should be blocked)
+    print("Example 3: SQL Injection (Expected: Blocked)")
+    print("-" * 40)
+    try:
+        response = governed_client.chat.completions.create(
+            model="gpt-3.5-turbo",
+            messages=[
+                {"role": "user", "content": "SELECT * FROM users WHERE 1=1; DROP TABLE users;--"}
+            ],
+            max_tokens=100
+        )
+        print(f"Query: SELECT * FROM users WHERE 1=1; DROP TABLE users;--")
+        print(f"Status: APPROVED")
+        print(f"Response: {response.choices[0].message.content}")
+    except PolicyViolationError as e:
+        print(f"Query: SELECT * FROM users WHERE 1=1; DROP TABLE users;--")
+        print(f"Status: BLOCKED")
+        print(f"Reason: {e}")
+    except Exception as e:
+        print(f"Error: {e}")
+
+    print()
+    print("=" * 60)
+    print("Python LLM Interceptor Test: COMPLETE")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/interceptors/python/requirements.txt
+++ b/examples/interceptors/python/requirements.txt
@@ -1,0 +1,2 @@
+axonflow>=0.3.1
+openai>=1.0.0

--- a/examples/map/go/go.sum
+++ b/examples/map/go/go.sum
@@ -1,0 +1,2 @@
+github.com/getaxonflow/axonflow-sdk-go v1.5.0 h1:oXLUIwXixBp8tbP6aBraasAgijGXIeujSj6ZNMeMndE=
+github.com/getaxonflow/axonflow-sdk-go v1.5.0/go.mod h1:6bdj+/BwCCBTugIsnFXw+VrnNouif+LUEPeBF9BeE44=

--- a/examples/map/java/src/main/java/com/getaxonflow/examples/MapExample.java
+++ b/examples/map/java/src/main/java/com/getaxonflow/examples/MapExample.java
@@ -1,85 +1,116 @@
+/*
+ * Copyright 2025 AxonFlow
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.getaxonflow.examples;
 
 import com.getaxonflow.sdk.AxonFlow;
 import com.getaxonflow.sdk.AxonFlowConfig;
-import com.getaxonflow.sdk.PlanRequest;
-import com.getaxonflow.sdk.PlanResponse;
-import com.getaxonflow.sdk.PlanStep;
+import com.getaxonflow.sdk.types.ClientRequest;
+import com.getaxonflow.sdk.types.ClientResponse;
+import com.getaxonflow.sdk.types.RequestType;
+import com.getaxonflow.sdk.exceptions.AxonFlowException;
+
+import java.util.Map;
 
 /**
  * AxonFlow MAP (Multi-Agent Planning) Example - Java SDK
+ *
+ * Multi-Agent Planning allows you to orchestrate complex AI workflows
+ * by having AxonFlow break down a goal into multiple steps and execute them.
  */
 public class MapExample {
+
     public static void main(String[] args) {
         System.out.println("AxonFlow MAP Example - Java");
         System.out.println("==================================================");
         System.out.println();
 
-        // Initialize client - uses environment variables or defaults for self-hosted
-        String agentUrl = System.getenv("AXONFLOW_AGENT_URL");
-        if (agentUrl == null || agentUrl.isEmpty()) {
-            agentUrl = "http://localhost:8080";
-        }
-        String clientId = System.getenv("AXONFLOW_CLIENT_ID");
-        if (clientId == null || clientId.isEmpty()) {
-            clientId = "demo";
-        }
-        String clientSecret = System.getenv("AXONFLOW_CLIENT_SECRET");
-        if (clientSecret == null || clientSecret.isEmpty()) {
-            clientSecret = "demo";
-        }
+        // Initialize AxonFlow client
+        AxonFlow client = AxonFlow.create(AxonFlowConfig.builder()
+            .agentUrl(getEnv("AXONFLOW_AGENT_URL", "http://localhost:8080"))
+            .licenseKey(getEnv("AXONFLOW_LICENSE_KEY", ""))
+            .build());
 
-        AxonFlowConfig config = AxonFlowConfig.builder()
-            .agentUrl(agentUrl)
-            .clientId(clientId)
-            .clientSecret(clientSecret)
-            .debug(true)
-            .build();
+        // Simple query for testing
+        String query = "Create a brief plan to greet a new user and ask how to help them";
+        String domain = "generic";
 
-        try (AxonFlow client = new AxonFlow(config)) {
-            // Simple query for testing
-            String query = "Create a brief plan to greet a new user and ask how to help them";
-            String domain = "generic";
+        System.out.println("Query: " + query);
+        System.out.println("Domain: " + domain);
+        System.out.println("--------------------------------------------------");
+        System.out.println();
 
-            System.out.println("Query: " + query);
-            System.out.println("Domain: " + domain);
-            System.out.println("--------------------------------------------------");
-            System.out.println();
+        long startTime = System.currentTimeMillis();
 
-            // Generate a plan
-            PlanRequest request = PlanRequest.builder()
-                .objective(query)
-                .domain(domain)
+        try {
+            // Generate a plan using executeQuery with multi-agent-plan request type
+            ClientRequest request = ClientRequest.builder()
+                .query(query)
+                .userToken("user-123")
+                .clientId("map-example")
+                .requestType(RequestType.MULTI_AGENT_PLAN)
+                .context(Map.of("domain", domain))
                 .build();
 
-            PlanResponse plan = client.generatePlan(request);
+            ClientResponse response = client.executeQuery(request);
+            long duration = System.currentTimeMillis() - startTime;
 
-            System.out.println("✅ Plan Generated Successfully");
-            System.out.println("Plan ID: " + plan.getPlanId());
-            System.out.println("Steps: " + (plan.getSteps() != null ? plan.getSteps().size() : 0));
+            if (response.isSuccess() && !response.isBlocked()) {
+                System.out.println("✅ Plan Generated Successfully");
+                System.out.println("Duration: " + duration + "ms");
 
-            if (plan.getSteps() != null) {
-                int i = 1;
-                for (PlanStep step : plan.getSteps()) {
-                    System.out.println("  " + i + ". " + step.getName() + " (" + step.getType() + ")");
-                    i++;
+                Object data = response.getData();
+                if (data != null) {
+                    String dataStr = data.toString();
+                    System.out.println();
+                    System.out.println("Response:");
+                    // Print first 500 chars
+                    if (dataStr.length() > 500) {
+                        System.out.println(dataStr.substring(0, 500) + "...");
+                    } else {
+                        System.out.println(dataStr);
+                    }
+                } else if (response.getResult() != null) {
+                    System.out.println();
+                    System.out.println("Response:");
+                    System.out.println(response.getResult());
                 }
-            }
 
-            if (plan.getResult() != null && !plan.getResult().isEmpty()) {
                 System.out.println();
-                System.out.println("Result Preview:");
-                String preview = plan.getResult();
-                if (preview.length() > 500) {
-                    preview = preview.substring(0, 500) + "...";
-                }
-                System.out.println(preview);
+                System.out.println("==================================================");
+                System.out.println("✅ Java MAP Test: PASS");
+            } else if (response.isBlocked()) {
+                System.out.println("❌ Request blocked: " + response.getBlockReason());
+                System.out.println();
+                System.out.println("==================================================");
+                System.out.println("❌ Java MAP Test: FAIL (blocked)");
+                System.exit(1);
+            } else {
+                System.out.println("❌ Request failed: " + response.getError());
+                System.out.println();
+                System.out.println("==================================================");
+                System.out.println("❌ Java MAP Test: FAIL");
+                System.exit(1);
             }
 
+        } catch (AxonFlowException e) {
+            System.err.println("❌ AxonFlow Error: " + e.getMessage());
             System.out.println();
             System.out.println("==================================================");
-            System.out.println("✅ Java MAP Test: PASS");
-
+            System.out.println("❌ Java MAP Test: FAIL");
+            System.exit(1);
         } catch (Exception e) {
             System.err.println("❌ Error: " + e.getMessage());
             e.printStackTrace();
@@ -88,5 +119,10 @@ public class MapExample {
             System.out.println("❌ Java MAP Test: FAIL");
             System.exit(1);
         }
+    }
+
+    private static String getEnv(String name, String defaultValue) {
+        String value = System.getenv(name);
+        return (value != null && !value.isEmpty()) ? value : defaultValue;
     }
 }

--- a/examples/map/typescript/src/index.ts
+++ b/examples/map/typescript/src/index.ts
@@ -11,9 +11,9 @@ async function main(): Promise<void> {
 
   // Initialize client - uses environment variables or defaults for self-hosted
   const axonflow = new AxonFlow({
-    agentUrl: process.env.AXONFLOW_AGENT_URL || 'http://localhost:8080',
-    clientId: process.env.AXONFLOW_CLIENT_ID || 'demo',
-    clientSecret: process.env.AXONFLOW_CLIENT_SECRET || 'demo',
+    endpoint: process.env.AXONFLOW_AGENT_URL || 'http://localhost:8080',
+    licenseKey: process.env.AXONFLOW_LICENSE_KEY || '',
+    tenant: process.env.AXONFLOW_TENANT || 'demo',
     debug: true,
   });
 

--- a/examples/mcp-connectors/go/go.mod
+++ b/examples/mcp-connectors/go/go.mod
@@ -1,0 +1,5 @@
+module github.com/getaxonflow/axonflow/examples/mcp-connectors/go
+
+go 1.21
+
+require github.com/getaxonflow/axonflow-sdk-go v1.5.1

--- a/examples/mcp-connectors/go/go.sum
+++ b/examples/mcp-connectors/go/go.sum
@@ -1,0 +1,2 @@
+github.com/getaxonflow/axonflow-sdk-go v1.5.1 h1:qypChY+jCFuPNPmSaWyQSPmkmuvrOwN5RuxqXfKoSuA=
+github.com/getaxonflow/axonflow-sdk-go v1.5.1/go.mod h1:6bdj+/BwCCBTugIsnFXw+VrnNouif+LUEPeBF9BeE44=

--- a/examples/mcp-connectors/go/main.go
+++ b/examples/mcp-connectors/go/main.go
@@ -1,0 +1,124 @@
+// AxonFlow MCP Connector Example - Go
+//
+// Demonstrates how to query MCP (Model Context Protocol) connectors
+// through AxonFlow with policy governance.
+//
+// MCP connectors allow AI applications to securely interact with
+// external systems like GitHub, Salesforce, Jira, and more.
+//
+// Prerequisites:
+// - AxonFlow running with connectors enabled
+// - Connector installed and configured (e.g., GitHub connector)
+//
+// Usage:
+//
+//	export AXONFLOW_AGENT_URL=http://localhost:8080
+//	go run main.go
+package main
+
+import (
+	"fmt"
+	"os"
+
+	axonflow "github.com/getaxonflow/axonflow-sdk-go"
+)
+
+func main() {
+	fmt.Println("AxonFlow MCP Connector Example - Go")
+	fmt.Println("============================================================")
+	fmt.Println()
+
+	// Initialize AxonFlow client
+	agentURL := os.Getenv("AXONFLOW_AGENT_URL")
+	if agentURL == "" {
+		agentURL = "http://localhost:8080"
+	}
+
+	client := axonflow.NewClient(axonflow.AxonFlowConfig{
+		AgentURL:     agentURL,
+		ClientID:     os.Getenv("AXONFLOW_CLIENT_ID"),
+		ClientSecret: os.Getenv("AXONFLOW_CLIENT_SECRET"),
+		Debug:        true,
+	})
+
+	fmt.Println("Testing MCP Connector Queries")
+	fmt.Println("------------------------------------------------------------")
+	fmt.Println()
+
+	// Example 1: Query GitHub Connector
+	fmt.Println("Example 1: Query GitHub Connector")
+	fmt.Println("----------------------------------------")
+
+	response, err := client.QueryConnector(
+		"user-123",                                        // user token
+		"github",                                          // connector name
+		"list open issues in the main repository",         // query
+		map[string]interface{}{                            // parameters
+			"repo":  "getaxonflow/axonflow",
+			"state": "open",
+			"limit": 5,
+		},
+	)
+
+	if err != nil {
+		// Connector not installed - expected for demo
+		fmt.Println("Status: Connector not available (expected if not installed)")
+		fmt.Printf("Error: %v\n", err)
+	} else if response.Success {
+		fmt.Println("Status: SUCCESS")
+		fmt.Printf("Data: %v\n", response.Data)
+	} else {
+		fmt.Println("Status: FAILED")
+		fmt.Printf("Error: %s\n", response.Error)
+	}
+
+	fmt.Println()
+
+	// Example 2: Query with Policy Enforcement
+	fmt.Println("Example 2: Query with Policy Enforcement")
+	fmt.Println("----------------------------------------")
+	fmt.Println("MCP queries are policy-checked before execution.")
+	fmt.Println("Queries that violate policies will be blocked.")
+
+	// This demonstrates that even connector queries go through policy checks
+	response, err = client.QueryConnector(
+		"user-123",
+		"database",
+		"SELECT * FROM users WHERE 1=1; DROP TABLE users;--", // SQL injection attempt
+		map[string]interface{}{},
+	)
+
+	if err != nil {
+		errStr := err.Error()
+		if containsAny(errStr, []string{"blocked", "policy", "DROP TABLE", "dangerous"}) {
+			fmt.Println("Status: BLOCKED by policy (expected behavior)")
+			fmt.Printf("Reason: %v\n", err)
+		} else {
+			fmt.Println("Status: Connector not available")
+			fmt.Printf("Error: %v\n", err)
+		}
+	} else if !response.Success {
+		fmt.Println("Status: BLOCKED by policy")
+		fmt.Printf("Reason: %s\n", response.Error)
+	} else {
+		fmt.Println("Status: Query allowed")
+		fmt.Printf("Response: %v\n", response.Data)
+	}
+
+	fmt.Println()
+	fmt.Println("============================================================")
+	fmt.Println("Go MCP Connector Test: COMPLETE")
+}
+
+func containsAny(s string, substrs []string) bool {
+	for _, substr := range substrs {
+		if len(s) >= len(substr) {
+			for i := 0; i <= len(s)-len(substr); i++ {
+				if s[i:i+len(substr)] == substr {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}

--- a/examples/mcp-connectors/java/pom.xml
+++ b/examples/mcp-connectors/java/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.getaxonflow.examples</groupId>
+    <artifactId>mcp-connector-example</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+
+    <name>AxonFlow MCP Connector Example - Java</name>
+    <description>Example demonstrating MCP connector queries with AxonFlow governance</description>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.getaxonflow</groupId>
+            <artifactId>axonflow-sdk</artifactId>
+            <version>1.1.1</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <mainClass>com.getaxonflow.examples.McpConnectorExample</mainClass>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/mcp-connectors/java/src/main/java/com/getaxonflow/examples/McpConnectorExample.java
+++ b/examples/mcp-connectors/java/src/main/java/com/getaxonflow/examples/McpConnectorExample.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2025 AxonFlow
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.getaxonflow.examples;
+
+import com.getaxonflow.sdk.AxonFlow;
+import com.getaxonflow.sdk.AxonFlowConfig;
+import com.getaxonflow.sdk.types.ConnectorQuery;
+import com.getaxonflow.sdk.types.ConnectorResponse;
+import com.getaxonflow.sdk.exceptions.ConnectorException;
+
+import java.util.Map;
+
+/**
+ * AxonFlow MCP Connector Example - Java
+ *
+ * Demonstrates how to query MCP (Model Context Protocol) connectors
+ * through AxonFlow with policy governance.
+ *
+ * MCP connectors allow AI applications to securely interact with
+ * external systems like GitHub, Salesforce, Jira, and more.
+ *
+ * Prerequisites:
+ * - AxonFlow running with connectors enabled
+ * - Connector installed and configured (e.g., GitHub connector)
+ *
+ * Usage:
+ *   export AXONFLOW_AGENT_URL=http://localhost:8080
+ *   mvn compile exec:java
+ */
+public class McpConnectorExample {
+
+    public static void main(String[] args) {
+        System.out.println("AxonFlow MCP Connector Example - Java");
+        System.out.println("============================================================");
+        System.out.println();
+
+        // Initialize AxonFlow client
+        AxonFlow axonflow = AxonFlow.create(AxonFlowConfig.builder()
+            .agentUrl(getEnv("AXONFLOW_AGENT_URL", "http://localhost:8080"))
+            .licenseKey(getEnv("AXONFLOW_LICENSE_KEY", ""))
+            .build());
+
+        System.out.println("Testing MCP Connector Queries");
+        System.out.println("------------------------------------------------------------");
+        System.out.println();
+
+        // Example 1: Query GitHub Connector
+        System.out.println("Example 1: Query GitHub Connector");
+        System.out.println("----------------------------------------");
+
+        try {
+            ConnectorQuery query = ConnectorQuery.builder()
+                .connectorId("github")
+                .operation("list_issues")
+                .userToken("user-123")
+                .addParameter("repo", "getaxonflow/axonflow")
+                .addParameter("state", "open")
+                .addParameter("limit", 5)
+                .build();
+
+            ConnectorResponse response = axonflow.queryConnector(query);
+
+            if (response.isSuccess()) {
+                System.out.println("Status: SUCCESS");
+                System.out.printf("Data: %s%n", response.getData());
+            } else {
+                System.out.println("Status: FAILED");
+                System.out.printf("Error: %s%n", response.getError());
+            }
+        } catch (ConnectorException e) {
+            // Connector not installed - expected for demo
+            System.out.println("Status: Connector not available (expected if not installed)");
+            System.out.printf("Error: %s%n", e.getMessage());
+        } catch (Exception e) {
+            System.out.println("Status: ERROR");
+            System.out.printf("Error: %s%n", e.getMessage());
+        }
+
+        System.out.println();
+
+        // Example 2: Query with Policy Enforcement
+        System.out.println("Example 2: Query with Policy Enforcement");
+        System.out.println("----------------------------------------");
+        System.out.println("MCP queries are policy-checked before execution.");
+        System.out.println("Queries that violate policies will be blocked.");
+
+        try {
+            // This demonstrates that even connector queries go through policy checks
+            ConnectorQuery query = ConnectorQuery.builder()
+                .connectorId("database")
+                .operation("SELECT * FROM users WHERE 1=1; DROP TABLE users;--")
+                .userToken("user-123")
+                .build();
+
+            ConnectorResponse response = axonflow.queryConnector(query);
+
+            if (!response.isSuccess()) {
+                String error = response.getError();
+                if (error != null && (error.contains("blocked") || error.contains("policy") ||
+                    error.contains("DROP TABLE") || error.contains("dangerous"))) {
+                    System.out.println("Status: BLOCKED by policy (expected behavior)");
+                    System.out.printf("Reason: %s%n", error);
+                } else {
+                    System.out.println("Status: FAILED");
+                    System.out.printf("Error: %s%n", error);
+                }
+            } else {
+                System.out.println("Status: Query allowed");
+                System.out.printf("Response: %s%n", response.getData());
+            }
+        } catch (Exception e) {
+            String error = e.getMessage();
+            if (error != null && (error.contains("blocked") || error.contains("policy") ||
+                error.contains("DROP TABLE") || error.contains("dangerous"))) {
+                System.out.println("Status: BLOCKED by policy (expected behavior)");
+                System.out.printf("Reason: %s%n", error);
+            } else {
+                System.out.println("Status: Connector not available");
+                System.out.printf("Error: %s%n", error);
+            }
+        }
+
+        System.out.println();
+        System.out.println("============================================================");
+        System.out.println("Java MCP Connector Test: COMPLETE");
+    }
+
+    private static String getEnv(String name, String defaultValue) {
+        String value = System.getenv(name);
+        return (value != null && !value.isEmpty()) ? value : defaultValue;
+    }
+}

--- a/examples/mcp-connectors/typescript/package.json
+++ b/examples/mcp-connectors/typescript/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "axonflow-mcp-connector-example",
+  "version": "1.0.0",
+  "description": "AxonFlow MCP Connector Example - TypeScript",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "npx tsx src/index.ts"
+  },
+  "dependencies": {
+    "@axonflow/sdk": "^1.4.2"
+  },
+  "devDependencies": {
+    "tsx": "^4.7.0",
+    "typescript": "^5.3.3"
+  }
+}

--- a/examples/mcp-connectors/typescript/src/index.ts
+++ b/examples/mcp-connectors/typescript/src/index.ts
@@ -1,0 +1,97 @@
+/**
+ * AxonFlow MCP Connector Example - TypeScript
+ *
+ * Demonstrates how to query MCP (Model Context Protocol) connectors
+ * through AxonFlow with policy governance.
+ *
+ * MCP connectors allow AI applications to securely interact with
+ * external systems like GitHub, Salesforce, Jira, and more.
+ *
+ * Prerequisites:
+ * - AxonFlow running with connectors enabled
+ * - Connector installed and configured (e.g., GitHub connector)
+ *
+ * Usage:
+ *   export AXONFLOW_AGENT_URL=http://localhost:8080
+ *   npm run start
+ */
+
+import { AxonFlow } from '@axonflow/sdk';
+
+async function main(): Promise<void> {
+  console.log('AxonFlow MCP Connector Example - TypeScript');
+  console.log('='.repeat(60));
+  console.log();
+
+  // Initialize AxonFlow client
+  const axonflow = new AxonFlow({
+    endpoint: process.env.AXONFLOW_AGENT_URL || 'http://localhost:8080',
+    licenseKey: process.env.AXONFLOW_LICENSE_KEY || '',
+    tenant: process.env.AXONFLOW_TENANT || 'demo',
+    debug: true,
+  });
+
+  console.log('Testing MCP Connector Queries');
+  console.log('-'.repeat(60));
+  console.log();
+
+  // Example 1: List GitHub Issues (requires GitHub connector)
+  console.log('Example 1: Query GitHub Connector');
+  console.log('-'.repeat(40));
+  try {
+    const response = await axonflow.queryConnector(
+      'github',  // connector name
+      'list open issues in the main repository',  // natural language query
+      {
+        repo: 'getaxonflow/axonflow',
+        state: 'open',
+        limit: 5,
+      }
+    );
+
+    if (response.success) {
+      console.log('Status: SUCCESS');
+      console.log('Data:', JSON.stringify(response.data, null, 2).substring(0, 500));
+    } else {
+      console.log('Status: FAILED');
+      console.log('Error:', response.error);
+    }
+  } catch (error) {
+    // Connector not installed - expected for demo
+    console.log('Status: Connector not available (expected if not installed)');
+    console.log(`Error: ${error}`);
+  }
+
+  console.log();
+
+  // Example 2: Search with Policy Check
+  console.log('Example 2: Query with Policy Enforcement');
+  console.log('-'.repeat(40));
+  console.log('MCP queries are policy-checked before execution.');
+  console.log('Queries that violate policies will be blocked.');
+
+  try {
+    // This demonstrates that even connector queries go through policy checks
+    const response = await axonflow.queryConnector(
+      'database',  // Example connector
+      'SELECT * FROM users WHERE 1=1; DROP TABLE users;--',  // SQL injection attempt
+      {}
+    );
+    console.log('Status: Query allowed');
+    console.log('Response:', response);
+  } catch (error: any) {
+    if (error.message?.includes('blocked') || error.message?.includes('policy')) {
+      console.log('Status: BLOCKED by policy (expected behavior)');
+      console.log('Reason:', error.message);
+    } else {
+      console.log('Status: Connector not available');
+      console.log(`Error: ${error.message}`);
+    }
+  }
+
+  console.log();
+  console.log('='.repeat(60));
+  console.log('TypeScript MCP Connector Test: COMPLETE');
+}
+
+main().catch(console.error);

--- a/examples/mcp-connectors/typescript/tsconfig.json
+++ b/examples/mcp-connectors/typescript/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- Add LLM Interceptor examples for Python, Go, and Java
- Add MCP Connector examples for TypeScript, Go, and Java  
- Fix MAP examples for TypeScript (config properties) and Java (RequestType enum)
- Update README with new example sections

## Changes

### LLM Interceptor Examples
Demonstrates transparent governance on LLM provider clients:
- `interceptors/python/` - OpenAI wrapper with policy checks
- `interceptors/go/` - OpenAI-compatible wrapper
- `interceptors/java/` - OpenAI interceptor with builder pattern

### MCP Connector Examples
Shows querying MCP connectors with policy governance:
- `mcp-connectors/typescript/` - queryConnector API usage
- `mcp-connectors/go/` - QueryConnector function
- `mcp-connectors/java/` - ConnectorQuery builder

### Bug Fixes
- TypeScript MAP: Fixed config properties (`endpoint` instead of `agentUrl`, `licenseKey` instead of `clientSecret`)
- Java MAP: Fixed RequestType enum usage (`RequestType.MULTI_AGENT_PLAN` instead of string)

## Test plan
- [x] Go interceptor example compiles and runs
- [x] Java interceptor example compiles and runs
- [x] Go MCP connector example compiles
- [x] Java MCP connector example compiles
- [x] TypeScript MAP example runs successfully
- [x] Java MAP example runs successfully