### PR TITLE
docs: restore Code Governance section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ AxonFlow runs inline with LLM traffic, enforcing policies and routing decisions 
 
 **SQL Injection Response Scanning** — Detect SQLi payloads in MCP connector responses. Protects against data exfiltration when compromised data is returned from databases.
 
+**Code Governance** — Detect LLM-generated code, identify language and security issues (secrets, eval, shell injection). Logged for compliance.
+
 **Audit Trails** — Every request logged with full context. Know what was blocked, why, and by which policy. Token usage tracked for cost analysis.
 
 **Multi-Model Routing** — Route requests across OpenAI, Anthropic, Bedrock, Ollama based on cost, capability, or compliance requirements. Failover included.
@@ -310,6 +312,7 @@ if (approval.isApproved()) {
 | Example | Description |
 |---------|-------------|
 | **[Support Demo](examples/support-demo/)** | Customer support with PII redaction and RBAC |
+| **[Code Governance](examples/code-governance/)** | Detect and audit LLM-generated code |
 | **[Hello World](examples/hello-world/)** | Minimal SDK example (30 lines) |
 
 → **[More examples](https://docs.getaxonflow.com/docs/examples/overview)**


### PR DESCRIPTION
## Summary

Restores the Code Governance feature description and example link that was accidentally removed during enterprise sync.

## What happened

- Added in `fc42202` (Dec 28): Code Governance section added to README
- Removed in `100b7a2` (Dec 29): Enterprise sync overwrote README with older version

## Root cause

The sync workflow's safety check (before PR #813) only counted commits instead of comparing file content, so it didn't detect the community-only changes.

**This is now fixed** - PR #813 (merged Dec 30) added file content comparison to the safety check.

## Changes

- Re-add Code Governance to "What AxonFlow Does" section
- Re-add Code Governance example to Examples table