### PR TITLE
fix(llm): respect ANTHROPIC_MODEL env var for provider selection

### DIFF
--- a/platform/orchestrator/llm_router_test.go
+++ b/platform/orchestrator/llm_router_test.go
@@ -1294,7 +1294,7 @@ func TestNewAnthropicProvider(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			provider := NewAnthropicProvider(tt.apiKey)
+			provider := NewAnthropicProvider(tt.apiKey, "") // Empty model uses package default
 
 			if provider == nil {
 				t.Fatal("Expected non-nil provider")

--- a/platform/orchestrator/run.go
+++ b/platform/orchestrator/run.go
@@ -254,9 +254,11 @@ func LoadLLMConfig() LLMRouterConfig {
 
 	// OpenAI configuration
 	config.OpenAIKey = os.Getenv("OPENAI_API_KEY")
+	config.OpenAIModel = os.Getenv("OPENAI_MODEL")
 
 	// Anthropic configuration
 	config.AnthropicKey = os.Getenv("ANTHROPIC_API_KEY")
+	config.AnthropicModel = os.Getenv("ANTHROPIC_MODEL")
 
 	// Bedrock configuration
 	// Allow environment-specific overrides (e.g., BEDROCK_REGION_PROD)

--- a/platform/orchestrator/runtime_config_integration.go
+++ b/platform/orchestrator/runtime_config_integration.go
@@ -150,11 +150,17 @@ func LoadLLMConfigFromService(ctx context.Context, tenantID string) LLMRouterCon
 		case ProviderOpenAI:
 			if apiKey, ok := credentials["api_key"]; ok && apiKey != "" {
 				routerConfig.OpenAIKey = apiKey
+				if model, hasModel := providerConfig["model"].(string); hasModel && model != "" {
+					routerConfig.OpenAIModel = model
+				}
 				log.Printf("[LLM Config] OpenAI provider loaded from %s", source)
 			}
 		case ProviderAnthropic:
 			if apiKey, ok := credentials["api_key"]; ok && apiKey != "" {
 				routerConfig.AnthropicKey = apiKey
+				if model, hasModel := providerConfig["model"].(string); hasModel && model != "" {
+					routerConfig.AnthropicModel = model
+				}
 				log.Printf("[LLM Config] Anthropic provider loaded from %s", source)
 			}
 		case ProviderBedrock:


### PR DESCRIPTION
## Summary
- Fix Anthropic provider ignoring ANTHROPIC_MODEL env var
- Add OpenAIModel and AnthropicModel fields to LLMRouterConfig
- Update EnhancedAnthropicProvider to use configured model

## Problem
The Anthropic provider was hardcoded to use `claude-3-5-sonnet-20241022` even when `ANTHROPIC_MODEL` was set to a different model (e.g., `claude-3-haiku-20240307`). This caused 404 errors when the API key didn't have access to the default model.

## Solution
- Store the configured model in `EnhancedAnthropicProvider` struct
- Use model priority: `options.Model` > provider's configured model > package default
- Extract model from RuntimeConfigService provider configs
- Add model reading in LoadLLMConfig for env var fallback path

## Test plan
- [x] All orchestrator tests pass
- [x] Tested with `ANTHROPIC_MODEL=claude-3-haiku-20240307`
- [x] Verified weighted routing works with both OpenAI and Anthropic providers
- [x] Verified failover behavior when provider errors occur