### PR TITLE
docs: clarify Gateway Mode supports similar frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ AxonFlow runs inline with LLM traffic, enforcing policies and routing decisions 
 
 **Proxy Mode** — Full request lifecycle: policy, planning, routing, audit. Recommended for new projects.
 
-**Gateway Mode** — Governance for existing stacks (LangChain, CrewAI). Pre-check → your call → audit.
+**Gateway Mode** — Governance for existing stacks (LangChain, CrewAI, and similar frameworks). Pre-check → your call → audit.
 
 → **[Choosing a mode](https://docs.getaxonflow.com/docs/sdk/choosing-a-mode)** · **[Architecture deep-dive](https://docs.getaxonflow.com/docs/architecture/overview)**
 


### PR DESCRIPTION
Minor README improvement - clarify that Gateway Mode works with LangChain, CrewAI, and similar frameworks.

**Change:**
```diff
- **Gateway Mode** — Governance for existing stacks (LangChain, CrewAI). Pre-check → your call → audit.
+ **Gateway Mode** — Governance for existing stacks (LangChain, CrewAI, and similar frameworks). Pre-check → your call → audit.
```