### PR TITLE
docs: add Gregory Zak's support demo contributions

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -28,6 +28,8 @@ Contributors are listed here as their PRs are merged.
 |------|--------------|-----|
 | [Gregory Zak](https://github.com/gzak) | Self-hosted auth fix | [#89](https://github.com/getaxonflow/axonflow/pull/89) |
 | [Gregory Zak](https://github.com/gzak) | Usage recording Community fix | [#97](https://github.com/getaxonflow/axonflow/pull/97) |
+| [Gregory Zak](https://github.com/gzak) | Support demo backend build fix | [#125](https://github.com/getaxonflow/axonflow/pull/125) |
+| [Gregory Zak](https://github.com/gzak) | Support demo port conflicts fix | [#127](https://github.com/getaxonflow/axonflow/pull/127) |
 
 ## Documentation Contributors
 


### PR DESCRIPTION
Adds Greg's PRs #125 and #127 to the contributors list for his support demo fixes.