### PR TITLE
fix(example): remove local replace directive from Go code governance example

### DIFF
--- a/examples/code-governance/go/go.mod
+++ b/examples/code-governance/go/go.mod
@@ -2,6 +2,4 @@ module github.com/axonflow/examples/code-governance
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go v1.6.0
-
-replace github.com/getaxonflow/axonflow-sdk-go => /Users/saurabhjain/Development/axonflow-sdk-go
+require github.com/getaxonflow/axonflow-sdk-go v1.7.0

--- a/examples/code-governance/go/go.sum
+++ b/examples/code-governance/go/go.sum
@@ -1,0 +1,2 @@
+github.com/getaxonflow/axonflow-sdk-go v1.7.0 h1:8bCS5F2wL+N+39fjpIShhex8fw8Lh5/Kqc78YifDnvg=
+github.com/getaxonflow/axonflow-sdk-go v1.7.0/go.mod h1:6bdj+/BwCCBTugIsnFXw+VrnNouif+LUEPeBF9BeE44=


### PR DESCRIPTION
## Summary

The Go code governance example had a `replace` directive pointing to a local path:
```
replace github.com/getaxonflow/axonflow-sdk-go => /Users/saurabhjain/Development/axonflow-sdk-go
```

This meant the example **never worked** for anyone who cloned the repo.

## Fix

- Removed the local `replace` directive
- Updated to use published Go SDK v1.7.0

## Test plan

- [x] `go build` succeeds
- [x] Example runs and shows CodeArtifact detection