### PR TITLE
chore: add v2.3.0 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [2.3.0] - 2025-12-30
+
+### Changed
+
+- **LLM Router Consolidation**: Completed migration to interface-based router architecture
+  - Removed legacy `LLMRouter` concrete implementation (~1,700 lines)
+  - All routing now through `LLMRouterInterface` abstraction introduced in v2.2.0
+  - Cleaner codebase with single routing implementation path
+
+- **Docker Compose Architecture**: Simplified deployment configuration
+  - `docker-compose.yml` now serves as Community base configuration
+  - Enterprise features available via overlay pattern
+
+- **Default Anthropic Model**: Updated to `claude-sonnet-4-20250514` (Claude 4)
+
+### Added
+
+- **LLM Provider E2E Tests**: Comprehensive end-to-end test suite
+  - Coverage for OpenAI, Anthropic, Google Gemini, and AWS Bedrock
+  - Multi-language test implementations (Go, Python, TypeScript, Java)
+
+### Removed
+
+- `llm_router.go` - Superseded by `UnifiedRouterWrapper`
+- `llm_routing_strategy.go` - Consolidated into unified router
+- Legacy router test files
+
+---
+
 ## [2.2.0] - 2025-12-29
 
 ### Added


### PR DESCRIPTION
## Summary

Adds changelog entry for v2.3.0 release.

## Changes

- **LLM Router Consolidation**: Removed legacy implementation (~1,700 lines)
- **Docker Compose Architecture**: Simplified deployment configuration  
- **Default Anthropic Model**: Updated to claude-sonnet-4-20250514
- **LLM Provider E2E Tests**: Coverage for OpenAI, Anthropic, Gemini, Bedrock

## Testing

All community examples tested end-to-end:
- hello-world: Go ✅, Python ✅, TypeScript ✅
- gateway-mode: Go ✅, Python ✅, TypeScript ✅
- proxy-mode: Go ✅, Python ✅, TypeScript ✅
- policies: Go ✅, Python ✅, TypeScript ✅
- llm-routing: Go ✅, Python ✅, TypeScript ✅
- code-governance: Go ✅, Python ✅, TypeScript ✅
- hitl: Go ✅, Python ✅, TypeScript ✅

Note: Java examples skipped (SDK not on Maven Central - tracked separately)