### PR TITLE
feat: SQL injection scanner environment configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# AxonFlow Local Development Environment Variables
+# Copy this file to .env and fill in your API keys
+
+# LLM API Keys (optional for local development)
+# Only needed if testing LLM integrations
+OPENAI_API_KEY=
+ANTHROPIC_API_KEY=
+
+# Local LLM Endpoint (optional)
+# If running a local LLM (e.g., Ollama, LM Studio)
+LOCAL_LLM_ENDPOINT=
+
+# Database settings are configured in docker-compose.yml
+# No need to set them here unless you're using external PostgreSQL

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,6 +102,12 @@ services:
       DEPLOYMENT_MODE: ${DEPLOYMENT_MODE:-community}
       LOG_LEVEL: debug
 
+      # SQL Injection Scanner Configuration
+      # SQLI_SCANNER_MODE: off, basic, advanced (default: basic)
+      # SQLI_BLOCK_MODE: block, warn (default: block)
+      SQLI_SCANNER_MODE: ${SQLI_SCANNER_MODE:-basic}
+      SQLI_BLOCK_MODE: ${SQLI_BLOCK_MODE:-block}
+
       # Redis (optional)
       REDIS_URL: redis://redis:6379
 

--- a/examples/hello-world/go/.env.example
+++ b/examples/hello-world/go/.env.example
@@ -1,0 +1,11 @@
+# AxonFlow Configuration
+# Copy this file to .env and source it before running
+
+# Agent Endpoint (from CloudFormation Outputs)
+export AXONFLOW_ENDPOINT=https://your-agent-endpoint
+
+# License Key (from CloudFormation Outputs)
+export AXONFLOW_LICENSE_KEY=AXON-V2-your-key-here
+
+# Organization ID
+export AXONFLOW_ORG_ID=my-org

--- a/examples/hello-world/python/.env.example
+++ b/examples/hello-world/python/.env.example
@@ -1,0 +1,5 @@
+# AxonFlow Configuration
+AXONFLOW_AGENT_URL=http://localhost:8080
+AXONFLOW_LICENSE_KEY=your-license-key-here
+AXONFLOW_CLIENT_ID=demo
+AXONFLOW_CLIENT_SECRET=demo-secret

--- a/examples/hello-world/typescript/.env.example
+++ b/examples/hello-world/typescript/.env.example
@@ -1,0 +1,7 @@
+# AxonFlow Configuration
+AXONFLOW_AGENT_URL=http://localhost:8080
+AXONFLOW_LICENSE_KEY=your-license-key-here
+AXONFLOW_TENANT=demo
+
+# LLM Provider
+OPENAI_API_KEY=sk-your-openai-key-here

--- a/examples/integrations/crewai/.env.example
+++ b/examples/integrations/crewai/.env.example
@@ -1,0 +1,8 @@
+# AxonFlow Configuration
+AXONFLOW_AGENT_URL=http://localhost:8080
+AXONFLOW_LICENSE_KEY=your-license-key-here
+AXONFLOW_CLIENT_ID=demo
+AXONFLOW_CLIENT_SECRET=demo-secret
+
+# LLM Provider
+OPENAI_API_KEY=sk-your-openai-key-here

--- a/examples/integrations/gateway-mode/go/.env.example
+++ b/examples/integrations/gateway-mode/go/.env.example
@@ -1,0 +1,8 @@
+# AxonFlow Configuration
+AXONFLOW_AGENT_URL=http://localhost:8080
+AXONFLOW_LICENSE_KEY=your-license-key-here
+AXONFLOW_CLIENT_ID=demo
+AXONFLOW_CLIENT_SECRET=demo-secret
+
+# LLM Provider
+OPENAI_API_KEY=sk-your-openai-key-here

--- a/examples/integrations/gateway-mode/python/.env.example
+++ b/examples/integrations/gateway-mode/python/.env.example
@@ -1,0 +1,9 @@
+# AxonFlow Configuration
+AXONFLOW_AGENT_URL=http://localhost:8080
+AXONFLOW_LICENSE_KEY=your-license-key-here
+AXONFLOW_CLIENT_ID=demo
+AXONFLOW_CLIENT_SECRET=demo-secret
+
+# LLM Providers
+OPENAI_API_KEY=sk-your-openai-key-here
+ANTHROPIC_API_KEY=sk-ant-your-anthropic-key-here

--- a/examples/integrations/gateway-mode/typescript/.env.example
+++ b/examples/integrations/gateway-mode/typescript/.env.example
@@ -1,0 +1,8 @@
+# AxonFlow Configuration
+AXONFLOW_AGENT_URL=http://localhost:8080
+AXONFLOW_LICENSE_KEY=your-license-key-here
+AXONFLOW_TENANT=demo
+
+# LLM Provider Configuration (choose one or both)
+OPENAI_API_KEY=sk-your-openai-key-here
+ANTHROPIC_API_KEY=sk-ant-your-anthropic-key-here

--- a/examples/integrations/langchain/.env.example
+++ b/examples/integrations/langchain/.env.example
@@ -1,0 +1,9 @@
+# AxonFlow Configuration
+AXONFLOW_AGENT_URL=http://localhost:8080
+AXONFLOW_LICENSE_KEY=your-license-key-here
+AXONFLOW_CLIENT_ID=demo
+AXONFLOW_CLIENT_SECRET=demo-secret
+
+# LLM Providers
+OPENAI_API_KEY=sk-your-openai-key-here
+ANTHROPIC_API_KEY=sk-ant-your-anthropic-key-here

--- a/examples/integrations/proxy-mode/go/.env.example
+++ b/examples/integrations/proxy-mode/go/.env.example
@@ -1,0 +1,5 @@
+# AxonFlow Configuration
+AXONFLOW_AGENT_URL=http://localhost:8080
+AXONFLOW_LICENSE_KEY=your-license-key-here
+AXONFLOW_CLIENT_ID=demo
+AXONFLOW_CLIENT_SECRET=demo-secret

--- a/examples/integrations/proxy-mode/python/.env.example
+++ b/examples/integrations/proxy-mode/python/.env.example
@@ -1,0 +1,5 @@
+# AxonFlow Configuration
+AXONFLOW_AGENT_URL=http://localhost:8080
+AXONFLOW_LICENSE_KEY=your-license-key-here
+AXONFLOW_CLIENT_ID=demo
+AXONFLOW_CLIENT_SECRET=demo-secret

--- a/examples/integrations/proxy-mode/typescript/.env.example
+++ b/examples/integrations/proxy-mode/typescript/.env.example
@@ -1,0 +1,7 @@
+# AxonFlow Configuration
+AXONFLOW_AGENT_URL=http://localhost:8080
+AXONFLOW_LICENSE_KEY=your-license-key-here
+AXONFLOW_TENANT=demo
+
+# LLM Provider Configuration
+OPENAI_API_KEY=sk-your-openai-key-here

--- a/examples/policies/crud/.env.example
+++ b/examples/policies/crud/.env.example
@@ -1,0 +1,9 @@
+# AxonFlow Configuration
+AXONFLOW_AGENT_URL=http://localhost:8080
+AXONFLOW_ORCHESTRATOR_URL=http://localhost:8081
+AXONFLOW_LICENSE_KEY=your-license-key-here
+AXONFLOW_CLIENT_ID=demo
+AXONFLOW_CLIENT_SECRET=demo-secret
+
+# Tenant ID for multi-tenant deployments
+AXONFLOW_TENANT_ID=test-org-001

--- a/examples/support-demo/.env.example
+++ b/examples/support-demo/.env.example
@@ -1,0 +1,48 @@
+# AxonFlow Support Demo - Environment Variables
+# Copy this file to .env and fill in your values
+
+# ===========================================
+# LLM Provider API Keys (at least one required)
+# ===========================================
+
+# OpenAI API Key
+# Get yours at: https://platform.openai.com/api-keys
+OPENAI_API_KEY=sk-your-openai-key-here
+
+# Anthropic API Key
+# Get yours at: https://console.anthropic.com/
+ANTHROPIC_API_KEY=sk-ant-your-anthropic-key-here
+
+# ===========================================
+# AxonFlow Platform (optional)
+# ===========================================
+
+# AxonFlow Agent endpoint (for policy enforcement)
+# Default: http://localhost:8080 (uses built-in policy engine if not set)
+AXONFLOW_ENDPOINT=http://localhost:8080
+
+# ===========================================
+# Database Configuration (optional)
+# ===========================================
+
+# PostgreSQL connection string
+# Default: postgres://axonflow:axonflow_demo@localhost:5432/support_demo?sslmode=disable
+DATABASE_URL=postgres://axonflow:axonflow_demo@localhost:5432/support_demo?sslmode=disable
+
+# ===========================================
+# Security (optional, has defaults)
+# ===========================================
+
+# JWT signing secret for authentication
+# IMPORTANT: Change this in production!
+JWT_SECRET=demo-secret-change-in-production
+
+# ===========================================
+# Server Configuration (optional)
+# ===========================================
+
+# Backend server port
+PORT=8080
+
+# Frontend URL (for CORS)
+FRONTEND_URL=http://localhost:3000

--- a/examples/workflows/01-simple-sequential/.env.example
+++ b/examples/workflows/01-simple-sequential/.env.example
@@ -1,0 +1,5 @@
+# AxonFlow Agent URL (defaults to localhost if not set)
+AXONFLOW_AGENT_URL=http://localhost:8080
+
+# License Key (REQUIRED)
+AXONFLOW_LICENSE_KEY=your-license-key-here

--- a/examples/workflows/02-parallel-execution/.env.example
+++ b/examples/workflows/02-parallel-execution/.env.example
@@ -1,0 +1,5 @@
+# AxonFlow Agent URL (defaults to localhost if not set)
+AXONFLOW_AGENT_URL=http://localhost:8080
+
+# License Key (REQUIRED)
+AXONFLOW_LICENSE_KEY=your-license-key-here

--- a/examples/workflows/03-conditional-logic/.env.example
+++ b/examples/workflows/03-conditional-logic/.env.example
@@ -1,0 +1,5 @@
+# AxonFlow Agent URL (defaults to localhost if not set)
+AXONFLOW_AGENT_URL=http://localhost:8080
+
+# License Key (REQUIRED)
+AXONFLOW_LICENSE_KEY=your-license-key-here

--- a/examples/workflows/04-travel-booking-fallbacks/.env.example
+++ b/examples/workflows/04-travel-booking-fallbacks/.env.example
@@ -1,0 +1,5 @@
+# AxonFlow Agent URL (defaults to localhost if not set)
+AXONFLOW_AGENT_URL=http://localhost:8080
+
+# License Key (REQUIRED)
+AXONFLOW_LICENSE_KEY=your-license-key-here

--- a/examples/workflows/05-data-pipeline/.env.example
+++ b/examples/workflows/05-data-pipeline/.env.example
@@ -1,0 +1,5 @@
+# AxonFlow Agent URL (defaults to localhost if not set)
+AXONFLOW_AGENT_URL=http://localhost:8080
+
+# License Key (REQUIRED)
+AXONFLOW_LICENSE_KEY=your-license-key-here

--- a/examples/workflows/06-multi-step-approval/.env.example
+++ b/examples/workflows/06-multi-step-approval/.env.example
@@ -1,0 +1,5 @@
+# AxonFlow Agent URL (defaults to localhost if not set)
+AXONFLOW_AGENT_URL=http://localhost:8080
+
+# License Key (REQUIRED)
+AXONFLOW_LICENSE_KEY=your-license-key-here

--- a/examples/workflows/07-healthcare-diagnosis/.env.example
+++ b/examples/workflows/07-healthcare-diagnosis/.env.example
@@ -1,0 +1,5 @@
+# AxonFlow Agent URL (defaults to localhost if not set)
+AXONFLOW_AGENT_URL=http://localhost:8080
+
+# License Key (REQUIRED)
+AXONFLOW_LICENSE_KEY=your-license-key-here

--- a/examples/workflows/08-ecommerce-order/.env.example
+++ b/examples/workflows/08-ecommerce-order/.env.example
@@ -1,0 +1,5 @@
+# AxonFlow Agent URL (defaults to localhost if not set)
+AXONFLOW_AGENT_URL=http://localhost:8080
+
+# License Key (REQUIRED)
+AXONFLOW_LICENSE_KEY=your-license-key-here

--- a/examples/workflows/09-financial-report/.env.example
+++ b/examples/workflows/09-financial-report/.env.example
@@ -1,0 +1,5 @@
+# AxonFlow Agent URL (defaults to localhost if not set)
+AXONFLOW_AGENT_URL=http://localhost:8080
+
+# License Key (REQUIRED)
+AXONFLOW_LICENSE_KEY=your-license-key-here

--- a/examples/workflows/10-chatbot-memory/.env.example
+++ b/examples/workflows/10-chatbot-memory/.env.example
@@ -1,0 +1,5 @@
+# AxonFlow Agent URL (defaults to localhost if not set)
+AXONFLOW_AGENT_URL=http://localhost:8080
+
+# License Key (REQUIRED)
+AXONFLOW_LICENSE_KEY=your-license-key-here

--- a/platform/agent/gateway_handlers.go
+++ b/platform/agent/gateway_handlers.go
@@ -399,7 +399,21 @@ func handlePolicyPreCheck(w http.ResponseWriter, r *http.Request) {
 		log.Printf("⚠️ [Pre-check] India PII detected (non-critical): %v", piiResult.DetectedTypes)
 	}
 
-	// Evaluate policies (reuse existing policy engine)
+	// IMPORTANT: Gateway Mode Design Decision - Static Policies Only
+	//
+	// Gateway Mode intentionally ONLY evaluates static policies (PII detection, SQL injection,
+	// dangerous queries) for lowest latency. It does NOT call the Orchestrator for dynamic
+	// policies.
+	//
+	// This means:
+	// - Custom policies created via Customer Portal UI or API are NOT enforced
+	// - Policy versioning and testing features are NOT available
+	// - Only built-in security patterns are evaluated
+	//
+	// For full policy support including dynamic policies, users should use Proxy Mode.
+	// See: docs.getaxonflow.com/docs/sdk/choosing-a-mode
+	//
+	// Evaluate static policies only (reuse existing policy engine)
 	var policyResult *StaticPolicyResult
 	if dbPolicyEngine != nil {
 		policyResult = dbPolicyEngine.EvaluateStaticPolicies(user, req.Query, "llm_chat")


### PR DESCRIPTION
## Sync from Enterprise Repository

Changes synced from enterprise:

**Security:**
- Added `SQLI_SCANNER_MODE` env var (off/basic/advanced)
- Added `SQLI_BLOCK_MODE` env var (block/warn)
- Integrated sqli package scanner with DatabasePolicyEngine

**Documentation:**
- Updated SQL injection scanning docs with env var config
- Added inline comments for Gateway Mode static-only limitation

**Examples:**
- Added `.env.example` template files across all SDK examples

### Files changed: 31
- 24 added (.env.example files)
- 7 modified (sqli config, docs, docker-compose)