### PR TITLE
fix(demo): auto-install all Python dependencies

### DIFF
--- a/examples/demo/README.md
+++ b/examples/demo/README.md
@@ -22,11 +22,13 @@ docker-compose ps
 
 - **Docker & Docker Compose** - For running AxonFlow services
 - **Python 3.8+** - For running demo examples
-- **AxonFlow Python SDK** - Installed automatically if missing
+- **Python packages** - Installed automatically (see `requirements.txt`)
 
-Optional (for full demo):
-- **OpenAI API Key** - Set `OPENAI_API_KEY` for LLM calls
-- **Anthropic API Key** - Set `ANTHROPIC_API_KEY` for multi-model demo
+Required (for LLM features):
+- **OpenAI API Key** - `export OPENAI_API_KEY=sk-your-key` (see main README)
+
+Optional:
+- **Anthropic API Key** - `export ANTHROPIC_API_KEY=...` for multi-model demo
 
 ## Demo Structure
 

--- a/examples/demo/demo.sh
+++ b/examples/demo/demo.sh
@@ -96,9 +96,10 @@ check_python() {
         exit 1
     fi
 
-    if ! python3 -c "import axonflow" 2>/dev/null; then
-        echo -e "${YELLOW}Installing axonflow SDK...${NC}"
-        pip3 install axonflow --quiet
+    # Only install if packages are missing
+    if ! python3 -c "import axonflow, httpx, openai" 2>/dev/null; then
+        echo -e "${YELLOW}Installing Python dependencies...${NC}"
+        pip3 install -r "$SCRIPT_DIR/requirements.txt" --quiet --disable-pip-version-check
     fi
 }
 

--- a/examples/demo/requirements.txt
+++ b/examples/demo/requirements.txt
@@ -1,0 +1,12 @@
+# Core SDK
+axonflow>=0.3.0
+
+# HTTP client
+httpx>=0.24.0
+
+# LLM providers
+openai>=1.0.0
+
+# LangChain (for gateway mode demo)
+langchain-openai>=0.1.0
+langchain-core>=0.1.0


### PR DESCRIPTION
## Summary

The demo.sh script only installed the axonflow SDK, but the demo examples also require additional packages. Users would hit import errors when running the demo.

## The Bug

```python
# 01_the_problem.py uses:
import openai

# 04_gateway_mode.py uses:
from langchain_openai import ChatOpenAI
from langchain_core.messages import HumanMessage

# Multiple files use:
import httpx
```

None of these were being installed.

## The Fix

| File | Change |
|------|--------|
| `requirements.txt` | New file listing all dependencies |
| `demo.sh` | Install from requirements.txt instead of just axonflow |
| `README.md` | Updated prerequisites section |

## requirements.txt

```
axonflow
httpx
openai
langchain-openai
langchain-core
```

## Test Plan

- [ ] Run `./examples/demo/demo.sh` from fresh clone
- [ ] Verify no import errors
- [ ] All 7 parts complete successfully