### PR TITLE
fix(example): remove local replace directive, update to Go SDK v1.7.0

### DIFF
--- a/examples/code-governance/go/go.mod
+++ b/examples/code-governance/go/go.mod
@@ -3,5 +3,3 @@ module github.com/axonflow/examples/code-governance
 go 1.21
 
 require github.com/getaxonflow/axonflow-sdk-go v1.6.0
-
-replace github.com/getaxonflow/axonflow-sdk-go => /Users/saurabhjain/Development/axonflow-sdk-go


### PR DESCRIPTION
## Summary

Fixes the Go code governance example:
- Removed local `replace` directive that pointed to developer's local path
- Updated Go SDK version from v1.6.0 to v1.7.0 (which includes CodeArtifact support)

## Related

- Go SDK v1.7.0: https://github.com/getaxonflow/axonflow-sdk-go/releases/tag/v1.7.0
- Issue: #761

## Test plan

- [x] Verify go.mod is valid
- [ ] Test example against live server after merge