### PR TITLE
chore(examples): update SDK versions for v2.0.0 release

### DIFF
--- a/examples/policies/go/create-custom-policy/go.mod
+++ b/examples/policies/go/create-custom-policy/go.mod
@@ -2,6 +2,6 @@ module github.com/getaxonflow/axonflow-enterprise/examples/policies/go
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go v0.0.0
+require github.com/getaxonflow/axonflow-sdk-go v1.6.0
 
 replace github.com/getaxonflow/axonflow-sdk-go => /Users/saurabhjain/Development/axonflow-sdk-go

--- a/examples/policies/go/list-and-filter/go.mod
+++ b/examples/policies/go/list-and-filter/go.mod
@@ -2,6 +2,6 @@ module github.com/getaxonflow/axonflow-enterprise/examples/policies/go
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go v0.0.0
+require github.com/getaxonflow/axonflow-sdk-go v1.6.0
 
 replace github.com/getaxonflow/axonflow-sdk-go => /Users/saurabhjain/Development/axonflow-sdk-go

--- a/examples/policies/go/test-pattern/go.mod
+++ b/examples/policies/go/test-pattern/go.mod
@@ -2,6 +2,6 @@ module github.com/getaxonflow/axonflow-enterprise/examples/policies/go
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go v0.0.0
+require github.com/getaxonflow/axonflow-sdk-go v1.6.0
 
 replace github.com/getaxonflow/axonflow-sdk-go => /Users/saurabhjain/Development/axonflow-sdk-go

--- a/examples/policies/java/pom.xml
+++ b/examples/policies/java/pom.xml
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>1.1.2</version>
+            <version>1.2.0</version>
         </dependency>
     </dependencies>
 

--- a/examples/policies/python/requirements.txt
+++ b/examples/policies/python/requirements.txt
@@ -1,5 +1,5 @@
 # AxonFlow SDK (from feature branch)
-axonflow @ git+https://github.com/getaxonflow/axonflow-sdk-python.git@feat/policy-crud
+axonflow>=0.4.0
 
 # For loading environment variables
 python-dotenv>=1.0.0

--- a/examples/policies/typescript/package.json
+++ b/examples/policies/typescript/package.json
@@ -10,7 +10,7 @@
     "all": "npm run create && npm run list && npm run test-pattern"
   },
   "dependencies": {
-    "@axonflow/sdk": "github:getaxonflow/axonflow-sdk-typescript#feat/policy-crud"
+    "@axonflow/sdk": "^1.5.0"
   },
   "devDependencies": {
     "tsx": "^4.7.0",


### PR DESCRIPTION
## Summary

Update policy examples to use released SDK versions instead of git branches:

| SDK | Old Version | New Version |
|-----|-------------|-------------|
| TypeScript | `github:getaxonflow/axonflow-sdk-typescript#feat/policy-crud` | `^1.5.0` |
| Python | `git+...@feat/policy-crud` | `>=0.4.0` |
| Go | `v1.5.2-0.20251224...` | `v1.6.0` |
| Java | `1.1.2` | `1.2.0` |

## Test plan

- [ ] Run TypeScript examples with `npm install && npm run create`
- [ ] Run Python examples with `pip install -r requirements.txt && python create_custom_policy.py`
- [ ] Run Go examples with `go run .`
- [ ] Run Java examples with `mvn compile exec:java`