### PR TITLE
docs(readme): add full interactive demo instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,26 @@ curl -X POST http://localhost:8080/api/policy/pre-check \
 {"approved": false, "block_reason": "PII detected: ssn", "policies": ["pii_ssn_detection"]}
 ```
 
-For a full end-to-end demo (gateway mode, policy enforcement, multi-agent planning), see `./examples/demo/demo.sh`.
+### Full Interactive Demo (10 min)
+
+Experience the complete governance suite: PII detection, SQL injection blocking,
+proxy and gateway modes, MCP connectors, multi-agent planning, and observability.
+
+```bash
+# Create .env with your API key (containers read from this file at startup)
+echo "OPENAI_API_KEY=$OPENAI_API_KEY" > .env
+
+# Restart services to load the key
+docker compose up -d --force-recreate
+
+# Run the interactive demo
+./examples/demo/demo.sh
+```
+
+The demo walks through a realistic customer support scenario with live LLM calls.
+See [`examples/demo/README.md`](examples/demo/README.md) for options (`--quick`, `--part N`).
+
+---
 
 AxonFlow runs inline with LLM traffic, enforcing policies and routing decisions in single-digit milliseconds — fast enough to prevent failures rather than observe them after the fact.
 


### PR DESCRIPTION
## Summary

- Adds a "Full Interactive Demo (10 min)" section after the 30-second curl example
- Provides clear instructions for running `demo.sh` with proper `.env` setup
- Uses `docker compose up -d --force-recreate` for reliable environment loading

## Why

The existing README mentions `./examples/demo/demo.sh` but doesn't explain:
1. That containers need the API key in a `.env` file (not just shell export)
2. That containers must be restarted to pick up the new env vars

This caused confusion when users ran the demo and got "no healthy providers available" errors.

## What's Changed

| Before | After |
|--------|-------|
| Single line: "see `./examples/demo/demo.sh`" | Full section with 3-command setup |
| Shell `export` in Quick Start (doesn't reach containers) | `.env` file approach (works reliably) |

## Design Decisions

- **Keeps 30-second curl as primary** — still works without LLM key
- **Explicit restart semantics** — `--force-recreate` avoids env propagation confusion
- **Links to demo README** — for `--quick` and `--part N` options
- **No output pasted** — describes the experience, doesn't reproduce it