### PR TITLE
fix(example): correct frontend port mapping to nginx port 80

### DIFF
--- a/examples/support-demo/docker-compose.yml
+++ b/examples/support-demo/docker-compose.yml
@@ -50,7 +50,7 @@ services:
     environment:
       - REACT_APP_API_URL=http://localhost:8082
     ports:
-      - "3001:3000"
+      - "3001:80"
     depends_on:
       - backend
 


### PR DESCRIPTION
The docker-compose port mapping was `3001:3000` but nginx in the frontend container listens on port 80, not 3000. This caused connection resets.

**Fix:** Change to `3001:80`

Found during end-to-end testing of the support demo.