### PR TITLE
feat: v3.0.0 - Single Entry Point + Detection Defaults + Strict Enforcement

### DIFF
--- a/.github/workflows/sdk-smoke-tests.yml
+++ b/.github/workflows/sdk-smoke-tests.yml
@@ -147,41 +147,44 @@ jobs:
           echo ""
           echo "✅ All services are healthy!"
 
-      - name: Test PII Detection (SSN - Monitoring Mode)
+      - name: Test PII Detection (SSN - Redact Mode)
         shell: bash
         run: |
-          echo "🧪 Testing PII detection (SSN - monitoring mode)..."
+          echo "🧪 Testing PII detection (SSN - redact mode)..."
           response=$(curl -s -X POST http://localhost:8080/api/policy/pre-check \
             -H "Content-Type: application/json" \
             -d '{"user_token": "test-user", "client_id": "smoke-test", "query": "Look up customer with SSN 123-45-6789"}')
 
           echo "Response: $response"
 
-          # SSN detection is in monitoring mode (approved=true but detected)
-          # Verify the policy was triggered even though request is approved
-          if echo "$response" | jq -e '.policies | length > 0' > /dev/null 2>&1; then
+          # SSN detection defaults to redact mode (approved=true, requires_redaction=true)
+          # Issue #891: PII now defaults to redact instead of block
+          if echo "$response" | jq -e '.requires_redaction == true' > /dev/null 2>&1; then
             policy=$(echo "$response" | jq -r '.policies[0]')
-            echo "✅ SSN detected by policy: $policy"
+            echo "✅ SSN detected, flagged for redaction (policy: $policy)"
           else
-            echo "❌ SSN not detected - no policies triggered"
+            echo "❌ SSN not flagged for redaction"
+            echo "Expected: requires_redaction=true"
             exit 1
           fi
 
-      - name: Test PII Detection (Credit Card)
+      - name: Test PII Detection (Credit Card - Redact Mode)
         shell: bash
         run: |
-          echo "🧪 Testing PII detection (Credit Card)..."
+          echo "🧪 Testing PII detection (Credit Card - redact mode)..."
           response=$(curl -s -X POST http://localhost:8080/api/policy/pre-check \
             -H "Content-Type: application/json" \
             -d '{"user_token": "test-user", "client_id": "smoke-test", "query": "Process payment for card 4111-1111-1111-1111"}')
 
           echo "Response: $response"
 
-          if echo "$response" | jq -e '.approved == false or .policyApproved == false or .blocked == true' > /dev/null 2>&1; then
-            echo "✅ Credit card correctly blocked"
+          # Credit card detection defaults to redact mode (approved=true, requires_redaction=true)
+          # Issue #891: PII now defaults to redact instead of block
+          if echo "$response" | jq -e '.requires_redaction == true' > /dev/null 2>&1; then
+            echo "✅ Credit card detected, flagged for redaction"
           else
-            echo "❌ Credit card not blocked"
-            echo "Expected: approved=false or blocked=true"
+            echo "❌ Credit card not flagged for redaction"
+            echo "Expected: requires_redaction=true"
             exit 1
           fi
 
@@ -274,7 +277,7 @@ jobs:
           echo "✅ SDK smoke tests passed!"
           echo ""
           echo "Validated:"
-          echo "  - PII Detection (SSN - monitoring mode)"
-          echo "  - PII Blocking (Credit Card)"
-          echo "  - SQL Injection Blocking"
-          echo "  - Safe Query Approval"
+          echo "  - PII Detection (SSN - redact mode, requires_redaction=true)"
+          echo "  - PII Detection (Credit Card - redact mode, requires_redaction=true)"
+          echo "  - SQL Injection Blocking (approved=false)"
+          echo "  - Safe Query Approval (approved=true)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,101 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.0.0] - 2026-01-05
+
+### Breaking Changes
+
+- **Single Entry Point Architecture (ADR-026)**: All API routes now go through the Agent (port 8080)
+  - Agent proxies `/api/v1/dynamic-policies/*`, `/api/v1/budgets/*`, `/api/v1/usage/*`, `/api/v1/executions/*` to Orchestrator
+  - Agent proxies `/portal/*` routes to Customer Portal
+  - SDKs now use single `endpoint` parameter (default: `http://localhost:8080`)
+  - **Deprecated**: `agent_url` and `orchestrator_url` SDK parameters (use `endpoint` instead)
+  - **Deprecated**: Direct Orchestrator access on port 8081 (still works but not recommended)
+
+- **Detection Defaults Changed (ADR-027)**: More nuanced default actions based on detection confidence
+  - PII detection: `block` → `redact` (non-blocking, better UX)
+  - High risk score (>0.8): `block` → `warn` (composite score needs tuning)
+  - SQL injection: remains `block` (high confidence attacks)
+  - Dangerous queries (DROP/TRUNCATE): remains `block` (destructive operations)
+
+- **Environment Variable Changes**:
+  - **New**: `SQLI_ACTION` (values: `block`, `warn`, `log`) - replaces `SQLI_BLOCK_MODE`
+  - **New**: `PII_ACTION` (values: `block`, `warn`, `redact`, `log`) - replaces `PII_BLOCK_CRITICAL`
+  - **New**: `SENSITIVE_DATA_ACTION` (values: `block`, `warn`, `log`) - credentials/secrets detection
+  - **New**: `HIGH_RISK_ACTION` (values: `block`, `warn`, `log`) - high risk score threshold
+  - **New**: `DANGEROUS_QUERY_ACTION` (values: `block`, `warn`, `log`) - DROP/TRUNCATE detection
+  - **Deprecated**: `SQLI_BLOCK_MODE` (use `SQLI_ACTION` instead)
+  - **Deprecated**: `PII_BLOCK_CRITICAL` (use `PII_ACTION` instead)
+
+### Added
+
+- **Sensitive Data Patterns in Database**: Credential and secret detection patterns now stored in `static_policies` table
+  - Password, API key, token, secret, credentials, connection string patterns
+  - Context exclusions for SQL keywords (PRIMARY KEY, FOREIGN KEY no longer false positives)
+  - Per-tenant customization via policy overrides (Enterprise)
+
+- **Environment Variable Precedence**: Clear hierarchy for detection configuration
+  1. Per-tenant policy override (API) - highest priority
+  2. Environment variable (docker-compose)
+  3. Per-policy DB default (migration seed) - lowest priority
+
+- **PII Redaction Support in SDKs**: New `requiresRedaction` field in `PolicyApprovalResult`
+  - Returns `true` when PII was detected with `redact` action
+  - Callers should process response for redaction when this flag is set
+  - Available in all SDKs: `isRequiresRedaction()` (Java), `requires_redaction` (Python), `RequiresRedaction` (Go), `requiresRedaction` (TypeScript)
+
+- **Strict Provider Enforcement for Dynamic Policies** (Issue #883): Compliance-aware LLM routing
+  - Policies can specify `allowed_providers` to restrict which LLM providers handle requests
+  - Requests **fail** (instead of fallback) if no compliant provider is available
+  - Multiple policies use **intersection logic** (least privilege - most restrictive wins)
+  - Enables GDPR, HIPAA, RBI compliance scenarios (e.g., EU data stays on-premise)
+  - Example: `{"allowed_providers": ["ollama"]}` ensures only local model handles sensitive data
+
+### Fixed
+
+- **Dynamic policy condition evaluation**: `DatabaseDynamicPolicyEngine` now correctly evaluates conditions before applying actions
+  - Previously, all policy actions were applied regardless of whether conditions matched
+  - Now supports operators: `equals`, `not_equals`, `contains`, `not_contains`, `contains_any`, `regex`, `greater_than`, `less_than`, `in`, `not_in`
+
+- **Tenant extraction bug**: Fixed `Client.ID` → `Client.TenantID` in policy evaluation
+
+### Changed
+
+- **SDK Method Signatures**: All SDKs updated for single endpoint
+  - Go: `axonflow.NewClient(axonflow.AxonFlowConfig{Endpoint: "http://localhost:8080"})`
+  - Python: `AxonFlow(endpoint="http://localhost:8080")`
+  - TypeScript: `new AxonFlow({ endpoint: "http://localhost:8080" })`
+  - Java: `AxonFlow.create(AxonFlowConfig.builder().endpoint("http://localhost:8080").build())`
+
+### Migration Guide
+
+**SDK Migration:**
+```python
+# Before (v2.x)
+client = AxonFlow(
+    agent_url="http://localhost:8080",
+    orchestrator_url="http://localhost:8081"
+)
+
+# After (v3.0)
+client = AxonFlow(endpoint="http://localhost:8080")
+```
+
+**Environment Variable Migration:**
+```yaml
+# Before (v2.x)
+SQLI_BLOCK_MODE: "block"
+PII_BLOCK_CRITICAL: "true"
+
+# After (v3.0)
+SQLI_ACTION: "block"
+PII_ACTION: "redact"
+SENSITIVE_DATA_ACTION: "warn"
+HIGH_RISK_ACTION: "warn"
+```
+
+---
+
 ## [2.6.0] - 2026-01-04
 
 ### Added

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,9 +96,8 @@ services:
       DATABASE_PASSWORD: localdev123
       DATABASE_SSLMODE: disable
 
-      # Internal services
+      # Internal services (Orchestrator/Portal URLs auto-discovered via Docker service names)
       REDIS_URL: redis://redis:6379
-      ORCHESTRATOR_URL: http://axonflow-orchestrator:8081
       DATABASE_URL: postgres://axonflow:localdev123@postgres:5432/axonflow?sslmode=disable
 
       # Ollama (for local/air-gapped LLM deployments)
@@ -110,9 +109,21 @@ services:
       LLM_ROUTING_STRATEGY: ${LLM_ROUTING_STRATEGY:-weighted}
       PROVIDER_WEIGHTS: ${PROVIDER_WEIGHTS:-}
 
-      # Security scanning
+      # Security scanning - detection actions (Issue #891)
+      # Philosophy: Block high-confidence threats, warn on heuristics, redact PII
       SQLI_SCANNER_MODE: ${SQLI_SCANNER_MODE:-basic}
-      SQLI_BLOCK_MODE: ${SQLI_BLOCK_MODE:-block}
+      # SQLI_ACTION: block|warn|log (default: block - high confidence attacks)
+      SQLI_ACTION: ${SQLI_ACTION:-block}
+      # PII_ACTION: block|warn|redact|log (default: redact - preserves UX)
+      PII_ACTION: ${PII_ACTION:-redact}
+      # SENSITIVE_DATA_ACTION: block|warn|log (default: warn - may have false positives)
+      SENSITIVE_DATA_ACTION: ${SENSITIVE_DATA_ACTION:-warn}
+      # HIGH_RISK_ACTION: block|warn|log (default: warn - composite score needs tuning)
+      HIGH_RISK_ACTION: ${HIGH_RISK_ACTION:-warn}
+      # DANGEROUS_QUERY_ACTION: block|warn|log (default: block - DROP/TRUNCATE)
+      DANGEROUS_QUERY_ACTION: ${DANGEROUS_QUERY_ACTION:-block}
+      # Deprecated: use SQLI_ACTION instead
+      # SQLI_BLOCK_MODE: ${SQLI_BLOCK_MODE:-block}
 
       # Misc
       ORG_ID: local-dev-org

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,33 +2,72 @@
 
 AxonFlow is designed with secure-by-default settings that are fully configurable. This document covers all environment variables for controlling security detection and policy enforcement.
 
-## Security Configuration
+## Security Detection Configuration (Issue #891)
+
+AxonFlow uses a tiered default approach: **block high-confidence threats, warn on heuristics, redact PII**.
 
 | Variable | Values | Default | Description |
 |----------|--------|---------|-------------|
-| `PII_BLOCK_CRITICAL` | `true`, `false` | `true` | Block requests containing critical PII (SSN, Aadhaar, credit cards, etc.) |
+| `SQLI_ACTION` | `block`, `warn`, `log` | `block` | SQL injection detection action (high confidence) |
+| `PII_ACTION` | `block`, `warn`, `redact`, `log` | `redact` | PII detection action (preserves UX) |
+| `SENSITIVE_DATA_ACTION` | `block`, `warn`, `log` | `warn` | Credential/token detection action (may have false positives) |
+| `HIGH_RISK_ACTION` | `block`, `warn`, `log` | `warn` | High risk score (>0.8) action (needs tuning) |
+| `DANGEROUS_QUERY_ACTION` | `block`, `warn`, `log` | `block` | DROP/TRUNCATE detection action (destructive) |
 | `SQLI_SCANNER_MODE` | `off`, `basic`, `advanced` | `basic` | SQL injection scanning mode |
-| `SQLI_BLOCK_MODE` | `block`, `warn` | `block` | Action on SQLi detection |
 
-### Starting in Observe-Only Mode
+### Action Types
 
-For evaluation or development, you can run AxonFlow in observe-only mode where all detections are logged but not blocked:
+| Action | Behavior |
+|--------|----------|
+| `block` | Reject request immediately |
+| `redact` | Mask/redact detected content, allow request |
+| `warn` | Log warning, allow request |
+| `log` | Log for audit only, allow request |
 
-```yaml
-environment:
-  PII_BLOCK_CRITICAL: "false"  # Log only, don't block
-  SQLI_BLOCK_MODE: "warn"      # Warn only, don't block
-```
+### Deprecated Environment Variables
 
-This allows you to see what AxonFlow would detect without impacting your application. Once you've validated detection accuracy in your environment, you can enable blocking.
+These environment variables are deprecated and will be removed in a future release:
+
+| Deprecated | Replacement | Notes |
+|------------|-------------|-------|
+| `SQLI_BLOCK_MODE` | `SQLI_ACTION` | `block` → `SQLI_ACTION=block`, `warn` → `SQLI_ACTION=warn` |
+| `PII_BLOCK_CRITICAL` | `PII_ACTION` | `true` → `PII_ACTION=block`, `false` → `PII_ACTION=log` |
+
+### Philosophy: Tiered Defaults
+
+The default configuration is designed to minimize friction during evaluation while maintaining security:
+
+| Detection Type | Default | Rationale |
+|----------------|---------|-----------|
+| SQL Injection | `block` | High confidence, real attacks |
+| Dangerous Queries | `block` | Destructive operations |
+| PII | `redact` | Non-blocking, preserves user experience |
+| Sensitive Data | `warn` | May have false positives (e.g., "PRIMARY KEY") |
+| High Risk Score | `warn` | Composite score needs per-environment tuning |
 
 ### Progressive Enforcement
 
 A common adoption pattern:
 
-1. **Week 1-2: Observe** - Run with `PII_BLOCK_CRITICAL=false` and `SQLI_BLOCK_MODE=warn`
-2. **Week 3-4: Validate** - Review audit logs, tune any false positives
-3. **Week 5+: Enforce** - Enable blocking with confidence
+1. **Day 1: Out-of-the-box** - Start with defaults (PII redacted, SQLi blocked)
+2. **Week 1: Review** - Check audit logs for detection accuracy
+3. **Week 2: Tune** - Adjust actions based on your risk tolerance
+4. **Ongoing: Enforce** - Enable stricter blocking as confidence grows
+
+## Environment Variable Precedence
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ Priority 1: Per-tenant policy override (Enterprise API)         │
+│   Enterprise users can override any policy via API              │
+├─────────────────────────────────────────────────────────────────┤
+│ Priority 2: Environment variable (docker-compose)               │
+│   SQLI_ACTION=warn overrides all SQLi policies                  │
+├─────────────────────────────────────────────────────────────────┤
+│ Priority 3: Per-policy DB default (migration seed)              │
+│   static_policies.action from seed data                         │
+└─────────────────────────────────────────────────────────────────┘
+```
 
 ## Deployment Mode
 
@@ -52,34 +91,47 @@ connectors:
     sqli_scanner_mode: off       # Disable for trusted internal cache
 ```
 
-## Environment Variable Precedence
-
-1. **Per-connector config** (highest priority)
-2. **Environment variables**
-3. **Default values** (lowest priority)
-
 ## Docker Compose Example
 
 ```yaml
 services:
   axonflow-agent:
     environment:
-      # === Security Detection Configuration ===
-      # All enforcement is configurable. Start in observe-only mode for evaluation,
-      # then progressively enable blocking as confidence grows.
-      #
-      # PII Detection: Set to "false" to log-only (no blocking)
-      PII_BLOCK_CRITICAL: "true"
-      #
+      # === Security Detection Configuration (Issue #891) ===
+      # Philosophy: Block high-confidence threats, warn on heuristics, redact PII
+
       # SQLi Scanner: "off", "basic" (default), "advanced" (enterprise)
       SQLI_SCANNER_MODE: "basic"
-      #
-      # SQLi Action: "block" (default) or "warn" (log + allow)
-      SQLI_BLOCK_MODE: "block"
+
+      # SQLI_ACTION: block|warn|log (default: block - high confidence attacks)
+      SQLI_ACTION: "block"
+
+      # PII_ACTION: block|warn|redact|log (default: redact - preserves UX)
+      PII_ACTION: "redact"
+
+      # SENSITIVE_DATA_ACTION: block|warn|log (default: warn - may have false positives)
+      SENSITIVE_DATA_ACTION: "warn"
+
+      # HIGH_RISK_ACTION: block|warn|log (default: warn - composite score needs tuning)
+      HIGH_RISK_ACTION: "warn"
+
+      # DANGEROUS_QUERY_ACTION: block|warn|log (default: block - DROP/TRUNCATE)
+      DANGEROUS_QUERY_ACTION: "block"
 
       # === Deployment Mode ===
       # "community" = no auth required, "enterprise" = license required
       DEPLOYMENT_MODE: "community"
+```
+
+## Legacy Configuration (Deprecated)
+
+For backwards compatibility, the old environment variables still work but will log deprecation warnings:
+
+```yaml
+# DEPRECATED - use new *_ACTION variables instead
+environment:
+  PII_BLOCK_CRITICAL: "true"  # Use PII_ACTION=block instead
+  SQLI_BLOCK_MODE: "warn"     # Use SQLI_ACTION=warn instead
 ```
 
 ## Related Documentation

--- a/docs/security/sql-injection-scanning.md
+++ b/docs/security/sql-injection-scanning.md
@@ -94,7 +94,10 @@ For Docker and containerized deployments, configure SQL injection scanning using
 | Variable | Values | Default | Description |
 |----------|--------|---------|-------------|
 | `SQLI_SCANNER_MODE` | `off`, `basic`, `advanced` | `basic` | Sets the scanning mode for both input and response |
-| `SQLI_BLOCK_MODE` | `block`, `warn` | `block` | Controls whether detections are blocked or just logged |
+| `SQLI_ACTION` | `block`, `warn`, `log` | `block` | Controls the action when SQLi is detected |
+| `SQLI_BLOCK_MODE` | `block`, `warn` | `block` | **Deprecated** - use `SQLI_ACTION` instead |
+
+> **Note (Issue #891):** `SQLI_BLOCK_MODE` is deprecated. Use `SQLI_ACTION` for unified detection configuration.
 
 **Example: docker-compose.yml**
 
@@ -104,8 +107,8 @@ services:
     environment:
       # Scanning mode: off, basic, advanced
       SQLI_SCANNER_MODE: ${SQLI_SCANNER_MODE:-basic}
-      # Block mode: block (reject requests), warn (log only)
-      SQLI_BLOCK_MODE: ${SQLI_BLOCK_MODE:-block}
+      # Action on detection: block (reject), warn (log+allow), log (audit only)
+      SQLI_ACTION: ${SQLI_ACTION:-block}
 ```
 
 **Usage Examples:**
@@ -118,10 +121,10 @@ docker compose up -d
 SQLI_SCANNER_MODE=off docker compose up -d
 
 # Enable scanning in warn-only mode (log but don't block)
-SQLI_BLOCK_MODE=warn docker compose up -d
+SQLI_ACTION=warn docker compose up -d
 
 # Use advanced scanning (Enterprise only) with blocking
-SQLI_SCANNER_MODE=advanced SQLI_BLOCK_MODE=block docker compose up -d
+SQLI_SCANNER_MODE=advanced SQLI_ACTION=block docker compose up -d
 ```
 
 > **Note:** Invalid environment variable values are logged and fall back to defaults (basic mode, blocking enabled) to ensure security-first behavior.
@@ -143,7 +146,7 @@ SQLI_SCANNER_MODE=advanced SQLI_BLOCK_MODE=block docker compose up -d
 
 When SQL injection is detected, behavior depends on the configured block mode:
 
-### Block Mode (`SQLI_BLOCK_MODE=block`, default)
+### Block Mode (`SQLI_ACTION=block`, default)
 
 Returns HTTP 403 Forbidden and rejects the request:
 ```json
@@ -153,7 +156,7 @@ Returns HTTP 403 Forbidden and rejects the request:
 }
 ```
 
-### Warn Mode (`SQLI_BLOCK_MODE=warn`)
+### Warn Mode (`SQLI_ACTION=warn`)
 
 Logs the detection but allows the request through. Useful for:
 - Initial deployment to assess false positive rates

--- a/examples/audit-logging/go/main.go
+++ b/examples/audit-logging/go/main.go
@@ -167,8 +167,76 @@ func main() {
 
 	fmt.Println("Audit Logging Complete!")
 	fmt.Println()
-	fmt.Println("Query audit logs via Orchestrator API:")
-	fmt.Println("  curl http://localhost:8081/api/v1/audit/tenant/audit-logging-demo")
+
+	// =========================================================================
+	// Query Audit Logs (SDK Methods)
+	// =========================================================================
+
+	fmt.Println("========================================")
+	fmt.Println("Query Audit Logs via SDK")
+	fmt.Println("========================================")
+	fmt.Println()
+
+	// Get audit logs for tenant (default pagination)
+	fmt.Println("1. GetAuditLogsByTenant (default options):")
+	tenantLogs, err := axClient.GetAuditLogsByTenant(ctx, "audit-logging-demo", nil)
+	if err != nil {
+		fmt.Printf("   Error: %v\n", err)
+	} else {
+		fmt.Printf("   Found %d entries\n", len(tenantLogs.Entries))
+		if len(tenantLogs.Entries) > 0 {
+			fmt.Printf("   Latest: %s - %s/%s\n",
+				tenantLogs.Entries[0].Timestamp.Format(time.RFC3339),
+				tenantLogs.Entries[0].Provider,
+				tenantLogs.Entries[0].Model)
+		}
+	}
+	fmt.Println()
+
+	// Get audit logs with custom pagination
+	fmt.Println("2. GetAuditLogsByTenant (limit=5, offset=0):")
+	paginatedLogs, err := axClient.GetAuditLogsByTenant(ctx, "audit-logging-demo", &axonflow.AuditQueryOptions{
+		Limit:  5,
+		Offset: 0,
+	})
+	if err != nil {
+		fmt.Printf("   Error: %v\n", err)
+	} else {
+		hasMore := paginatedLogs.Total > paginatedLogs.Offset+len(paginatedLogs.Entries)
+		fmt.Printf("   Found %d entries (hasMore: %v)\n", len(paginatedLogs.Entries), hasMore)
+	}
+	fmt.Println()
+
+	// Search audit logs with filters
+	fmt.Println("3. SearchAuditLogs (with filters):")
+	searchResult, err := axClient.SearchAuditLogs(ctx, &axonflow.AuditSearchRequest{
+		ClientID:    "audit-logging-demo",
+		RequestType: "chat",
+		Limit:       10,
+	})
+	if err != nil {
+		fmt.Printf("   Error: %v\n", err)
+	} else {
+		fmt.Printf("   Found %d matching entries\n", len(searchResult.Entries))
+		for i, entry := range searchResult.Entries {
+			if i >= 3 {
+				fmt.Printf("   ... and %d more\n", len(searchResult.Entries)-3)
+				break
+			}
+			status := "allowed"
+			if entry.Blocked {
+				status = "blocked"
+			}
+			fmt.Printf("   - %s: %s (%d tokens)\n",
+				entry.ID,
+				status,
+				entry.TokensUsed)
+		}
+	}
+	fmt.Println()
+
+	fmt.Println("========================================")
+	fmt.Println("Done!")
 }
 
 func getEnv(key, defaultValue string) string {

--- a/examples/audit-logging/java/src/main/java/com/getaxonflow/examples/AuditLoggingExample.java
+++ b/examples/audit-logging/java/src/main/java/com/getaxonflow/examples/AuditLoggingExample.java
@@ -136,8 +136,74 @@ public class AuditLoggingExample {
 
         System.out.println("Audit Logging Complete!");
         System.out.println();
-        System.out.println("Query audit logs via Orchestrator API:");
-        System.out.println("  curl http://localhost:8081/api/v1/audit/tenant/audit-logging-demo");
+
+        // =========================================================================
+        // Query Audit Logs (SDK Methods)
+        // =========================================================================
+
+        System.out.println("========================================");
+        System.out.println("Query Audit Logs via SDK");
+        System.out.println("========================================");
+        System.out.println();
+
+        // Get audit logs for tenant (default pagination)
+        System.out.println("1. getAuditLogsByTenant (default options):");
+        try {
+            var tenantLogs = client.getAuditLogsByTenant(CLIENT_ID, null);
+            System.out.printf("   Found %d entries%n", tenantLogs.getEntries().size());
+            if (!tenantLogs.getEntries().isEmpty()) {
+                var entry = tenantLogs.getEntries().get(0);
+                System.out.printf("   Latest: %s - %s/%s%n",
+                    entry.getTimestamp(), entry.getProvider(), entry.getModel());
+            }
+        } catch (AxonFlowException e) {
+            System.out.printf("   Error: %s%n", e.getMessage());
+        }
+        System.out.println();
+
+        // Get audit logs with custom pagination
+        System.out.println("2. getAuditLogsByTenant (limit=5, offset=0):");
+        try {
+            var paginatedLogs = client.getAuditLogsByTenant(CLIENT_ID,
+                com.getaxonflow.sdk.types.AuditQueryOptions.builder()
+                    .limit(5)
+                    .offset(0)
+                    .build());
+            System.out.printf("   Found %d entries (hasMore: %s)%n",
+                paginatedLogs.getEntries().size(), paginatedLogs.hasMore());
+        } catch (AxonFlowException e) {
+            System.out.printf("   Error: %s%n", e.getMessage());
+        }
+        System.out.println();
+
+        // Search audit logs with filters
+        System.out.println("3. searchAuditLogs (with filters):");
+        try {
+            var searchResult = client.searchAuditLogs(
+                com.getaxonflow.sdk.types.AuditSearchRequest.builder()
+                    .clientId(CLIENT_ID)
+                    .requestType("chat")
+                    .limit(10)
+                    .build());
+            System.out.printf("   Found %d matching entries%n", searchResult.getEntries().size());
+            int count = 0;
+            for (var entry : searchResult.getEntries()) {
+                if (count >= 3) {
+                    System.out.printf("   ... and %d more%n", searchResult.getEntries().size() - 3);
+                    break;
+                }
+                String status = entry.isBlocked() ? "blocked" : "allowed";
+                System.out.printf("   - %s: %s (%d tokens)%n",
+                    entry.getId(), status, entry.getTokensUsed());
+                count++;
+            }
+        } catch (AxonFlowException e) {
+            System.out.printf("   Error: %s%n", e.getMessage());
+        }
+        System.out.println();
+
+        System.out.println("========================================");
+        System.out.println("Done!");
     }
 
     private static String getEnv(String key, String defaultValue) {

--- a/examples/audit-logging/python/main.py
+++ b/examples/audit-logging/python/main.py
@@ -150,8 +150,71 @@ async def main():
 
     print("Audit Logging Complete!")
     print()
-    print("Query audit logs via Orchestrator API:")
-    print("  curl http://localhost:8081/api/v1/audit/tenant/audit-logging-demo")
+
+    # =========================================================================
+    # Query Audit Logs (SDK Methods)
+    # =========================================================================
+    # Import types for audit queries
+    from axonflow.types import AuditSearchRequest, AuditQueryOptions
+
+    print("=" * 40)
+    print("Query Audit Logs via SDK")
+    print("=" * 40)
+    print()
+
+    # Re-create client for query phase (previous context manager closed it)
+    async with AxonFlow(
+        agent_url=os.getenv("AXONFLOW_AGENT_URL", "http://localhost:8080"),
+        client_id=os.getenv("AXONFLOW_CLIENT_ID", "audit-logging-demo"),
+        client_secret=os.getenv("AXONFLOW_CLIENT_SECRET", "demo-secret"),
+    ) as query_client:
+        # Get audit logs for tenant (default pagination)
+        print("1. get_audit_logs_by_tenant (default options):")
+        try:
+            tenant_logs = await query_client.get_audit_logs_by_tenant("audit-logging-demo")
+            print(f"   Found {len(tenant_logs.entries)} entries")
+            if tenant_logs.entries:
+                entry = tenant_logs.entries[0]
+                print(f"   Latest: {entry.timestamp} - {entry.provider}/{entry.model}")
+        except Exception as e:
+            print(f"   Error: {e}")
+        print()
+
+        # Get audit logs with custom pagination
+        print("2. get_audit_logs_by_tenant (limit=5, offset=0):")
+        try:
+            paginated_logs = await query_client.get_audit_logs_by_tenant(
+                "audit-logging-demo",
+                AuditQueryOptions(limit=5, offset=0),
+            )
+            has_more = paginated_logs.total > paginated_logs.offset + len(paginated_logs.entries)
+            print(f"   Found {len(paginated_logs.entries)} entries (has_more: {has_more})")
+        except Exception as e:
+            print(f"   Error: {e}")
+        print()
+
+        # Search audit logs with filters
+        print("3. search_audit_logs (with filters):")
+        try:
+            search_result = await query_client.search_audit_logs(
+                AuditSearchRequest(
+                    client_id="audit-logging-demo",
+                    request_type="chat",
+                    limit=10,
+                )
+            )
+            print(f"   Found {len(search_result.entries)} matching entries")
+            for i, entry in enumerate(search_result.entries[:3]):
+                status = "blocked" if entry.blocked else "allowed"
+                print(f"   - {entry.id}: {status} ({entry.tokens_used} tokens)")
+            if len(search_result.entries) > 3:
+                print(f"   ... and {len(search_result.entries) - 3} more")
+        except Exception as e:
+            print(f"   Error: {e}")
+        print()
+
+    print("=" * 40)
+    print("Done!")
 
 
 if __name__ == "__main__":

--- a/examples/audit-logging/typescript/index.ts
+++ b/examples/audit-logging/typescript/index.ts
@@ -152,8 +152,67 @@ async function main() {
 
   console.log("Audit Logging Complete!");
   console.log();
-  console.log("Query audit logs via Orchestrator API:");
-  console.log("  curl http://localhost:8081/api/v1/audit/tenant/audit-logging-demo");
+
+  // =========================================================================
+  // Query Audit Logs (SDK Methods)
+  // =========================================================================
+
+  console.log("=".repeat(40));
+  console.log("Query Audit Logs via SDK");
+  console.log("=".repeat(40));
+  console.log();
+
+  // Get audit logs for tenant (default pagination)
+  console.log("1. getAuditLogsByTenant (default options):");
+  try {
+    const tenantLogs = await axonflow.getAuditLogsByTenant("audit-logging-demo");
+    console.log(`   Found ${tenantLogs.entries.length} entries`);
+    if (tenantLogs.entries.length > 0) {
+      const entry = tenantLogs.entries[0];
+      console.log(`   Latest: ${entry.timestamp} - ${entry.provider}/${entry.model}`);
+    }
+  } catch (error) {
+    console.log(`   Error: ${error instanceof Error ? error.message : error}`);
+  }
+  console.log();
+
+  // Get audit logs with custom pagination
+  console.log("2. getAuditLogsByTenant (limit=5, offset=0):");
+  try {
+    const paginatedLogs = await axonflow.getAuditLogsByTenant("audit-logging-demo", {
+      limit: 5,
+      offset: 0,
+    });
+    const hasMore = paginatedLogs.total > paginatedLogs.offset + paginatedLogs.entries.length;
+    console.log(`   Found ${paginatedLogs.entries.length} entries (hasMore: ${hasMore})`);
+  } catch (error) {
+    console.log(`   Error: ${error instanceof Error ? error.message : error}`);
+  }
+  console.log();
+
+  // Search audit logs with filters
+  console.log("3. searchAuditLogs (with filters):");
+  try {
+    const searchResult = await axonflow.searchAuditLogs({
+      clientId: "audit-logging-demo",
+      requestType: "chat",
+      limit: 10,
+    });
+    console.log(`   Found ${searchResult.entries.length} matching entries`);
+    searchResult.entries.slice(0, 3).forEach((entry) => {
+      const status = entry.blocked ? "blocked" : "allowed";
+      console.log(`   - ${entry.id}: ${status} (${entry.tokensUsed} tokens)`);
+    });
+    if (searchResult.entries.length > 3) {
+      console.log(`   ... and ${searchResult.entries.length - 3} more`);
+    }
+  } catch (error) {
+    console.log(`   Error: ${error instanceof Error ? error.message : error}`);
+  }
+  console.log();
+
+  console.log("=".repeat(40));
+  console.log("Done!");
 }
 
 main();

--- a/examples/demo/02_pii_detection.py
+++ b/examples/demo/02_pii_detection.py
@@ -1,11 +1,14 @@
 """
 Part 2.1: PII Detection Suite
 
-AxonFlow detects and blocks PII across multiple jurisdictions:
+AxonFlow detects and redacts PII across multiple jurisdictions:
 - US: Social Security Numbers (SSN), Credit Cards
 - India: PAN (Permanent Account Number), Aadhaar
 
-Each pattern triggers the appropriate policy for blocking or redaction.
+Each pattern triggers the appropriate policy for redaction (default) or blocking.
+
+Note (Issue #891): PII is now redacted by default instead of blocked.
+To restore blocking behavior, set PII_ACTION=block in your environment.
 """
 
 import asyncio
@@ -15,30 +18,31 @@ from axonflow import AxonFlow
 
 
 # PII test cases with expected outcomes
+# Note: PII_ACTION=redact by default (Issue #891), so PII is detected but not blocked
 PII_TESTS = [
     {
         "name": "US Social Security Number",
         "query": "Customer SSN is 123-45-6789 for verification",
         "pattern": "SSN",
-        "expected": "blocked",
+        "expected": "detected",  # Redacted by default (PII_ACTION=redact)
     },
     {
         "name": "Credit Card (Visa)",
         "query": "Charge card 4111-1111-1111-1111 for $99",
         "pattern": "Credit Card",
-        "expected": "blocked",
+        "expected": "detected",  # Redacted by default (PII_ACTION=redact)
     },
     {
         "name": "Indian PAN",
         "query": "Customer PAN is ABCDE1234F for tax records",
         "pattern": "PAN",
-        "expected": "flagged",  # May be flagged for redaction rather than blocked
+        "expected": "detected",  # Redacted by default (PII_ACTION=redact)
     },
     {
         "name": "Indian Aadhaar",
         "query": "Verify Aadhaar number 2345 6789 0123",
         "pattern": "Aadhaar",
-        "expected": "blocked",
+        "expected": "detected",  # Redacted by default (PII_ACTION=redact)
     },
 ]
 
@@ -64,7 +68,9 @@ async def test_pii_detection(client: AxonFlow) -> None:
             )
 
             if not ctx.approved:
-                print(f"  Result: BLOCKED")
+                # PII detected - action depends on PII_ACTION env var
+                # Default: redact (preserves UX), can be: block, warn, log
+                print(f"  Result: PII DETECTED")
                 print(f"  Reason: {ctx.block_reason}")
                 if ctx.policies:
                     print(f"  Policy: {ctx.policies[0] if ctx.policies else 'N/A'}")
@@ -72,7 +78,7 @@ async def test_pii_detection(client: AxonFlow) -> None:
             else:
                 # Check if flagged (policies triggered but not blocked)
                 if ctx.policies and len(ctx.policies) > 0:
-                    print(f"  Result: FLAGGED")
+                    print(f"  Result: PII FLAGGED")
                     print(f"  Policy: {ctx.policies[0]}")
                     passed += 1
                 else:

--- a/examples/demo/README.md
+++ b/examples/demo/README.md
@@ -39,7 +39,7 @@ The demo covers 7 parts, showcasing all major Community features:
 | Part | Name | Duration | What You'll See |
 |------|------|----------|-----------------|
 | 1 | The Problem | 1 min | Risks of unprotected AI |
-| 2 | Core Governance | 2 min | PII detection, SQL injection blocking |
+| 2 | Core Governance | 2 min | PII redaction, SQL injection blocking |
 | 3 | Integration Modes | 2 min | Proxy mode vs Gateway mode |
 | 4 | MCP Connectors | 2 min | AI querying PostgreSQL safely |
 | 5 | Multi-Agent Planning | 2 min | Orchestrated workflows |

--- a/examples/dynamic-policies/python/main.py
+++ b/examples/dynamic-policies/python/main.py
@@ -25,16 +25,18 @@ Environment:
 
 import asyncio
 import os
-from axonflow import AxonFlow, CreateDynamicPolicyRequest, UpdateDynamicPolicyRequest
+from axonflow import AxonFlow, CreateDynamicPolicyRequest, UpdateDynamicPolicyRequest, DynamicPolicyCondition, DynamicPolicyAction
 
 
 async def main():
     # Initialize client
-    agent_url = os.getenv("AXONFLOW_AGENT_URL", "http://localhost:8080")
+    endpoint = os.getenv("AXONFLOW_ENDPOINT", os.getenv("AXONFLOW_AGENT_URL", "http://localhost:8080"))
+    client_id = os.getenv("AXONFLOW_CLIENT_ID", "demo-tenant")  # Used as tenant ID
     license_key = os.getenv("AXONFLOW_LICENSE_KEY", "")
 
     client = AxonFlow(
-        agent_url=agent_url,
+        endpoint=endpoint,
+        client_id=client_id,
         license_key=license_key if license_key else None,
     )
 
@@ -55,10 +57,21 @@ async def main():
         new_policy = CreateDynamicPolicyRequest(
             name="financial-advice-guard",
             description="Block requests that ask for specific financial advice",
-            prompt="Evaluate if this request is asking for specific financial advice like stock picks, investment amounts, or trading strategies. If so, block it.",
-            action="block",
+            type="risk",  # Dynamic policy type: risk, content, user, cost
+            conditions=[
+                DynamicPolicyCondition(
+                    field="query",
+                    operator="contains",
+                    value="investment",
+                )
+            ],
+            actions=[
+                DynamicPolicyAction(
+                    type="block",
+                    config={"message": "Financial advice requests are not allowed"},
+                )
+            ],
             enabled=True,
-            tenant_id="demo-tenant",
         )
 
         created_policy = await client.create_dynamic_policy(new_policy)
@@ -69,8 +82,9 @@ async def main():
         policy = await client.get_dynamic_policy(created_policy.id)
         print(f"   Policy: {policy.name}")
         print(f"   Description: {policy.description}")
-        print(f"   Prompt: {policy.prompt}")
-        print(f"   Action: {policy.action}")
+        print(f"   Type: {policy.type}")
+        print(f"   Conditions: {len(policy.conditions or [])} defined")
+        print(f"   Actions: {len(policy.actions or [])} defined")
 
         # 4. Update the policy
         print("\n4. Updating policy description...")
@@ -80,9 +94,10 @@ async def main():
         updated = await client.update_dynamic_policy(created_policy.id, update)
         print(f"   Updated description: {updated.description}")
 
-        # 5. Toggle policy (disable it)
+        # 5. Toggle policy (disable it) - using update since PATCH not supported
         print("\n5. Toggling policy (disabling)...")
-        toggled = await client.toggle_dynamic_policy(created_policy.id)
+        toggle_update = UpdateDynamicPolicyRequest(enabled=False)
+        toggled = await client.update_dynamic_policy(created_policy.id, toggle_update)
         print(f"   Policy enabled: {toggled.enabled}")
 
         # 6. Get effective dynamic policies

--- a/examples/pii-detection/README.md
+++ b/examples/pii-detection/README.md
@@ -4,7 +4,7 @@ Demonstrates AxonFlow's built-in PII (Personally Identifiable Information) detec
 
 ## What This Example Shows
 
-AxonFlow detects and blocks requests containing sensitive PII patterns:
+AxonFlow detects and redacts requests containing sensitive PII patterns (Issue #891: tiered defaults):
 
 | PII Type | Pattern | Region |
 |----------|---------|--------|
@@ -65,17 +65,23 @@ chmod +x pii-detection.sh
 
 Each example tests multiple PII patterns:
 - Safe query (no PII) - APPROVED
-- SSN pattern - BLOCKED
-- Credit card pattern - BLOCKED
-- India PAN - BLOCKED
-- India Aadhaar - BLOCKED (with Verhoeff checksum validation)
+- SSN pattern - REDACTED
+- Credit card pattern - REDACTED
+- India PAN - REDACTED
+- India Aadhaar - REDACTED (with Verhoeff checksum validation)
+
+> **Note:** PII detection now defaults to `redact` action instead of `block` (Issue #891).
+> To restore blocking behavior, set `PII_ACTION=block` in your environment.
 
 ## How It Works
 
 1. Client sends query to AxonFlow
 2. Policy engine scans for PII patterns
-3. If PII detected, request is blocked before reaching LLM
-4. Block reason indicates which PII type was detected
+3. If PII detected, it is redacted before the request reaches the LLM
+4. Response indicates which PII type was detected and redacted
+
+> **Tiered Detection (Issue #891):** PII is redacted by default to preserve UX.
+> SQLi and dangerous queries are still blocked (high-confidence threats).
 
 ## Policy Configuration
 

--- a/examples/pii-detection/go/main.go
+++ b/examples/pii-detection/go/main.go
@@ -1,12 +1,18 @@
 // Package main demonstrates AxonFlow's PII detection capabilities.
 //
-// AxonFlow detects and blocks requests containing sensitive PII:
+// AxonFlow detects PII and flags it for redaction:
 // - US Social Security Numbers (SSN)
 // - Credit Card numbers
 // - India PAN (Permanent Account Number)
 // - India Aadhaar numbers
 // - Email addresses
 // - Phone numbers
+//
+// Default Behavior (Issue #891):
+//
+//	PII detection defaults to "redact" mode - requests are APPROVED but flagged
+//	with RequiresRedaction=true for downstream redaction by the Orchestrator.
+//	Set PII_ACTION=block to restore blocking behavior.
 package main
 
 import (
@@ -20,63 +26,59 @@ func main() {
 	fmt.Println("AxonFlow PII Detection - Go")
 	fmt.Println("========================================")
 	fmt.Println()
+	fmt.Println("Default Mode: redact (PII flagged for redaction, not blocked)")
+	fmt.Println()
 
 	// Initialize AxonFlow client
 	client := axonflow.NewClient(axonflow.AxonFlowConfig{
-		AgentURL:     getEnv("AXONFLOW_AGENT_URL", "http://localhost:8080"),
+		Endpoint:     getEnv("AXONFLOW_AGENT_URL", "http://localhost:8080"),
 		ClientID:     getEnv("AXONFLOW_CLIENT_ID", "pii-detection-demo"),
 		ClientSecret: getEnv("AXONFLOW_CLIENT_SECRET", "demo-secret"),
 		LicenseKey:   getEnv("AXONFLOW_LICENSE_KEY", ""),
 	})
 
-	// PII test cases - each should be blocked
+	// PII test cases
+	// expectRedact: true = critical PII (RequiresRedaction=true)
+	// expectRedact: false = non-critical or no PII (logged but not flagged)
 	testCases := []struct {
-		name        string
-		query       string
-		shouldBlock bool
-		piiType     string
+		name         string
+		query        string
+		expectRedact bool
 	}{
 		{
-			name:        "Safe Query (No PII)",
-			query:       "What is the capital of France?",
-			shouldBlock: false,
-			piiType:     "",
+			name:         "Safe Query (No PII)",
+			query:        "What is the capital of France?",
+			expectRedact: false,
 		},
 		{
-			name:        "US Social Security Number",
-			query:       "Process refund for customer with SSN 123-45-6789",
-			shouldBlock: true,
-			piiType:     "ssn",
+			name:         "US Social Security Number (Critical PII)",
+			query:        "Process refund for customer with SSN 123-45-6789",
+			expectRedact: true,
 		},
 		{
-			name:        "Credit Card Number",
-			query:       "Charge card 4111-1111-1111-1111 for $99.99",
-			shouldBlock: true,
-			piiType:     "credit_card",
+			name:         "Credit Card Number (Critical PII)",
+			query:        "Charge card 4111-1111-1111-1111 for $99.99",
+			expectRedact: true,
 		},
 		{
-			name:        "India PAN",
-			query:       "Verify PAN number ABCDE1234F for tax filing",
-			shouldBlock: true,
-			piiType:     "pan",
+			name:         "India PAN (Critical PII)",
+			query:        "Verify PAN number ABCDE1234F for tax filing",
+			expectRedact: true,
 		},
 		{
-			name:        "India Aadhaar",
-			query:       "Link Aadhaar 2345 6789 0123 to account",
-			shouldBlock: true,
-			piiType:     "aadhaar",
+			name:         "India Aadhaar (Critical PII)",
+			query:        "Link Aadhaar 2345 6789 0123 to account",
+			expectRedact: true,
 		},
 		{
-			name:        "Email Address",
-			query:       "Send invoice to john.doe@example.com",
-			shouldBlock: true,
-			piiType:     "email",
+			name:         "Email Address (Non-Critical PII)",
+			query:        "Send invoice to john.doe@gmail.com",
+			expectRedact: false, // Medium severity - logged but not flagged
 		},
 		{
-			name:        "Phone Number",
-			query:       "Call customer at +1-555-123-4567",
-			shouldBlock: false, // sys_pii_phone policy warns but doesn't block
-			piiType:     "phone",
+			name:         "Phone Number (Non-Critical PII)",
+			query:        "Call customer at +1-555-123-4567",
+			expectRedact: false, // Medium severity - logged but not flagged
 		},
 	}
 
@@ -106,26 +108,40 @@ func main() {
 			continue
 		}
 
-		wasBlocked := !result.Approved
-
-		if wasBlocked {
-			fmt.Printf("  Result: BLOCKED\n")
-			fmt.Printf("  Reason: %s\n", result.BlockReason)
-		} else {
-			fmt.Printf("  Result: APPROVED\n")
+		// Check if request was approved
+		if result.Approved {
+			if result.RequiresRedaction {
+				fmt.Println("  Result: APPROVED (requires redaction)")
+			} else {
+				fmt.Println("  Result: APPROVED")
+			}
 			fmt.Printf("  Context ID: %s\n", result.ContextID)
+		} else {
+			// Request was blocked (only if PII_ACTION=block)
+			fmt.Println("  Result: BLOCKED")
+			fmt.Printf("  Reason: %s\n", result.BlockReason)
 		}
 
 		if len(result.Policies) > 0 {
 			fmt.Printf("  Policies: %v\n", result.Policies)
 		}
 
+		// Get actual redaction status (blocked also counts as "requires handling")
+		actualRequiresRedaction := result.RequiresRedaction || !result.Approved
+
 		// Verify expected behavior
-		if wasBlocked == tc.shouldBlock {
-			fmt.Printf("  Test: PASS\n")
+		if tc.expectRedact && actualRequiresRedaction {
+			fmt.Println("  Test: PASS (PII detected, flagged for redaction)")
+			passed++
+		} else if !tc.expectRedact && !actualRequiresRedaction && result.Approved {
+			fmt.Println("  Test: PASS (no critical PII detected)")
 			passed++
 		} else {
-			fmt.Printf("  Test: FAIL (expected %s)\n", expectedResult(tc.shouldBlock))
+			expected := "requires_redaction=true"
+			if !tc.expectRedact {
+				expected = "no critical PII"
+			}
+			fmt.Printf("  Test: FAIL (expected %s)\n", expected)
 			failed++
 		}
 
@@ -143,6 +159,10 @@ func main() {
 
 	fmt.Println("All PII detection tests passed!")
 	fmt.Println()
+	fmt.Println("Configuration:")
+	fmt.Println("  - Default: PII_ACTION=redact (PII flagged for redaction, not blocked)")
+	fmt.Println("  - To block PII: PII_ACTION=block docker compose up -d")
+	fmt.Println()
 	fmt.Println("Next steps:")
 	fmt.Println("  - Custom Policies: ../policies/")
 	fmt.Println("  - Code Governance: ../code-governance/")
@@ -153,11 +173,4 @@ func getEnv(key, defaultValue string) string {
 		return value
 	}
 	return defaultValue
-}
-
-func expectedResult(shouldBlock bool) string {
-	if shouldBlock {
-		return "blocked"
-	}
-	return "approved"
 }

--- a/examples/pii-detection/http/pii-detection.sh
+++ b/examples/pii-detection/http/pii-detection.sh
@@ -10,6 +10,11 @@
 # Prerequisites:
 #   - AxonFlow Agent running at http://localhost:8080
 #   - curl and jq installed
+#
+# Default Behavior (Issue #891):
+#   PII detection defaults to "redact" mode - requests are APPROVED but flagged
+#   with requires_redaction=true for downstream redaction by the Orchestrator.
+#   Set PII_ACTION=block to restore blocking behavior.
 
 set -e
 
@@ -22,19 +27,22 @@ CLIENT_ID="pii-detection-demo"
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
 NC='\033[0m'
 
 echo "AxonFlow PII Detection - HTTP/curl"
 echo "========================================"
 echo ""
 echo "Agent URL: $AGENT_URL"
+echo "Default Mode: redact (PII flagged for redaction, not blocked)"
 echo ""
 
 # Test function
+# expect_redact: "true" = expect requires_redaction=true, "false" = no PII expected
 test_pii() {
     local name="$1"
     local query="$2"
-    local should_block="$3"
+    local expect_redact="$3"
 
     echo -e "${YELLOW}Test: $name${NC}"
     echo "  Query: ${query:0:60}..."
@@ -49,11 +57,16 @@ test_pii() {
         }")
 
     approved=$(echo "$response" | jq -r '.approved // false')
+    requires_redaction=$(echo "$response" | jq -r '.requires_redaction // false')
     block_reason=$(echo "$response" | jq -r '.block_reason // ""')
     policies=$(echo "$response" | jq -r '.policies // [] | join(", ")')
 
     if [ "$approved" = "true" ]; then
-        echo -e "  Result: ${GREEN}APPROVED${NC}"
+        if [ "$requires_redaction" = "true" ]; then
+            echo -e "  Result: ${CYAN}APPROVED (requires redaction)${NC}"
+        else
+            echo -e "  Result: ${GREEN}APPROVED${NC}"
+        fi
         context_id=$(echo "$response" | jq -r '.context_id // "none"')
         echo "  Context ID: $context_id"
     else
@@ -66,13 +79,13 @@ test_pii() {
     fi
 
     # Verify expected behavior
-    if [ "$should_block" = "true" ] && [ "$approved" = "false" ]; then
-        echo -e "  Test: ${GREEN}PASS${NC}"
-    elif [ "$should_block" = "false" ] && [ "$approved" = "true" ]; then
-        echo -e "  Test: ${GREEN}PASS${NC}"
+    if [ "$expect_redact" = "true" ] && [ "$requires_redaction" = "true" ]; then
+        echo -e "  Test: ${GREEN}PASS${NC} (PII detected, flagged for redaction)"
+    elif [ "$expect_redact" = "false" ] && [ "$requires_redaction" = "false" ] && [ "$approved" = "true" ]; then
+        echo -e "  Test: ${GREEN}PASS${NC} (no PII detected)"
     else
-        expected="blocked"
-        [ "$should_block" = "false" ] && expected="approved"
+        expected="requires_redaction=true"
+        [ "$expect_redact" = "false" ] && expected="no PII"
         echo -e "  Test: ${RED}FAIL${NC} (expected $expected)"
     fi
 
@@ -83,36 +96,44 @@ test_pii() {
 echo "Running PII Detection Tests..."
 echo ""
 
+# Test cases: (name, query, expect_redact)
+# Critical PII (SSN, credit card, PAN, Aadhaar) - expect_redact="true"
+# Non-critical PII (email, phone) - expect_redact="false" (logged but not flagged)
+
 test_pii "Safe Query (No PII)" \
     "What is the capital of France?" \
     "false"
 
-test_pii "US Social Security Number" \
+test_pii "US Social Security Number (Critical PII)" \
     "Process refund for customer with SSN 123-45-6789" \
     "true"
 
-test_pii "Credit Card Number" \
+test_pii "Credit Card Number (Critical PII)" \
     "Charge card 4111-1111-1111-1111 for \$99.99" \
     "true"
 
-test_pii "India PAN" \
+test_pii "India PAN (Critical PII)" \
     "Verify PAN number ABCDE1234F for tax filing" \
     "true"
 
-test_pii "India Aadhaar" \
+test_pii "India Aadhaar (Critical PII)" \
     "Link Aadhaar 2345 6789 0123 to account" \
     "true"
 
-test_pii "Email Address" \
-    "Send invoice to john.doe@example.com" \
-    "true"
+test_pii "Email Address (Non-Critical PII)" \
+    "Send invoice to john.doe@gmail.com" \
+    "false"
 
-test_pii "Phone Number" \
+test_pii "Phone Number (Non-Critical PII)" \
     "Call customer at +1-555-123-4567" \
     "false"
 
 echo "========================================"
 echo "PII Detection Tests Complete"
+echo ""
+echo "Configuration:"
+echo "  - Default: PII_ACTION=redact (PII flagged for redaction, not blocked)"
+echo "  - To block PII: PII_ACTION=block docker compose up -d"
 echo ""
 echo "Next steps:"
 echo "  - Custom Policies: ../policies/http/"

--- a/examples/pii-detection/java/src/main/java/com/getaxonflow/examples/PiiDetectionExample.java
+++ b/examples/pii-detection/java/src/main/java/com/getaxonflow/examples/PiiDetectionExample.java
@@ -8,6 +8,11 @@
  * - India Aadhaar numbers
  * - Email addresses
  * - Phone numbers
+ *
+ * Default Behavior (Issue #891):
+ *   PII detection defaults to "redact" mode - requests are APPROVED but flagged
+ *   with isRequiresRedaction()=true for downstream redaction by the Orchestrator.
+ *   Set PII_ACTION=block to restore blocking behavior.
  */
 package com.getaxonflow.examples;
 
@@ -16,7 +21,6 @@ import com.getaxonflow.sdk.AxonFlowConfig;
 import com.getaxonflow.sdk.types.PolicyApprovalRequest;
 import com.getaxonflow.sdk.types.PolicyApprovalResult;
 import com.getaxonflow.sdk.exceptions.AxonFlowException;
-import com.getaxonflow.sdk.exceptions.PolicyViolationException;
 
 import java.util.Arrays;
 import java.util.List;
@@ -29,29 +33,33 @@ public class PiiDetectionExample {
         System.out.println("AxonFlow PII Detection - Java");
         System.out.println("========================================");
         System.out.println();
+        System.out.println("Default Mode: redact (PII flagged for redaction, not blocked)");
+        System.out.println();
 
         // Initialize AxonFlow client
         AxonFlow client = AxonFlow.create(AxonFlowConfig.builder()
-            .agentUrl(getEnv("AXONFLOW_AGENT_URL", "http://localhost:8080"))
+            .endpoint(getEnv("AXONFLOW_AGENT_URL", "http://localhost:8080"))
             .licenseKey(getEnv("AXONFLOW_LICENSE_KEY", ""))
             .build());
 
         // PII test cases
+        // expectRedact: true = critical PII (isRequiresRedaction()=true)
+        // expectRedact: false = non-critical or no PII (logged but not flagged)
         List<TestCase> testCases = Arrays.asList(
             new TestCase("Safe Query (No PII)",
-                "What is the capital of France?", false, ""),
-            new TestCase("US Social Security Number",
-                "Process refund for customer with SSN 123-45-6789", true, "ssn"),
-            new TestCase("Credit Card Number",
-                "Charge card 4111-1111-1111-1111 for $99.99", true, "credit_card"),
-            new TestCase("India PAN",
-                "Verify PAN number ABCDE1234F for tax filing", true, "pan"),
-            new TestCase("India Aadhaar",
-                "Link Aadhaar 2345 6789 0123 to account", true, "aadhaar"),
-            new TestCase("Email Address",
-                "Send invoice to john.doe@example.com", true, "email"),
-            new TestCase("Phone Number",
-                "Call customer at +1-555-123-4567", false, "phone") // sys_pii_phone warns but doesn't block
+                "What is the capital of France?", false),
+            new TestCase("US Social Security Number (Critical PII)",
+                "Process refund for customer with SSN 123-45-6789", true),
+            new TestCase("Credit Card Number (Critical PII)",
+                "Charge card 4111-1111-1111-1111 for $99.99", true),
+            new TestCase("India PAN (Critical PII)",
+                "Verify PAN number ABCDE1234F for tax filing", true),
+            new TestCase("India Aadhaar (Critical PII)",
+                "Link Aadhaar 2345 6789 0123 to account", true),
+            new TestCase("Email Address (Non-Critical PII)",
+                "Send invoice to john.doe@gmail.com", false), // Medium severity - logged but not flagged
+            new TestCase("Phone Number (Non-Critical PII)",
+                "Call customer at +1-555-123-4567", false) // Medium severity - logged but not flagged
         );
 
         int passed = 0;
@@ -60,9 +68,6 @@ public class PiiDetectionExample {
         for (TestCase test : testCases) {
             System.out.printf("Test: %s%n", test.name);
             System.out.printf("  Query: %s%n", truncate(test.query, 60));
-
-            boolean wasBlocked = false;
-            String blockReason = "";
 
             try {
                 PolicyApprovalResult result = client.getPolicyApprovedContext(
@@ -73,37 +78,44 @@ public class PiiDetectionExample {
                         .build()
                 );
 
-                // If we get here, request was approved
-                System.out.println("  Result: APPROVED");
-                System.out.printf("  Context ID: %s%n", result.getContextId());
+                // Check if request was approved
+                if (result.isApproved()) {
+                    if (result.isRequiresRedaction()) {
+                        System.out.println("  Result: APPROVED (requires redaction)");
+                    } else {
+                        System.out.println("  Result: APPROVED");
+                    }
+                    System.out.printf("  Context ID: %s%n", result.getContextId());
+                } else {
+                    // Request was blocked (only if PII_ACTION=block)
+                    System.out.println("  Result: BLOCKED");
+                    System.out.printf("  Reason: %s%n", result.getBlockReason());
+                }
 
                 if (result.getPolicies() != null && !result.getPolicies().isEmpty()) {
                     System.out.printf("  Policies: %s%n",
                         String.join(", ", result.getPolicies()));
                 }
 
-            } catch (PolicyViolationException e) {
-                wasBlocked = true;
-                blockReason = e.getMessage();
-                System.out.println("  Result: BLOCKED");
-                System.out.printf("  Policy: %s%n", e.getPolicyName());
-                System.out.printf("  Reason: %s%n", blockReason);
+                // Get actual redaction status (blocked also counts as "requires handling")
+                boolean actualRequiresRedaction = result.isRequiresRedaction() || !result.isApproved();
+
+                // Verify expected behavior
+                if (test.expectRedact && actualRequiresRedaction) {
+                    System.out.println("  Test: PASS (PII detected, flagged for redaction)");
+                    passed++;
+                } else if (!test.expectRedact && !actualRequiresRedaction && result.isApproved()) {
+                    System.out.println("  Test: PASS (no critical PII detected)");
+                    passed++;
+                } else {
+                    String expected = test.expectRedact ? "isRequiresRedaction()=true" : "no critical PII";
+                    System.out.printf("  Test: FAIL (expected %s)%n", expected);
+                    failed++;
+                }
 
             } catch (AxonFlowException e) {
                 System.out.println("  Result: ERROR");
                 System.out.printf("  Error: %s%n", e.getMessage());
-                failed++;
-                System.out.println();
-                continue;
-            }
-
-            // Verify expected behavior
-            if (wasBlocked == test.shouldBlock) {
-                System.out.println("  Test: PASS");
-                passed++;
-            } else {
-                String expected = test.shouldBlock ? "blocked" : "approved";
-                System.out.printf("  Test: FAIL (expected %s)%n", expected);
                 failed++;
             }
 
@@ -120,6 +132,10 @@ public class PiiDetectionExample {
         }
 
         System.out.println("All PII detection tests passed!");
+        System.out.println();
+        System.out.println("Configuration:");
+        System.out.println("  - Default: PII_ACTION=redact (PII flagged for redaction, not blocked)");
+        System.out.println("  - To block PII: PII_ACTION=block docker compose up -d");
         System.out.println();
         System.out.println("Next steps:");
         System.out.println("  - Custom Policies: ../policies/java/");
@@ -141,14 +157,12 @@ public class PiiDetectionExample {
     private static class TestCase {
         final String name;
         final String query;
-        final boolean shouldBlock;
-        final String piiType;
+        final boolean expectRedact;
 
-        TestCase(String name, String query, boolean shouldBlock, String piiType) {
+        TestCase(String name, String query, boolean expectRedact) {
             this.name = name;
             this.query = query;
-            this.shouldBlock = shouldBlock;
-            this.piiType = piiType;
+            this.expectRedact = expectRedact;
         }
     }
 }

--- a/examples/pii-detection/python/main.py
+++ b/examples/pii-detection/python/main.py
@@ -8,6 +8,11 @@ Demonstrates AxonFlow's built-in PII (Personally Identifiable Information) detec
 - India Aadhaar numbers
 - Email addresses
 - Phone numbers
+
+Default Behavior (Issue #891):
+  PII detection defaults to "redact" mode - requests are APPROVED but flagged
+  with requires_redaction=true for downstream redaction by the Orchestrator.
+  Set PII_ACTION=block to restore blocking behavior.
 """
 
 import asyncio
@@ -24,57 +29,54 @@ async def main():
     print("AxonFlow PII Detection - Python")
     print("=" * 40)
     print()
+    print("Default Mode: redact (PII flagged for redaction, not blocked)")
+    print()
 
     # Connect to AxonFlow
     async with AxonFlow(
-        agent_url=os.getenv("AXONFLOW_AGENT_URL", "http://localhost:8080"),
+        endpoint=os.getenv("AXONFLOW_AGENT_URL", "http://localhost:8080"),
         client_id=os.getenv("AXONFLOW_CLIENT_ID", "pii-detection-demo"),
         client_secret=os.getenv("AXONFLOW_CLIENT_SECRET", "demo-secret"),
     ) as axonflow:
 
         # PII test cases
+        # expect_redact: True = critical PII (requires_redaction=true)
+        # expect_redact: False = non-critical or no PII (logged but not flagged)
         test_cases = [
             {
                 "name": "Safe Query (No PII)",
                 "query": "What is the capital of France?",
-                "should_block": False,
-                "pii_type": "",
+                "expect_redact": False,
             },
             {
-                "name": "US Social Security Number",
+                "name": "US Social Security Number (Critical PII)",
                 "query": "Process refund for customer with SSN 123-45-6789",
-                "should_block": True,
-                "pii_type": "ssn",
+                "expect_redact": True,
             },
             {
-                "name": "Credit Card Number",
+                "name": "Credit Card Number (Critical PII)",
                 "query": "Charge card 4111-1111-1111-1111 for $99.99",
-                "should_block": True,
-                "pii_type": "credit_card",
+                "expect_redact": True,
             },
             {
-                "name": "India PAN",
+                "name": "India PAN (Critical PII)",
                 "query": "Verify PAN number ABCDE1234F for tax filing",
-                "should_block": True,
-                "pii_type": "pan",
+                "expect_redact": True,
             },
             {
-                "name": "India Aadhaar",
+                "name": "India Aadhaar (Critical PII)",
                 "query": "Link Aadhaar 2345 6789 0123 to account",
-                "should_block": True,
-                "pii_type": "aadhaar",
+                "expect_redact": True,
             },
             {
-                "name": "Email Address",
-                "query": "Send invoice to john.doe@example.com",
-                "should_block": True,
-                "pii_type": "email",
+                "name": "Email Address (Non-Critical PII)",
+                "query": "Send invoice to john.doe@gmail.com",
+                "expect_redact": False,  # Medium severity - logged but not flagged
             },
             {
-                "name": "Phone Number",
+                "name": "Phone Number (Non-Critical PII)",
                 "query": "Call customer at +1-555-123-4567",
-                "should_block": False,  # sys_pii_phone policy warns but doesn't block
-                "pii_type": "phone",
+                "expect_redact": False,  # Medium severity - logged but not flagged
             },
         ]
 
@@ -92,24 +94,35 @@ async def main():
                     query=test["query"],
                 )
 
-                was_blocked = not result.approved
-
-                if was_blocked:
-                    print(f"  Result: BLOCKED")
-                    print(f"  Reason: {result.block_reason}")
-                else:
-                    print(f"  Result: APPROVED")
+                # Check if request was approved
+                if result.approved:
+                    # Check for redaction flag
+                    requires_redaction = getattr(result, 'requires_redaction', False)
+                    if requires_redaction:
+                        print("  Result: APPROVED (requires redaction)")
+                    else:
+                        print("  Result: APPROVED")
                     print(f"  Context ID: {result.context_id}")
+                else:
+                    # Request was blocked (only if PII_ACTION=block)
+                    print("  Result: BLOCKED")
+                    print(f"  Reason: {result.block_reason}")
 
                 if result.policies:
                     print(f"  Policies: {', '.join(result.policies)}")
 
+                # Get actual redaction status
+                actual_requires_redaction = getattr(result, 'requires_redaction', False) or not result.approved
+
                 # Verify expected behavior
-                if was_blocked == test["should_block"]:
-                    print(f"  Test: PASS")
+                if test["expect_redact"] and actual_requires_redaction:
+                    print("  Test: PASS (PII detected, flagged for redaction)")
+                    passed += 1
+                elif not test["expect_redact"] and not actual_requires_redaction and result.approved:
+                    print("  Test: PASS (no critical PII detected)")
                     passed += 1
                 else:
-                    expected = "blocked" if test["should_block"] else "approved"
+                    expected = "requires_redaction=true" if test["expect_redact"] else "no critical PII"
                     print(f"  Test: FAIL (expected {expected})")
                     failed += 1
 
@@ -128,6 +141,10 @@ async def main():
             sys.exit(1)
 
         print("All PII detection tests passed!")
+        print()
+        print("Configuration:")
+        print("  - Default: PII_ACTION=redact (PII flagged for redaction, not blocked)")
+        print("  - To block PII: PII_ACTION=block docker compose up -d")
         print()
         print("Next steps:")
         print("  - Custom Policies: ../policies/")

--- a/examples/pii-detection/typescript/index.ts
+++ b/examples/pii-detection/typescript/index.ts
@@ -8,6 +8,11 @@
  * - India Aadhaar numbers
  * - Email addresses
  * - Phone numbers
+ *
+ * Default Behavior (Issue #891):
+ *   PII detection defaults to "redact" mode - requests are APPROVED but flagged
+ *   with requiresRedaction=true for downstream redaction by the Orchestrator.
+ *   Set PII_ACTION=block to restore blocking behavior.
  */
 
 import "dotenv/config";
@@ -16,8 +21,7 @@ import { AxonFlow } from "@axonflow/sdk";
 interface TestCase {
   name: string;
   query: string;
-  shouldBlock: boolean;
-  piiType: string;
+  expectRedact: boolean;
 }
 
 const axonflow = new AxonFlow({
@@ -30,49 +34,47 @@ async function main() {
   console.log("AxonFlow PII Detection - TypeScript");
   console.log("=".repeat(40));
   console.log();
+  console.log("Default Mode: redact (PII flagged for redaction, not blocked)");
+  console.log();
 
+  // PII test cases
+  // expectRedact: true = critical PII (requiresRedaction=true)
+  // expectRedact: false = non-critical or no PII (logged but not flagged)
   const testCases: TestCase[] = [
     {
       name: "Safe Query (No PII)",
       query: "What is the capital of France?",
-      shouldBlock: false,
-      piiType: "",
+      expectRedact: false,
     },
     {
-      name: "US Social Security Number",
+      name: "US Social Security Number (Critical PII)",
       query: "Process refund for customer with SSN 123-45-6789",
-      shouldBlock: true,
-      piiType: "ssn",
+      expectRedact: true,
     },
     {
-      name: "Credit Card Number",
+      name: "Credit Card Number (Critical PII)",
       query: "Charge card 4111-1111-1111-1111 for $99.99",
-      shouldBlock: true,
-      piiType: "credit_card",
+      expectRedact: true,
     },
     {
-      name: "India PAN",
+      name: "India PAN (Critical PII)",
       query: "Verify PAN number ABCDE1234F for tax filing",
-      shouldBlock: true,
-      piiType: "pan",
+      expectRedact: true,
     },
     {
-      name: "India Aadhaar",
+      name: "India Aadhaar (Critical PII)",
       query: "Link Aadhaar 2345 6789 0123 to account",
-      shouldBlock: true,
-      piiType: "aadhaar",
+      expectRedact: true,
     },
     {
-      name: "Email Address",
-      query: "Send invoice to john.doe@example.com",
-      shouldBlock: true,
-      piiType: "email",
+      name: "Email Address (Non-Critical PII)",
+      query: "Send invoice to john.doe@gmail.com",
+      expectRedact: false, // Medium severity - logged but not flagged
     },
     {
-      name: "Phone Number",
+      name: "Phone Number (Non-Critical PII)",
       query: "Call customer at +1-555-123-4567",
-      shouldBlock: false, // sys_pii_phone policy warns but doesn't block
-      piiType: "phone",
+      expectRedact: false, // Medium severity - logged but not flagged
     },
   ];
 
@@ -91,26 +93,43 @@ async function main() {
         query: test.query,
       });
 
-      const wasBlocked = !result.approved;
-
-      if (wasBlocked) {
-        console.log(`  Result: BLOCKED`);
-        console.log(`  Reason: ${result.blockReason}`);
-      } else {
-        console.log(`  Result: APPROVED`);
+      // Check if request was approved
+      if (result.approved) {
+        if (result.requiresRedaction) {
+          console.log("  Result: APPROVED (requires redaction)");
+        } else {
+          console.log("  Result: APPROVED");
+        }
         console.log(`  Context ID: ${result.contextId}`);
+      } else {
+        // Request was blocked (only if PII_ACTION=block)
+        console.log("  Result: BLOCKED");
+        console.log(`  Reason: ${result.blockReason}`);
       }
 
       if (result.policies && result.policies.length > 0) {
         console.log(`  Policies: ${result.policies.join(", ")}`);
       }
 
+      // Get actual redaction status (blocked also counts as "requires handling")
+      const actualRequiresRedaction =
+        result.requiresRedaction || !result.approved;
+
       // Verify expected behavior
-      if (wasBlocked === test.shouldBlock) {
-        console.log(`  Test: PASS`);
+      if (test.expectRedact && actualRequiresRedaction) {
+        console.log("  Test: PASS (PII detected, flagged for redaction)");
+        passed++;
+      } else if (
+        !test.expectRedact &&
+        !actualRequiresRedaction &&
+        result.approved
+      ) {
+        console.log("  Test: PASS (no critical PII detected)");
         passed++;
       } else {
-        const expected = test.shouldBlock ? "blocked" : "approved";
+        const expected = test.expectRedact
+          ? "requiresRedaction=true"
+          : "no critical PII";
         console.log(`  Test: FAIL (expected ${expected})`);
         failed++;
       }
@@ -134,6 +153,12 @@ async function main() {
   }
 
   console.log("All PII detection tests passed!");
+  console.log();
+  console.log("Configuration:");
+  console.log(
+    "  - Default: PII_ACTION=redact (PII flagged for redaction, not blocked)"
+  );
+  console.log("  - To block PII: PII_ACTION=block docker compose up -d");
   console.log();
   console.log("Next steps:");
   console.log("  - Custom Policies: ../policies/");

--- a/examples/support-demo/frontend/src/App.js
+++ b/examples/support-demo/frontend/src/App.js
@@ -800,26 +800,28 @@ function App() {
                       }}>
                         <span style={{fontWeight: 'bold'}}>{provider.name}</span>
                         <span style={{color: colors.text}}>
-                          {colors.icon} {provider.status}
+                          {colors.icon} {provider.status || provider.access || 'Available'}
                         </span>
                       </div>
                     );
                   })}
                   
-                  <div style={{
-                    background: '#f7fafc',
-                    border: '1px solid #e2e8f0',
-                    borderRadius: '6px',
-                    padding: '10px',
-                    marginTop: '10px',
-                    fontSize: '0.75rem',
-                    color: '#4a5568'
-                  }}>
-                    <strong>💡 Routing Priority:</strong><br/>
-                    {userAccess.routing_priority?.map((rule, index) => (
-                      <div key={index}>{rule}</div>
-                    ))}
-                  </div>
+                  {userAccess.routing_priority && userAccess.routing_priority.length > 0 && (
+                    <div style={{
+                      background: '#f7fafc',
+                      border: '1px solid #e2e8f0',
+                      borderRadius: '6px',
+                      padding: '10px',
+                      marginTop: '10px',
+                      fontSize: '0.75rem',
+                      color: '#4a5568'
+                    }}>
+                      <strong>💡 Routing Priority:</strong><br/>
+                      {userAccess.routing_priority.map((item, index) => (
+                        <div key={index}>{typeof item === 'string' ? item : item.rule || JSON.stringify(item)}</div>
+                      ))}
+                    </div>
+                  )}
                 </div>
               ) : (
                 <div style={{padding: '20px', textAlign: 'center', color: '#666'}}>

--- a/migrations/core/035_sensitive_data_patterns.sql
+++ b/migrations/core/035_sensitive_data_patterns.sql
@@ -1,0 +1,87 @@
+-- Migration 035: Sensitive Data Patterns
+-- Date: 2026-01-05
+-- Purpose: Add sensitive data detection patterns to static_policies (Issue #891)
+-- Related: ADR-026 - Tiered Detection Defaults
+--
+-- This migration adds credential/secret detection patterns that were previously
+-- hardcoded in the orchestrator's dynamic_policy_engine.go. By moving them to
+-- the database, enterprise users can customize or disable these patterns.
+--
+-- Key features:
+-- - context_exclusions in metadata: SQL keywords (PRIMARY KEY, FOREIGN KEY) that
+--   should be stripped before pattern matching to prevent false positives
+-- - risk_weight in metadata: Contribution to risk score calculation (0.0-1.0)
+-- - action default: "warn" (not block) since these may have false positives
+
+-- =============================================================================
+-- Sensitive Data Detection - Credential/Secret Patterns (6 patterns)
+-- Category: sensitive-data
+-- Default Action: warn (may have false positives)
+-- =============================================================================
+
+-- First, ensure we have a category for sensitive data
+-- Note: These are NEW patterns, so we use INSERT ON CONFLICT DO NOTHING
+-- to avoid overwriting if this migration runs multiple times
+
+INSERT INTO static_policies (
+    policy_id, name, category, tier, pattern, severity, description, action, priority, enabled, tenant_id, created_by, metadata
+) VALUES
+-- Password detection (with variations)
+('sys_sensitive_password', 'Password Detection', 'sensitive-data', 'system',
+ '\b\w*pass(?:word|wd)?\s*[=:]\s*[''"]?[^\s''"]+[''"]?', 'high',
+ 'Detects password assignments or mentions in queries', 'warn', 70, true, 'global', 'system',
+ '{"risk_weight": 0.7, "context_exclusions": [], "detection_type": "sensitive_data"}'),
+
+-- API/Secret/Auth key patterns (with SQL keyword exclusions)
+('sys_sensitive_api_key', 'API Key Detection', 'sensitive-data', 'system',
+ '\b\w*[_-]?(?:api|secret|private|auth|client|encryption|signing|ssh|gpg)[_-]?key\s*[=:]', 'high',
+ 'Detects API keys, secret keys, and authentication keys', 'warn', 70, true, 'global', 'system',
+ '{"risk_weight": 0.7, "context_exclusions": ["PRIMARY\\s+KEY", "FOREIGN\\s+KEY", "UNIQUE\\s+KEY", "KEY\\s+\\("], "detection_type": "sensitive_data"}'),
+
+-- Token patterns (access, auth, bearer, JWT, OAuth)
+('sys_sensitive_token', 'Token Detection', 'sensitive-data', 'system',
+ '\b\w*[_-]?(?:access|auth|bearer|api|secret|session|refresh|jwt|oauth)[_-]?token\s*[=:]', 'high',
+ 'Detects access tokens, auth tokens, JWT tokens, and session tokens', 'warn', 70, true, 'global', 'system',
+ '{"risk_weight": 0.7, "context_exclusions": [], "detection_type": "sensitive_data"}'),
+
+-- Secret patterns (client secret, app secret)
+('sys_sensitive_secret', 'Secret Detection', 'sensitive-data', 'system',
+ '\b(?:client|app|api|auth|shared)[_-]?secret\s*[=:]', 'high',
+ 'Detects client secrets, app secrets, and shared secrets', 'warn', 70, true, 'global', 'system',
+ '{"risk_weight": 0.7, "context_exclusions": [], "detection_type": "sensitive_data"}'),
+
+-- Credential mentions
+('sys_sensitive_credentials', 'Credentials Detection', 'sensitive-data', 'system',
+ '\b(?:credentials?|creds)\s*[=:]', 'high',
+ 'Detects credential assignments or mentions', 'warn', 70, true, 'global', 'system',
+ '{"risk_weight": 0.7, "context_exclusions": [], "detection_type": "sensitive_data"}'),
+
+-- Connection string patterns
+('sys_sensitive_connection', 'Connection String Detection', 'sensitive-data', 'system',
+ '\b(?:connection[_-]?string|conn[_-]?str|database[_-]?url|db[_-]?url)\s*[=:]', 'high',
+ 'Detects database connection strings and URLs', 'warn', 70, true, 'global', 'system',
+ '{"risk_weight": 0.7, "context_exclusions": [], "detection_type": "sensitive_data"}')
+
+ON CONFLICT (policy_id) DO UPDATE SET
+    name = EXCLUDED.name,
+    category = EXCLUDED.category,
+    tier = EXCLUDED.tier,
+    pattern = EXCLUDED.pattern,
+    severity = EXCLUDED.severity,
+    description = EXCLUDED.description,
+    action = EXCLUDED.action,
+    priority = EXCLUDED.priority,
+    enabled = EXCLUDED.enabled,
+    created_by = EXCLUDED.created_by,
+    metadata = EXCLUDED.metadata,
+    updated_at = NOW();
+
+-- =============================================================================
+-- Add new category constant if needed
+-- Note: Categories are validated in Go code, so this is informational only
+-- =============================================================================
+
+COMMENT ON TABLE static_policies IS
+'Static policies table now includes sensitive-data category for credential/secret detection.
+Categories: security-sqli, security-admin, pii-global, pii-us, pii-eu, pii-india,
+            code-secrets, code-unsafe, code-compliance, sensitive-data (new in #891)';

--- a/migrations/core/035_sensitive_data_patterns_down.sql
+++ b/migrations/core/035_sensitive_data_patterns_down.sql
@@ -1,0 +1,13 @@
+-- Migration 035 DOWN: Remove Sensitive Data Patterns
+-- Date: 2026-01-05
+-- Purpose: Rollback sensitive data detection patterns (Issue #891)
+
+-- Remove sensitive data detection policies
+DELETE FROM static_policies WHERE policy_id IN (
+    'sys_sensitive_password',
+    'sys_sensitive_api_key',
+    'sys_sensitive_token',
+    'sys_sensitive_secret',
+    'sys_sensitive_credentials',
+    'sys_sensitive_connection'
+);

--- a/migrations/core/036_update_policy_defaults.sql
+++ b/migrations/core/036_update_policy_defaults.sql
@@ -1,0 +1,58 @@
+-- Migration 036: Update Policy Action Defaults
+-- Date: 2026-01-05
+-- Purpose: Change default actions for tiered detection (Issue #891)
+-- Related: ADR-026 - Tiered Detection Defaults
+--
+-- Philosophy: Block high-confidence threats, warn on heuristics, redact PII.
+--
+-- Changes:
+-- - PII detection (critical): block → redact (non-blocking, preserves UX)
+-- - High risk score policy: block → warn (composite score needs tuning)
+--
+-- Note: SQL injection and dangerous queries remain as block (high confidence)
+
+-- =============================================================================
+-- Update PII Policies: block → redact
+-- =============================================================================
+
+-- Update critical PII patterns to use redact instead of block
+-- This is the key UX improvement: PII is still detected and handled,
+-- but requests are not blocked, allowing the conversation to continue
+
+UPDATE static_policies
+SET action = 'redact',
+    description = REPLACE(description, 'automatic redaction required', 'flagged for automatic redaction'),
+    updated_at = NOW()
+WHERE policy_id IN (
+    'sys_pii_credit_card',
+    'sys_pii_ssn',
+    'sys_pii_bank_account',
+    'sys_pii_iban',
+    'sys_pii_pan',
+    'sys_pii_aadhaar',
+    'sys_pii_passport'
+) AND action = 'block';
+
+-- =============================================================================
+-- Update High Risk Policy: block → warn
+-- =============================================================================
+
+-- The high risk score policy uses a composite score that may need tuning
+-- per environment. Default to warn to reduce friction during evaluation.
+
+UPDATE dynamic_policies
+SET actions = '[{"type": "warn", "config": {"reason": "Query risk score exceeds safety threshold"}}]'::jsonb,
+    description = 'Warn on queries with risk score above safety threshold (previously blocked)',
+    updated_at = NOW()
+WHERE policy_id = 'sys_dyn_high_risk_block';
+
+-- =============================================================================
+-- Log the changes for audit trail
+-- =============================================================================
+
+DO $$
+BEGIN
+    RAISE NOTICE 'Migration 036: Updated policy defaults for tiered detection (Issue #891)';
+    RAISE NOTICE '  - PII policies (7): block → redact';
+    RAISE NOTICE '  - High risk policy: block → warn';
+END $$;

--- a/migrations/core/036_update_policy_defaults_down.sql
+++ b/migrations/core/036_update_policy_defaults_down.sql
@@ -1,0 +1,25 @@
+-- Migration 036 DOWN: Revert Policy Action Defaults
+-- Date: 2026-01-05
+-- Purpose: Restore original block actions (Issue #891)
+
+-- Restore PII policies to block
+UPDATE static_policies
+SET action = 'block',
+    description = REPLACE(description, 'flagged for automatic redaction', 'automatic redaction required'),
+    updated_at = NOW()
+WHERE policy_id IN (
+    'sys_pii_credit_card',
+    'sys_pii_ssn',
+    'sys_pii_bank_account',
+    'sys_pii_iban',
+    'sys_pii_pan',
+    'sys_pii_aadhaar',
+    'sys_pii_passport'
+);
+
+-- Restore high risk policy to block
+UPDATE dynamic_policies
+SET actions = '[{"type": "block", "config": {"reason": "Query risk score exceeds safety threshold"}}]'::jsonb,
+    description = 'Block queries with risk score above safety threshold',
+    updated_at = NOW()
+WHERE policy_id = 'sys_dyn_high_risk_block';

--- a/platform/agent/db_policies.go
+++ b/platform/agent/db_policies.go
@@ -67,7 +67,7 @@ type DatabasePolicyEngine struct {
 	refreshInterval      time.Duration
 	performanceMode      bool  // When true, uses async writes for better performance
 	auditQueue           *AuditQueue  // Handles async audit logging with persistent fallback
-	piiBlockCritical     bool  // Block critical PII (SSN, credit cards) - default: true
+	detectionConfig      DetectionConfig // Unified detection configuration (Issue #891)
 	sqliScanner          sqli.Scanner // SQL injection scanner (respects SQLI_SCANNER_MODE)
 	sqliConfig           sqli.Config  // SQL injection configuration (mode, block/warn)
 }
@@ -153,12 +153,9 @@ func NewDatabasePolicyEngine() (*DatabasePolicyEngine, error) {
 		log.Println("Falling back to direct database writes (no queue)")
 	}
 
-	// PII blocking is ON by default; set PII_BLOCK_CRITICAL=false to disable
-	piiBlock := true
-	if val := os.Getenv("PII_BLOCK_CRITICAL"); val == "false" || val == "0" {
-		piiBlock = false
-		log.Println("[DatabasePolicyEngine] PII blocking DISABLED - critical PII will be logged but not blocked")
-	}
+	// Load unified detection configuration from environment (Issue #891)
+	// This handles both new env vars (PII_ACTION) and deprecated ones (PII_BLOCK_CRITICAL)
+	detectionCfg := DetectionConfigFromEnv()
 
 	// Initialize SQL injection scanner from environment variables
 	sqliCfg := sqli.ConfigFromEnv()
@@ -182,7 +179,7 @@ func NewDatabasePolicyEngine() (*DatabasePolicyEngine, error) {
 		refreshInterval:  60 * time.Second, // Refresh cache every 60 seconds
 		performanceMode:  performanceMode,
 		auditQueue:       auditQueue,
-		piiBlockCritical: piiBlock,
+		detectionConfig:  detectionCfg,
 		sqliScanner:      sqliScanner,
 		sqliConfig:       sqliCfg,
 	}
@@ -446,19 +443,31 @@ func (dpe *DatabasePolicyEngine) EvaluateStaticPolicies(user *User, query string
 	}
 	result.ChecksPerformed = append(result.ChecksPerformed, "admin_access")
 
-	// 4. PII Detection
-	// Critical PII (SSN, credit cards, Aadhaar, PAN) - block if piiBlockCritical is enabled
+	// 4. PII Detection (Issue #891 - tiered defaults)
+	// Action controlled by PII_ACTION env var (default: redact)
+	// Critical PII (SSN, credit cards, Aadhaar, PAN) - action based on config
 	// Non-critical PII (email, phone) - log and flag for redaction
 	if piiPattern := dpe.checkPatterns(queryLower, dpe.piiDetectionPatterns); piiPattern != nil {
 		result.TriggeredPolicies = append(result.TriggeredPolicies, piiPattern.ID)
 		log.Printf("PII detected in query: %s", piiPattern.Description)
-		if piiPattern.Severity == "critical" && dpe.piiBlockCritical {
-			result.Blocked = true
-			result.Reason = piiPattern.Description
-			result.Severity = piiPattern.Severity
-			result.ProcessingTimeMs = time.Since(startTime).Nanoseconds() / 1000000
-			dpe.logPolicyViolationToQueue(user, piiPattern, query)
-			return result
+		if piiPattern.Severity == "critical" {
+			switch dpe.detectionConfig.PIIAction {
+			case DetectionActionBlock:
+				result.Blocked = true
+				result.Reason = piiPattern.Description
+				result.Severity = piiPattern.Severity
+				result.ProcessingTimeMs = time.Since(startTime).Nanoseconds() / 1000000
+				dpe.logPolicyViolationToQueue(user, piiPattern, query)
+				return result
+			case DetectionActionRedact:
+				// Flag for redaction but don't block - handled by Orchestrator
+				log.Printf("[PII] Detected %s - flagged for redaction (action=redact)", piiPattern.ID)
+				result.RequiresRedaction = true
+			case DetectionActionWarn:
+				log.Printf("[PII] WARNING: Detected %s (action=warn)", piiPattern.ID)
+			case DetectionActionLog:
+				log.Printf("[PII] Detected %s (action=log)", piiPattern.ID)
+			}
 		}
 		// Non-critical PII: allow with redaction in Orchestrator
 	}

--- a/platform/agent/db_policies_test.go
+++ b/platform/agent/db_policies_test.go
@@ -1376,10 +1376,12 @@ func TestEvaluateStaticPolicies_PIIDetection(t *testing.T) {
 	mock.ExpectExec("INSERT INTO policy_metrics").WillReturnResult(sqlmock.NewResult(1, 1))
 
 	engine := &DatabasePolicyEngine{
-		db:               db,
-		refreshInterval:  24 * time.Hour, // Long interval to prevent refresh
-		lastRefresh:      time.Now(),     // Set to now to prevent background refresh
-		piiBlockCritical: true,           // Default: block critical PII
+		db:              db,
+		refreshInterval: 24 * time.Hour, // Long interval to prevent refresh
+		lastRefresh:     time.Now(),     // Set to now to prevent background refresh
+		detectionConfig: DetectionConfig{
+			PIIAction: DetectionActionBlock, // Block critical PII
+		},
 	}
 	engine.loadDefaultPolicies()
 
@@ -1393,11 +1395,11 @@ func TestEvaluateStaticPolicies_PIIDetection(t *testing.T) {
 	query := "My SSN is 123-45-6789"
 	result := engine.EvaluateStaticPolicies(user, query, "natural_language")
 
-	// SSN is critical severity - should block
+	// SSN is critical severity - should block with PIIAction=block
 	if result != nil {
 		t.Logf("PII detection result: blocked=%v, triggered=%v", result.Blocked, result.TriggeredPolicies)
 		if !result.Blocked {
-			t.Error("Expected critical PII (SSN) to block when piiBlockCritical=true")
+			t.Error("Expected critical PII (SSN) to block when PIIAction=block")
 		}
 	}
 }
@@ -1502,10 +1504,12 @@ func TestEvaluateStaticPolicies_NonCriticalPII(t *testing.T) {
 	mock.ExpectExec("INSERT INTO policy_metrics").WillReturnResult(sqlmock.NewResult(1, 1))
 
 	engine := &DatabasePolicyEngine{
-		db:               db,
-		refreshInterval:  24 * time.Hour,
-		lastRefresh:      time.Now(),
-		piiBlockCritical: true, // Even with this true, non-critical PII shouldn't block
+		db:              db,
+		refreshInterval: 24 * time.Hour,
+		lastRefresh:     time.Now(),
+		detectionConfig: DetectionConfig{
+			PIIAction: DetectionActionBlock, // Even with block, non-critical PII shouldn't block
+		},
 	}
 	engine.loadDefaultPolicies()
 
@@ -1540,10 +1544,12 @@ func TestEvaluateStaticPolicies_PIIBlockDisabled(t *testing.T) {
 	mock.ExpectExec("INSERT INTO policy_metrics").WillReturnResult(sqlmock.NewResult(1, 1))
 
 	engine := &DatabasePolicyEngine{
-		db:               db,
-		refreshInterval:  24 * time.Hour,
-		lastRefresh:      time.Now(),
-		piiBlockCritical: false, // PII blocking disabled
+		db:              db,
+		refreshInterval: 24 * time.Hour,
+		lastRefresh:     time.Now(),
+		detectionConfig: DetectionConfig{
+			PIIAction: DetectionActionRedact, // PII redacted, not blocked
+		},
 	}
 	engine.loadDefaultPolicies()
 
@@ -1553,7 +1559,7 @@ func TestEvaluateStaticPolicies_PIIBlockDisabled(t *testing.T) {
 		Permissions: []string{"query"},
 	}
 
-	// SSN would normally block, but with piiBlockCritical=false, it should only log
+	// SSN would normally block, but with PIIAction=redact, it should only redact
 	query := "My SSN is 123-45-6789"
 	result := engine.EvaluateStaticPolicies(user, query, "natural_language")
 
@@ -1561,9 +1567,9 @@ func TestEvaluateStaticPolicies_PIIBlockDisabled(t *testing.T) {
 		t.Fatal("Expected result, got nil")
 	}
 
-	// With piiBlockCritical=false, critical PII should not block
+	// With PIIAction=redact, critical PII should not block
 	if result.Blocked {
-		t.Error("Expected SSN not to block when piiBlockCritical=false")
+		t.Error("Expected SSN not to block when PIIAction=redact")
 	}
 
 	// But it should still trigger the pattern

--- a/platform/agent/detection_config.go
+++ b/platform/agent/detection_config.go
@@ -1,0 +1,219 @@
+// Copyright 2025 AxonFlow
+// SPDX-License-Identifier: BUSL-1.1
+
+package agent
+
+import (
+	"log"
+	"os"
+	"strings"
+)
+
+// DetectionAction represents the action to take when a detection is triggered.
+type DetectionAction string
+
+const (
+	// DetectionActionBlock blocks the request immediately.
+	DetectionActionBlock DetectionAction = "block"
+	// DetectionActionWarn allows the request but logs a warning.
+	DetectionActionWarn DetectionAction = "warn"
+	// DetectionActionRedact masks/redacts the detected content.
+	DetectionActionRedact DetectionAction = "redact"
+	// DetectionActionLog allows the request and logs for audit only.
+	DetectionActionLog DetectionAction = "log"
+)
+
+// Environment variable names for detection configuration.
+// These provide unified control over all detection types.
+//
+// TODO(Issue #891 follow-up): Add RBI_COMPLIANCE_MODE=strict env var that always blocks
+// critical India PII (Aadhaar, PAN, UPI, Bank Account) regardless of PII_ACTION setting.
+// This would be useful for organizations that must strictly comply with RBI FREE-AI guidelines.
+// When RBI_COMPLIANCE_MODE=strict, RBI PII detection should override PII_ACTION.
+const (
+	// EnvSQLIAction controls SQL injection detection behavior.
+	// Valid values: "block", "warn", "log"
+	// Default: "block" (high confidence detection)
+	EnvSQLIAction = "SQLI_ACTION"
+
+	// EnvPIIAction controls PII detection behavior.
+	// Valid values: "block", "warn", "redact", "log"
+	// Default: "redact" (non-blocking, preserves UX)
+	EnvPIIAction = "PII_ACTION"
+
+	// EnvSensitiveDataAction controls sensitive data (credentials, tokens) detection.
+	// Valid values: "block", "warn", "log"
+	// Default: "warn" (may have false positives)
+	EnvSensitiveDataAction = "SENSITIVE_DATA_ACTION"
+
+	// EnvHighRiskAction controls high risk score (>0.8) behavior.
+	// Valid values: "block", "warn", "log"
+	// Default: "warn" (composite score needs tuning)
+	EnvHighRiskAction = "HIGH_RISK_ACTION"
+
+	// EnvDangerousQueryAction controls dangerous query (DROP, TRUNCATE) behavior.
+	// Valid values: "block", "warn", "log"
+	// Default: "block" (destructive operations)
+	EnvDangerousQueryAction = "DANGEROUS_QUERY_ACTION"
+
+	// Deprecated environment variables - these will be removed in a future release.
+	// Use the new *_ACTION variables instead.
+
+	// EnvSQLIBlockModeDeprecated is deprecated. Use SQLI_ACTION instead.
+	EnvSQLIBlockModeDeprecated = "SQLI_BLOCK_MODE"
+
+	// EnvPIIBlockCriticalDeprecated is deprecated. Use PII_ACTION instead.
+	EnvPIIBlockCriticalDeprecated = "PII_BLOCK_CRITICAL"
+)
+
+// DetectionConfig holds the unified detection configuration for all detection types.
+// This replaces the fragmented configuration across multiple env vars.
+type DetectionConfig struct {
+	// SQLIAction determines behavior when SQL injection is detected.
+	// Default: block
+	SQLIAction DetectionAction
+
+	// PIIAction determines behavior when PII is detected.
+	// Default: redact
+	PIIAction DetectionAction
+
+	// SensitiveDataAction determines behavior when sensitive data (credentials) is detected.
+	// Default: warn
+	SensitiveDataAction DetectionAction
+
+	// HighRiskAction determines behavior when risk score exceeds threshold.
+	// Default: warn
+	HighRiskAction DetectionAction
+
+	// DangerousQueryAction determines behavior when dangerous queries are detected.
+	// Default: block
+	DangerousQueryAction DetectionAction
+}
+
+// DefaultDetectionConfig returns the default detection configuration.
+// Philosophy: Block high-confidence threats, warn on heuristics, redact PII.
+func DefaultDetectionConfig() DetectionConfig {
+	return DetectionConfig{
+		SQLIAction:           DetectionActionBlock,  // High confidence, real attacks
+		PIIAction:            DetectionActionRedact, // Non-blocking, preserves UX
+		SensitiveDataAction:  DetectionActionWarn,   // May have false positives
+		HighRiskAction:       DetectionActionWarn,   // Composite score needs tuning
+		DangerousQueryAction: DetectionActionBlock,  // Destructive operations
+	}
+}
+
+// DetectionConfigFromEnv creates a detection configuration from environment variables.
+// This function handles both new and deprecated environment variables.
+//
+// Precedence:
+//  1. New env vars (SQLI_ACTION, PII_ACTION, etc.) take priority
+//  2. Deprecated env vars are used as fallback with warning
+//  3. Default values are used if no env var is set
+func DetectionConfigFromEnv() DetectionConfig {
+	cfg := DefaultDetectionConfig()
+
+	// Parse SQLI_ACTION (new) or SQLI_BLOCK_MODE (deprecated)
+	if action := os.Getenv(EnvSQLIAction); action != "" {
+		cfg.SQLIAction = parseDetectionAction(action, "SQLI_ACTION", DetectionActionBlock,
+			[]DetectionAction{DetectionActionBlock, DetectionActionWarn, DetectionActionLog})
+	} else if deprecated := os.Getenv(EnvSQLIBlockModeDeprecated); deprecated != "" {
+		// Deprecated: convert old format to new
+		log.Printf("[Detection] WARNING: %s is deprecated. Use %s instead.", EnvSQLIBlockModeDeprecated, EnvSQLIAction)
+		switch strings.ToLower(deprecated) {
+		case "block":
+			cfg.SQLIAction = DetectionActionBlock
+		case "warn":
+			cfg.SQLIAction = DetectionActionWarn
+		default:
+			cfg.SQLIAction = DetectionActionBlock
+		}
+	}
+
+	// Parse PII_ACTION (new) or PII_BLOCK_CRITICAL (deprecated)
+	if action := os.Getenv(EnvPIIAction); action != "" {
+		cfg.PIIAction = parseDetectionAction(action, "PII_ACTION", DetectionActionRedact,
+			[]DetectionAction{DetectionActionBlock, DetectionActionWarn, DetectionActionRedact, DetectionActionLog})
+	} else if deprecated := os.Getenv(EnvPIIBlockCriticalDeprecated); deprecated != "" {
+		// Deprecated: convert old format to new
+		log.Printf("[Detection] WARNING: %s is deprecated. Use %s instead.", EnvPIIBlockCriticalDeprecated, EnvPIIAction)
+		if deprecated == "false" || deprecated == "0" {
+			cfg.PIIAction = DetectionActionLog // Disabled = log only
+		} else {
+			cfg.PIIAction = DetectionActionBlock // Enabled = block
+		}
+	}
+
+	// Parse SENSITIVE_DATA_ACTION
+	if action := os.Getenv(EnvSensitiveDataAction); action != "" {
+		cfg.SensitiveDataAction = parseDetectionAction(action, "SENSITIVE_DATA_ACTION", DetectionActionWarn,
+			[]DetectionAction{DetectionActionBlock, DetectionActionWarn, DetectionActionLog})
+	}
+
+	// Parse HIGH_RISK_ACTION
+	if action := os.Getenv(EnvHighRiskAction); action != "" {
+		cfg.HighRiskAction = parseDetectionAction(action, "HIGH_RISK_ACTION", DetectionActionWarn,
+			[]DetectionAction{DetectionActionBlock, DetectionActionWarn, DetectionActionLog})
+	}
+
+	// Parse DANGEROUS_QUERY_ACTION
+	if action := os.Getenv(EnvDangerousQueryAction); action != "" {
+		cfg.DangerousQueryAction = parseDetectionAction(action, "DANGEROUS_QUERY_ACTION", DetectionActionBlock,
+			[]DetectionAction{DetectionActionBlock, DetectionActionWarn, DetectionActionLog})
+	}
+
+	// Log configuration summary
+	log.Printf("[Detection] Configuration: SQLI=%s, PII=%s, SensitiveData=%s, HighRisk=%s, DangerousQuery=%s",
+		cfg.SQLIAction, cfg.PIIAction, cfg.SensitiveDataAction, cfg.HighRiskAction, cfg.DangerousQueryAction)
+
+	return cfg
+}
+
+// parseDetectionAction parses an action string and returns the corresponding DetectionAction.
+// If the value is invalid, it logs a warning and returns the default.
+func parseDetectionAction(value, envName string, defaultAction DetectionAction, validActions []DetectionAction) DetectionAction {
+	normalized := DetectionAction(strings.ToLower(strings.TrimSpace(value)))
+	for _, valid := range validActions {
+		if normalized == valid {
+			return normalized
+		}
+	}
+	log.Printf("[Detection] WARNING: Invalid %s=%q, using default %q. Valid values: %v",
+		envName, value, defaultAction, validActions)
+	return defaultAction
+}
+
+// ShouldBlock returns true if the action is block.
+func (a DetectionAction) ShouldBlock() bool {
+	return a == DetectionActionBlock
+}
+
+// ShouldRedact returns true if the action is redact.
+func (a DetectionAction) ShouldRedact() bool {
+	return a == DetectionActionRedact
+}
+
+// ShouldWarn returns true if the action is warn.
+func (a DetectionAction) ShouldWarn() bool {
+	return a == DetectionActionWarn
+}
+
+// ShouldLog returns true if the action is log (or any action, since all actions log).
+func (a DetectionAction) ShouldLog() bool {
+	return true // All actions result in logging
+}
+
+// ToOverrideAction converts DetectionAction to OverrideAction for policy compatibility.
+func (a DetectionAction) ToOverrideAction() OverrideAction {
+	switch a {
+	case DetectionActionBlock:
+		return ActionBlock
+	case DetectionActionRedact:
+		return ActionRedact
+	case DetectionActionWarn:
+		return ActionWarn
+	case DetectionActionLog:
+		return ActionLog
+	default:
+		return ActionBlock
+	}
+}

--- a/platform/agent/detection_config_test.go
+++ b/platform/agent/detection_config_test.go
@@ -1,0 +1,495 @@
+// Copyright 2025 AxonFlow
+// SPDX-License-Identifier: BUSL-1.1
+
+package agent
+
+import (
+	"os"
+	"testing"
+)
+
+// TestDefaultDetectionConfig tests the default configuration values.
+func TestDefaultDetectionConfig(t *testing.T) {
+	cfg := DefaultDetectionConfig()
+
+	// Verify defaults match Issue #891 philosophy:
+	// Block high-confidence threats, warn on heuristics, redact PII
+	tests := []struct {
+		name     string
+		got      DetectionAction
+		expected DetectionAction
+	}{
+		{"SQLIAction defaults to block", cfg.SQLIAction, DetectionActionBlock},
+		{"PIIAction defaults to redact", cfg.PIIAction, DetectionActionRedact},
+		{"SensitiveDataAction defaults to warn", cfg.SensitiveDataAction, DetectionActionWarn},
+		{"HighRiskAction defaults to warn", cfg.HighRiskAction, DetectionActionWarn},
+		{"DangerousQueryAction defaults to block", cfg.DangerousQueryAction, DetectionActionBlock},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.got != tt.expected {
+				t.Errorf("got %s, expected %s", tt.got, tt.expected)
+			}
+		})
+	}
+}
+
+// TestDetectionConfigFromEnv_Defaults tests that defaults are used when no env vars are set.
+func TestDetectionConfigFromEnv_Defaults(t *testing.T) {
+	// Clear all relevant env vars
+	envVars := []string{
+		EnvSQLIAction, EnvPIIAction, EnvSensitiveDataAction,
+		EnvHighRiskAction, EnvDangerousQueryAction,
+		EnvSQLIBlockModeDeprecated, EnvPIIBlockCriticalDeprecated,
+	}
+	for _, env := range envVars {
+		os.Unsetenv(env)
+	}
+	defer func() {
+		for _, env := range envVars {
+			os.Unsetenv(env)
+		}
+	}()
+
+	cfg := DetectionConfigFromEnv()
+
+	if cfg.SQLIAction != DetectionActionBlock {
+		t.Errorf("SQLIAction: got %s, expected %s", cfg.SQLIAction, DetectionActionBlock)
+	}
+	if cfg.PIIAction != DetectionActionRedact {
+		t.Errorf("PIIAction: got %s, expected %s", cfg.PIIAction, DetectionActionRedact)
+	}
+	if cfg.SensitiveDataAction != DetectionActionWarn {
+		t.Errorf("SensitiveDataAction: got %s, expected %s", cfg.SensitiveDataAction, DetectionActionWarn)
+	}
+	if cfg.HighRiskAction != DetectionActionWarn {
+		t.Errorf("HighRiskAction: got %s, expected %s", cfg.HighRiskAction, DetectionActionWarn)
+	}
+	if cfg.DangerousQueryAction != DetectionActionBlock {
+		t.Errorf("DangerousQueryAction: got %s, expected %s", cfg.DangerousQueryAction, DetectionActionBlock)
+	}
+}
+
+// TestDetectionConfigFromEnv_NewEnvVars tests that new env vars override defaults.
+func TestDetectionConfigFromEnv_NewEnvVars(t *testing.T) {
+	// Clear deprecated env vars first
+	os.Unsetenv(EnvSQLIBlockModeDeprecated)
+	os.Unsetenv(EnvPIIBlockCriticalDeprecated)
+
+	tests := []struct {
+		name     string
+		envVar   string
+		value    string
+		field    string
+		expected DetectionAction
+	}{
+		{"SQLI_ACTION=block", EnvSQLIAction, "block", "SQLIAction", DetectionActionBlock},
+		{"SQLI_ACTION=warn", EnvSQLIAction, "warn", "SQLIAction", DetectionActionWarn},
+		{"SQLI_ACTION=log", EnvSQLIAction, "log", "SQLIAction", DetectionActionLog},
+		{"SQLI_ACTION uppercase", EnvSQLIAction, "BLOCK", "SQLIAction", DetectionActionBlock},
+		{"SQLI_ACTION with spaces", EnvSQLIAction, "  warn  ", "SQLIAction", DetectionActionWarn},
+		{"PII_ACTION=block", EnvPIIAction, "block", "PIIAction", DetectionActionBlock},
+		{"PII_ACTION=redact", EnvPIIAction, "redact", "PIIAction", DetectionActionRedact},
+		{"PII_ACTION=warn", EnvPIIAction, "warn", "PIIAction", DetectionActionWarn},
+		{"PII_ACTION=log", EnvPIIAction, "log", "PIIAction", DetectionActionLog},
+		{"SENSITIVE_DATA_ACTION=block", EnvSensitiveDataAction, "block", "SensitiveDataAction", DetectionActionBlock},
+		{"SENSITIVE_DATA_ACTION=warn", EnvSensitiveDataAction, "warn", "SensitiveDataAction", DetectionActionWarn},
+		{"SENSITIVE_DATA_ACTION=log", EnvSensitiveDataAction, "log", "SensitiveDataAction", DetectionActionLog},
+		{"HIGH_RISK_ACTION=block", EnvHighRiskAction, "block", "HighRiskAction", DetectionActionBlock},
+		{"HIGH_RISK_ACTION=warn", EnvHighRiskAction, "warn", "HighRiskAction", DetectionActionWarn},
+		{"HIGH_RISK_ACTION=log", EnvHighRiskAction, "log", "HighRiskAction", DetectionActionLog},
+		{"DANGEROUS_QUERY_ACTION=block", EnvDangerousQueryAction, "block", "DangerousQueryAction", DetectionActionBlock},
+		{"DANGEROUS_QUERY_ACTION=warn", EnvDangerousQueryAction, "warn", "DangerousQueryAction", DetectionActionWarn},
+		{"DANGEROUS_QUERY_ACTION=log", EnvDangerousQueryAction, "log", "DangerousQueryAction", DetectionActionLog},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Clear all env vars
+			os.Unsetenv(EnvSQLIAction)
+			os.Unsetenv(EnvPIIAction)
+			os.Unsetenv(EnvSensitiveDataAction)
+			os.Unsetenv(EnvHighRiskAction)
+			os.Unsetenv(EnvDangerousQueryAction)
+			os.Unsetenv(EnvSQLIBlockModeDeprecated)
+			os.Unsetenv(EnvPIIBlockCriticalDeprecated)
+
+			// Set the test env var
+			os.Setenv(tt.envVar, tt.value)
+			defer os.Unsetenv(tt.envVar)
+
+			cfg := DetectionConfigFromEnv()
+
+			var got DetectionAction
+			switch tt.field {
+			case "SQLIAction":
+				got = cfg.SQLIAction
+			case "PIIAction":
+				got = cfg.PIIAction
+			case "SensitiveDataAction":
+				got = cfg.SensitiveDataAction
+			case "HighRiskAction":
+				got = cfg.HighRiskAction
+			case "DangerousQueryAction":
+				got = cfg.DangerousQueryAction
+			}
+
+			if got != tt.expected {
+				t.Errorf("%s: got %s, expected %s", tt.field, got, tt.expected)
+			}
+		})
+	}
+}
+
+// TestDetectionConfigFromEnv_DeprecatedEnvVars tests deprecated env var handling.
+func TestDetectionConfigFromEnv_DeprecatedEnvVars(t *testing.T) {
+	// Clear new env vars
+	os.Unsetenv(EnvSQLIAction)
+	os.Unsetenv(EnvPIIAction)
+
+	tests := []struct {
+		name     string
+		envVar   string
+		value    string
+		field    string
+		expected DetectionAction
+	}{
+		// SQLI_BLOCK_MODE (deprecated)
+		{"SQLI_BLOCK_MODE=block", EnvSQLIBlockModeDeprecated, "block", "SQLIAction", DetectionActionBlock},
+		{"SQLI_BLOCK_MODE=warn", EnvSQLIBlockModeDeprecated, "warn", "SQLIAction", DetectionActionWarn},
+		{"SQLI_BLOCK_MODE=invalid defaults to block", EnvSQLIBlockModeDeprecated, "invalid", "SQLIAction", DetectionActionBlock},
+		// PII_BLOCK_CRITICAL (deprecated)
+		{"PII_BLOCK_CRITICAL=true", EnvPIIBlockCriticalDeprecated, "true", "PIIAction", DetectionActionBlock},
+		{"PII_BLOCK_CRITICAL=false", EnvPIIBlockCriticalDeprecated, "false", "PIIAction", DetectionActionLog},
+		{"PII_BLOCK_CRITICAL=0", EnvPIIBlockCriticalDeprecated, "0", "PIIAction", DetectionActionLog},
+		{"PII_BLOCK_CRITICAL=1", EnvPIIBlockCriticalDeprecated, "1", "PIIAction", DetectionActionBlock},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Clear env vars
+			os.Unsetenv(EnvSQLIAction)
+			os.Unsetenv(EnvPIIAction)
+			os.Unsetenv(EnvSQLIBlockModeDeprecated)
+			os.Unsetenv(EnvPIIBlockCriticalDeprecated)
+
+			// Set the test env var
+			os.Setenv(tt.envVar, tt.value)
+			defer os.Unsetenv(tt.envVar)
+
+			cfg := DetectionConfigFromEnv()
+
+			var got DetectionAction
+			switch tt.field {
+			case "SQLIAction":
+				got = cfg.SQLIAction
+			case "PIIAction":
+				got = cfg.PIIAction
+			}
+
+			if got != tt.expected {
+				t.Errorf("%s: got %s, expected %s", tt.field, got, tt.expected)
+			}
+		})
+	}
+}
+
+// TestDetectionConfigFromEnv_NewOverridesDeprecated tests that new env vars take precedence.
+func TestDetectionConfigFromEnv_NewOverridesDeprecated(t *testing.T) {
+	// Set both new and deprecated env vars - new should win
+	os.Setenv(EnvSQLIAction, "warn")
+	os.Setenv(EnvSQLIBlockModeDeprecated, "block")
+	os.Setenv(EnvPIIAction, "log")
+	os.Setenv(EnvPIIBlockCriticalDeprecated, "true")
+	defer func() {
+		os.Unsetenv(EnvSQLIAction)
+		os.Unsetenv(EnvSQLIBlockModeDeprecated)
+		os.Unsetenv(EnvPIIAction)
+		os.Unsetenv(EnvPIIBlockCriticalDeprecated)
+	}()
+
+	cfg := DetectionConfigFromEnv()
+
+	// New env vars should take precedence
+	if cfg.SQLIAction != DetectionActionWarn {
+		t.Errorf("SQLIAction: expected new var to win, got %s", cfg.SQLIAction)
+	}
+	if cfg.PIIAction != DetectionActionLog {
+		t.Errorf("PIIAction: expected new var to win, got %s", cfg.PIIAction)
+	}
+}
+
+// TestDetectionConfigFromEnv_InvalidValues tests that invalid values fall back to defaults.
+func TestDetectionConfigFromEnv_InvalidValues(t *testing.T) {
+	// Clear deprecated vars
+	os.Unsetenv(EnvSQLIBlockModeDeprecated)
+	os.Unsetenv(EnvPIIBlockCriticalDeprecated)
+
+	tests := []struct {
+		name     string
+		envVar   string
+		value    string
+		expected DetectionAction
+	}{
+		{"SQLI_ACTION invalid defaults to block", EnvSQLIAction, "invalid", DetectionActionBlock},
+		{"SQLI_ACTION empty defaults to block", EnvSQLIAction, "", DetectionActionBlock},
+		{"PII_ACTION invalid defaults to redact", EnvPIIAction, "invalid", DetectionActionRedact},
+		// Note: "redact" is not valid for SQLI, should fallback
+		{"SQLI_ACTION redact (invalid for sqli) defaults to block", EnvSQLIAction, "redact", DetectionActionBlock},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Clear env vars
+			os.Unsetenv(EnvSQLIAction)
+			os.Unsetenv(EnvPIIAction)
+
+			if tt.value != "" {
+				os.Setenv(tt.envVar, tt.value)
+				defer os.Unsetenv(tt.envVar)
+			}
+
+			cfg := DetectionConfigFromEnv()
+
+			var got DetectionAction
+			switch tt.envVar {
+			case EnvSQLIAction:
+				got = cfg.SQLIAction
+			case EnvPIIAction:
+				got = cfg.PIIAction
+			}
+
+			if got != tt.expected {
+				t.Errorf("got %s, expected %s", got, tt.expected)
+			}
+		})
+	}
+}
+
+// TestDetectionAction_ShouldBlock tests the ShouldBlock method.
+func TestDetectionAction_ShouldBlock(t *testing.T) {
+	tests := []struct {
+		action   DetectionAction
+		expected bool
+	}{
+		{DetectionActionBlock, true},
+		{DetectionActionWarn, false},
+		{DetectionActionRedact, false},
+		{DetectionActionLog, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.action), func(t *testing.T) {
+			if got := tt.action.ShouldBlock(); got != tt.expected {
+				t.Errorf("ShouldBlock() = %v, expected %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+// TestDetectionAction_ShouldRedact tests the ShouldRedact method.
+func TestDetectionAction_ShouldRedact(t *testing.T) {
+	tests := []struct {
+		action   DetectionAction
+		expected bool
+	}{
+		{DetectionActionBlock, false},
+		{DetectionActionWarn, false},
+		{DetectionActionRedact, true},
+		{DetectionActionLog, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.action), func(t *testing.T) {
+			if got := tt.action.ShouldRedact(); got != tt.expected {
+				t.Errorf("ShouldRedact() = %v, expected %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+// TestDetectionAction_ShouldWarn tests the ShouldWarn method.
+func TestDetectionAction_ShouldWarn(t *testing.T) {
+	tests := []struct {
+		action   DetectionAction
+		expected bool
+	}{
+		{DetectionActionBlock, false},
+		{DetectionActionWarn, true},
+		{DetectionActionRedact, false},
+		{DetectionActionLog, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.action), func(t *testing.T) {
+			if got := tt.action.ShouldWarn(); got != tt.expected {
+				t.Errorf("ShouldWarn() = %v, expected %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+// TestDetectionAction_ShouldLog tests the ShouldLog method.
+func TestDetectionAction_ShouldLog(t *testing.T) {
+	// All actions should log
+	tests := []DetectionAction{
+		DetectionActionBlock,
+		DetectionActionWarn,
+		DetectionActionRedact,
+		DetectionActionLog,
+	}
+
+	for _, action := range tests {
+		t.Run(string(action), func(t *testing.T) {
+			if got := action.ShouldLog(); !got {
+				t.Errorf("ShouldLog() = %v, expected true", got)
+			}
+		})
+	}
+}
+
+// TestDetectionAction_ToOverrideAction tests conversion to OverrideAction.
+func TestDetectionAction_ToOverrideAction(t *testing.T) {
+	tests := []struct {
+		action   DetectionAction
+		expected OverrideAction
+	}{
+		{DetectionActionBlock, ActionBlock},
+		{DetectionActionWarn, ActionWarn},
+		{DetectionActionRedact, ActionRedact},
+		{DetectionActionLog, ActionLog},
+		{DetectionAction("unknown"), ActionBlock}, // Unknown defaults to block
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.action), func(t *testing.T) {
+			if got := tt.action.ToOverrideAction(); got != tt.expected {
+				t.Errorf("ToOverrideAction() = %v, expected %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+// TestParseDetectionAction tests the parseDetectionAction function.
+func TestParseDetectionAction(t *testing.T) {
+	tests := []struct {
+		name         string
+		value        string
+		defaultVal   DetectionAction
+		validActions []DetectionAction
+		expected     DetectionAction
+	}{
+		{
+			name:         "valid block",
+			value:        "block",
+			defaultVal:   DetectionActionWarn,
+			validActions: []DetectionAction{DetectionActionBlock, DetectionActionWarn, DetectionActionLog},
+			expected:     DetectionActionBlock,
+		},
+		{
+			name:         "valid warn",
+			value:        "warn",
+			defaultVal:   DetectionActionBlock,
+			validActions: []DetectionAction{DetectionActionBlock, DetectionActionWarn, DetectionActionLog},
+			expected:     DetectionActionWarn,
+		},
+		{
+			name:         "valid log",
+			value:        "log",
+			defaultVal:   DetectionActionBlock,
+			validActions: []DetectionAction{DetectionActionBlock, DetectionActionWarn, DetectionActionLog},
+			expected:     DetectionActionLog,
+		},
+		{
+			name:         "case insensitive",
+			value:        "BLOCK",
+			defaultVal:   DetectionActionWarn,
+			validActions: []DetectionAction{DetectionActionBlock, DetectionActionWarn, DetectionActionLog},
+			expected:     DetectionActionBlock,
+		},
+		{
+			name:         "with whitespace",
+			value:        "  warn  ",
+			defaultVal:   DetectionActionBlock,
+			validActions: []DetectionAction{DetectionActionBlock, DetectionActionWarn, DetectionActionLog},
+			expected:     DetectionActionWarn,
+		},
+		{
+			name:         "invalid returns default",
+			value:        "invalid",
+			defaultVal:   DetectionActionBlock,
+			validActions: []DetectionAction{DetectionActionBlock, DetectionActionWarn, DetectionActionLog},
+			expected:     DetectionActionBlock,
+		},
+		{
+			name:         "redact not in valid list returns default",
+			value:        "redact",
+			defaultVal:   DetectionActionBlock,
+			validActions: []DetectionAction{DetectionActionBlock, DetectionActionWarn, DetectionActionLog},
+			expected:     DetectionActionBlock,
+		},
+		{
+			name:         "redact in valid list works",
+			value:        "redact",
+			defaultVal:   DetectionActionBlock,
+			validActions: []DetectionAction{DetectionActionBlock, DetectionActionWarn, DetectionActionRedact, DetectionActionLog},
+			expected:     DetectionActionRedact,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseDetectionAction(tt.value, "TEST_ENV", tt.defaultVal, tt.validActions)
+			if got != tt.expected {
+				t.Errorf("parseDetectionAction(%q) = %s, expected %s", tt.value, got, tt.expected)
+			}
+		})
+	}
+}
+
+// TestDetectionAction_Constants tests the constant values.
+func TestDetectionAction_Constants(t *testing.T) {
+	// Verify constant values match expected strings
+	tests := []struct {
+		action   DetectionAction
+		expected string
+	}{
+		{DetectionActionBlock, "block"},
+		{DetectionActionWarn, "warn"},
+		{DetectionActionRedact, "redact"},
+		{DetectionActionLog, "log"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			if string(tt.action) != tt.expected {
+				t.Errorf("constant value = %q, expected %q", string(tt.action), tt.expected)
+			}
+		})
+	}
+}
+
+// TestEnvVarConstants tests environment variable constant values.
+func TestEnvVarConstants(t *testing.T) {
+	tests := []struct {
+		constant string
+		expected string
+	}{
+		{EnvSQLIAction, "SQLI_ACTION"},
+		{EnvPIIAction, "PII_ACTION"},
+		{EnvSensitiveDataAction, "SENSITIVE_DATA_ACTION"},
+		{EnvHighRiskAction, "HIGH_RISK_ACTION"},
+		{EnvDangerousQueryAction, "DANGEROUS_QUERY_ACTION"},
+		{EnvSQLIBlockModeDeprecated, "SQLI_BLOCK_MODE"},
+		{EnvPIIBlockCriticalDeprecated, "PII_BLOCK_CRITICAL"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			if tt.constant != tt.expected {
+				t.Errorf("constant value = %q, expected %q", tt.constant, tt.expected)
+			}
+		})
+	}
+}

--- a/platform/agent/gateway_handlers.go
+++ b/platform/agent/gateway_handlers.go
@@ -142,13 +142,14 @@ type PreCheckRequest struct {
 
 // PreCheckResponse is returned to SDK with context and approval status
 type PreCheckResponse struct {
-	ContextID    string                 `json:"context_id"`
-	Approved     bool                   `json:"approved"`
-	ApprovedData map[string]interface{} `json:"approved_data,omitempty"`
-	Policies     []string               `json:"policies"`
-	RateLimit    *RateLimitInfo         `json:"rate_limit,omitempty"`
-	ExpiresAt    time.Time              `json:"expires_at"`
-	BlockReason  string                 `json:"block_reason,omitempty"`
+	ContextID         string                 `json:"context_id"`
+	Approved          bool                   `json:"approved"`
+	RequiresRedaction bool                   `json:"requires_redaction,omitempty"`
+	ApprovedData      map[string]interface{} `json:"approved_data,omitempty"`
+	Policies          []string               `json:"policies"`
+	RateLimit         *RateLimitInfo         `json:"rate_limit,omitempty"`
+	ExpiresAt         time.Time              `json:"expires_at"`
+	BlockReason       string                 `json:"block_reason,omitempty"`
 }
 
 // RateLimitInfo provides rate limiting status to SDK
@@ -256,10 +257,14 @@ func getRBIPIIDetector() *rbi.IndiaPIIDetector {
 // checkRBIPII checks request query for India-specific PII.
 // Returns the check result with detected PII types and blocking recommendation.
 // In Community builds, this returns a no-PII result (detection is disabled).
-func checkRBIPII(query string) *rbi.RBIPIICheckResult {
+// The blockOnCritical parameter respects PII_ACTION env var (Issue #891):
+// - block: blockOnCritical=true (default legacy behavior)
+// - redact: blockOnCritical=false (flag for redaction instead of blocking)
+func checkRBIPII(query string, blockOnCritical bool) *rbi.RBIPIICheckResult {
 	detector := getRBIPIIDetector()
 	// Block on critical PII (Aadhaar, PAN, UPI, Bank Account) per RBI FREE-AI guidelines
-	return rbi.CheckRequestForPII(detector, query, true)
+	// unless PII_ACTION=redact is configured
+	return rbi.CheckRequestForPII(detector, query, blockOnCritical)
 }
 
 // getGatewayAuditQueue returns the audit queue for Gateway Mode handlers
@@ -371,7 +376,14 @@ func handlePolicyPreCheck(w http.ResponseWriter, r *http.Request) {
 
 	// RBI FREE-AI Compliance: Check for India-specific PII before policy evaluation
 	// This runs in both Community (no-op) and Enterprise (full detection) modes
-	piiResult := checkRBIPII(req.Query)
+	// Issue #891: Respect PII_ACTION setting - block only if PII_ACTION=block
+	detectionConfig := DetectionConfigFromEnv()
+	blockOnCriticalPII := detectionConfig.PIIAction == DetectionActionBlock
+	piiResult := checkRBIPII(req.Query, blockOnCriticalPII)
+
+	// Track if RBI PII requires redaction (for PII_ACTION=redact mode)
+	rbiPIIRequiresRedaction := false
+
 	if piiResult.BlockRecommended {
 		log.Printf("🛑 [Pre-check] Request blocked by RBI PII detection: %s", piiResult.Reason)
 		gatewayPreCheckRequests.WithLabelValues("success", "false").Inc()
@@ -395,7 +407,13 @@ func handlePolicyPreCheck(w http.ResponseWriter, r *http.Request) {
 		for _, piiType := range piiResult.DetectedTypes {
 			gatewayRBIPIIDetected.WithLabelValues(string(piiType), "false").Inc()
 		}
-		log.Printf("⚠️ [Pre-check] India PII detected (non-critical): %v", piiResult.DetectedTypes)
+		// Issue #891: If critical India PII detected but PII_ACTION=redact, flag for redaction
+		if piiResult.CriticalPII && detectionConfig.PIIAction == DetectionActionRedact {
+			log.Printf("🇮🇳 [Pre-check] Critical India PII detected - flagged for redaction (action=redact): %v", piiResult.DetectedTypes)
+			rbiPIIRequiresRedaction = true
+		} else {
+			log.Printf("⚠️ [Pre-check] India PII detected (non-critical): %v", piiResult.DetectedTypes)
+		}
 	}
 
 	// IMPORTANT: Gateway Mode Design Decision - Static Policies Only
@@ -432,16 +450,26 @@ func handlePolicyPreCheck(w http.ResponseWriter, r *http.Request) {
 	expiresAt := time.Now().Add(defaultContextExpiry)
 
 	// Build response
+	// Issue #891: Combine redaction flags from static policies and RBI PII detection
+	requiresRedaction := policyResult.RequiresRedaction || rbiPIIRequiresRedaction
 	response := PreCheckResponse{
-		ContextID: contextID,
-		Approved:  !policyResult.Blocked,
-		Policies:  policyResult.TriggeredPolicies,
-		ExpiresAt: expiresAt,
+		ContextID:         contextID,
+		Approved:          !policyResult.Blocked,
+		RequiresRedaction: requiresRedaction,
+		Policies:          policyResult.TriggeredPolicies,
+		ExpiresAt:         expiresAt,
+	}
+
+	// Add RBI PII policy to triggered policies if redaction required
+	if rbiPIIRequiresRedaction {
+		response.Policies = append(response.Policies, "rbi_pii_protection")
 	}
 
 	if policyResult.Blocked {
 		response.BlockReason = policyResult.Reason
 		log.Printf("⛔ [Pre-check] Request blocked: %s", policyResult.Reason)
+	} else if requiresRedaction {
+		log.Printf("⚠️ [Pre-check] Request approved with redaction required: %s", policyResult.Reason)
 	} else {
 		// Fetch data from MCP connectors if data sources specified
 		if len(req.DataSources) > 0 && mcpRegistry != nil {

--- a/platform/agent/gateway_handlers_test.go
+++ b/platform/agent/gateway_handlers_test.go
@@ -895,7 +895,7 @@ func TestPreCheckHandler_WithDataSources(t *testing.T) {
 	}
 }
 
-// TestPreCheckHandler_PIIDetection tests PII detection (blocks critical PII by default)
+// TestPreCheckHandler_PIIDetection tests PII detection (redacts PII by default)
 func TestPreCheckHandler_PIIDetection(t *testing.T) {
 	os.Setenv("DEPLOYMENT_MODE", "community")
 	os.Setenv("ENVIRONMENT", "development")
@@ -906,7 +906,7 @@ func TestPreCheckHandler_PIIDetection(t *testing.T) {
 	dbPolicyEngine = nil
 	staticPolicyEngine = NewStaticPolicyEngine()
 
-	// Request with SSN (critical PII - blocks by default with PII_BLOCK_CRITICAL=true)
+	// Request with SSN (critical PII - flagged for redaction by default with PII_ACTION=redact)
 	reqBody := PreCheckRequest{
 		UserToken: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoxfQ.test",
 		ClientID:  "test-client",
@@ -929,9 +929,14 @@ func TestPreCheckHandler_PIIDetection(t *testing.T) {
 	var resp PreCheckResponse
 	json.Unmarshal(rr.Body.Bytes(), &resp)
 
-	// Critical PII (SSN) blocks by default (PII_BLOCK_CRITICAL=true)
-	if resp.Approved {
-		t.Error("Expected request to be blocked (critical PII detected, PII_BLOCK_CRITICAL=true)")
+	// Critical PII (SSN) is now approved with redaction by default (PII_ACTION=redact)
+	if !resp.Approved {
+		t.Error("Expected request to be approved (PII_ACTION=redact allows request with redaction flag)")
+	}
+
+	// Should require redaction for PII
+	if !resp.RequiresRedaction {
+		t.Error("Expected RequiresRedaction=true for SSN detection")
 	}
 
 	// Should have triggered PII policy
@@ -947,20 +952,20 @@ func TestPreCheckHandler_PIIDetection(t *testing.T) {
 	}
 }
 
-// TestPreCheckHandler_PIIDetection_Disabled tests that PII blocking can be disabled
-func TestPreCheckHandler_PIIDetection_Disabled(t *testing.T) {
+// TestPreCheckHandler_PIIDetection_BlockMode tests that PII blocks when PII_ACTION=block
+func TestPreCheckHandler_PIIDetection_BlockMode(t *testing.T) {
 	os.Setenv("DEPLOYMENT_MODE", "community")
 	os.Setenv("ENVIRONMENT", "development")
-	os.Setenv("PII_BLOCK_CRITICAL", "false") // Disable PII blocking
+	os.Setenv("PII_ACTION", "block") // Enable PII blocking
 	defer os.Unsetenv("DEPLOYMENT_MODE")
 	defer os.Unsetenv("ENVIRONMENT")
-	defer os.Unsetenv("PII_BLOCK_CRITICAL")
+	defer os.Unsetenv("PII_ACTION")
 
 	// Ensure we use staticPolicyEngine, not dbPolicyEngine
 	dbPolicyEngine = nil
 	staticPolicyEngine = NewStaticPolicyEngine()
 
-	// Request with SSN (should NOT be blocked when PII_BLOCK_CRITICAL=false)
+	// Request with SSN (should be blocked when PII_ACTION=block)
 	reqBody := PreCheckRequest{
 		UserToken: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoxfQ.test",
 		ClientID:  "test-client",
@@ -983,9 +988,56 @@ func TestPreCheckHandler_PIIDetection_Disabled(t *testing.T) {
 	var resp PreCheckResponse
 	json.Unmarshal(rr.Body.Bytes(), &resp)
 
-	// With PII_BLOCK_CRITICAL=false, critical PII should NOT block
+	// Critical PII (SSN) blocks when PII_ACTION=block
+	if resp.Approved {
+		t.Error("Expected request to be blocked (critical PII detected, PII_ACTION=block)")
+	}
+}
+
+// TestPreCheckHandler_PIIDetection_LogOnly tests PII in log-only mode (no block, no redact)
+func TestPreCheckHandler_PIIDetection_LogOnly(t *testing.T) {
+	os.Setenv("DEPLOYMENT_MODE", "community")
+	os.Setenv("ENVIRONMENT", "development")
+	os.Setenv("PII_ACTION", "log") // Log-only mode (no blocking or redaction)
+	defer os.Unsetenv("DEPLOYMENT_MODE")
+	defer os.Unsetenv("ENVIRONMENT")
+	defer os.Unsetenv("PII_ACTION")
+
+	// Ensure we use staticPolicyEngine, not dbPolicyEngine
+	dbPolicyEngine = nil
+	staticPolicyEngine = NewStaticPolicyEngine()
+
+	// Request with SSN (should NOT be blocked when PII_ACTION=log)
+	reqBody := PreCheckRequest{
+		UserToken: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoxfQ.test",
+		ClientID:  "test-client",
+		Query:     "My SSN is 123-45-6789, what can you tell me?",
+	}
+	body, _ := json.Marshal(reqBody)
+
+	req := httptest.NewRequest("POST", "/api/policy/pre-check", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(handlePolicyPreCheck)
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", rr.Code)
+		return
+	}
+
+	var resp PreCheckResponse
+	json.Unmarshal(rr.Body.Bytes(), &resp)
+
+	// With PII_ACTION=log, request should be approved without redaction
 	if !resp.Approved {
-		t.Errorf("Expected request to be approved when PII_BLOCK_CRITICAL=false, got blocked: %s", resp.BlockReason)
+		t.Errorf("Expected request to be approved when PII_ACTION=log, got blocked: %s", resp.BlockReason)
+	}
+
+	// Should NOT require redaction in log-only mode
+	if resp.RequiresRedaction {
+		t.Error("Expected RequiresRedaction=false when PII_ACTION=log")
 	}
 
 	// Should still have triggered PII policy (detection still happens)
@@ -997,7 +1049,7 @@ func TestPreCheckHandler_PIIDetection_Disabled(t *testing.T) {
 		}
 	}
 	if !hasPIIPolicy {
-		t.Error("Expected SSN detection policy to be triggered even when blocking is disabled")
+		t.Error("Expected SSN detection policy to be triggered even in log-only mode")
 	}
 }
 
@@ -2598,7 +2650,8 @@ func TestCheckRBIPII_Community(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := checkRBIPII(tt.query)
+			// Pass false for blockOnCritical - we're testing detection, not blocking behavior
+			result := checkRBIPII(tt.query, false)
 
 			// Community edition detects India PII with pattern matching
 			if result.HasPII != tt.expectHasPII {
@@ -2632,7 +2685,7 @@ func TestGetRBIPIIDetector(t *testing.T) {
 
 // TestPreCheckHandler_RBIPIIIntegration tests that RBI PII detection is integrated into pre-check flow
 // Both Community and Enterprise editions detect critical India PII (Aadhaar, PAN, UPI, Bank Account).
-// Community uses pattern-based detection (0.7 confidence), Enterprise adds Verhoeff checksum validation (0.98 confidence).
+// Default action is redact (PII_ACTION=redact), which approves the request but flags for redaction.
 func TestPreCheckHandler_RBIPIIIntegration(t *testing.T) {
 	os.Setenv("DEPLOYMENT_MODE", "community")
 	os.Setenv("ENVIRONMENT", "development")
@@ -2642,29 +2695,34 @@ func TestPreCheckHandler_RBIPIIIntegration(t *testing.T) {
 	staticPolicyEngine = NewStaticPolicyEngine()
 
 	tests := []struct {
-		name           string
-		query          string
-		expectApproved bool // Critical PII is blocked in both Community and Enterprise
+		name              string
+		query             string
+		expectApproved    bool // With PII_ACTION=redact (default), all approved but PII flagged
+		expectRedaction   bool // Whether redaction is required
 	}{
 		{
-			name:           "Normal query without India PII",
-			query:          "What is the GDP of India?",
-			expectApproved: true,
+			name:              "Normal query without India PII",
+			query:             "What is the GDP of India?",
+			expectApproved:    true,
+			expectRedaction:   false,
 		},
 		{
-			name:           "Query with Aadhaar number (blocked - critical PII)",
-			query:          "My Aadhaar is 2234 5678 9012",
-			expectApproved: false, // Community detects and blocks critical PII
+			name:              "Query with Aadhaar number (approved with redaction)",
+			query:             "My Aadhaar is 2234 5678 9012",
+			expectApproved:    true, // Default PII_ACTION=redact approves with flag
+			expectRedaction:   true,
 		},
 		{
-			name:           "Query with PAN number (blocked - critical PII)",
-			query:          "My PAN number is ABCDE1234F",
-			expectApproved: false, // Community detects and blocks critical PII
+			name:              "Query with PAN number (approved with redaction)",
+			query:             "My PAN number is ABCDE1234F",
+			expectApproved:    true, // Default PII_ACTION=redact approves with flag
+			expectRedaction:   true,
 		},
 		{
-			name:           "Query with UPI ID (blocked - critical PII)",
-			query:          "Send money to user@ybl",
-			expectApproved: false, // Community detects and blocks critical PII
+			name:              "Query with UPI ID (approved with redaction)",
+			query:             "Send money to user@ybl",
+			expectApproved:    true, // Default PII_ACTION=redact approves with flag
+			expectRedaction:   true,
 		},
 	}
 
@@ -2694,10 +2752,14 @@ func TestPreCheckHandler_RBIPIIIntegration(t *testing.T) {
 				t.Fatalf("Failed to unmarshal response: %v", err)
 			}
 
-			// Community edition now detects critical India PII (Aadhaar, PAN, UPI, Bank Account)
 			if resp.Approved != tt.expectApproved {
 				t.Errorf("Expected Approved=%v, got %v. BlockReason: %s",
 					tt.expectApproved, resp.Approved, resp.BlockReason)
+			}
+
+			if resp.RequiresRedaction != tt.expectRedaction {
+				t.Errorf("Expected RequiresRedaction=%v, got %v",
+					tt.expectRedaction, resp.RequiresRedaction)
 			}
 		})
 	}

--- a/platform/agent/policy_categories.go
+++ b/platform/agent/policy_categories.go
@@ -45,6 +45,14 @@ const (
 	// Includes: license headers, banned imports, deprecated APIs.
 	CategoryCodeCompliance PolicyCategory = "code-compliance"
 
+	// Static policy categories - Sensitive Data Detection (Issue #891)
+	// Detects credentials, tokens, and secrets in user queries.
+	// Default action: warn (may have false positives)
+
+	// CategorySensitiveData covers credential and secret detection in queries.
+	// Includes: passwords, API keys, tokens, connection strings.
+	CategorySensitiveData PolicyCategory = "sensitive-data"
+
 	// Dynamic policy categories
 
 	// CategoryDynamicRisk covers risk-based dynamic policies.
@@ -76,6 +84,7 @@ func StaticPolicyCategories() []PolicyCategory {
 		CategoryCodeSecrets,
 		CategoryCodeUnsafe,
 		CategoryCodeCompliance,
+		CategorySensitiveData, // Issue #891
 	}
 }
 

--- a/platform/agent/policy_categories_test.go
+++ b/platform/agent/policy_categories_test.go
@@ -20,6 +20,7 @@ func TestStaticPolicyCategories(t *testing.T) {
 		CategoryCodeSecrets,
 		CategoryCodeUnsafe,
 		CategoryCodeCompliance,
+		CategorySensitiveData, // Added for Issue #891 - credential detection
 	}
 
 	if len(categories) != len(expected) {

--- a/platform/agent/policy_types.go
+++ b/platform/agent/policy_types.go
@@ -215,16 +215,17 @@ type EffectiveDynamicPolicy struct {
 
 // CreateStaticPolicyRequest is the request body for creating a static policy.
 type CreateStaticPolicyRequest struct {
-	Name        string     `json:"name"`
-	Description string     `json:"description"`
-	Category    string     `json:"category"` // security-sqli, pii-global, etc.
-	Tier        PolicyTier `json:"tier"`     // Only 'organization' or 'tenant' allowed via API
-	Pattern     string     `json:"pattern"`
-	Action      string     `json:"action"`
-	Severity    string     `json:"severity"`
-	Priority    int        `json:"priority,omitempty"`
-	Enabled     bool       `json:"enabled"`
-	Tags        []string   `json:"tags,omitempty"`
+	Name           string     `json:"name"`
+	Description    string     `json:"description"`
+	Category       string     `json:"category"` // security-sqli, pii-global, etc.
+	Tier           PolicyTier `json:"tier"`     // Only 'organization' or 'tenant' allowed via API
+	OrganizationID string     `json:"organization_id,omitempty"`
+	Pattern        string     `json:"pattern"`
+	Action         string     `json:"action"`
+	Severity       string     `json:"severity"`
+	Priority       int        `json:"priority,omitempty"`
+	Enabled        bool       `json:"enabled"`
+	Tags           []string   `json:"tags,omitempty"`
 }
 
 // UpdateStaticPolicyRequest is the request body for updating a static policy.

--- a/platform/agent/proxy.go
+++ b/platform/agent/proxy.go
@@ -1,0 +1,205 @@
+// Copyright 2025 AxonFlow
+// SPDX-License-Identifier: BUSL-1.1
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import (
+	"log"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/gorilla/mux"
+)
+
+// ProxyConfig holds configuration for the reverse proxy
+type ProxyConfig struct {
+	OrchestratorInternalURL string
+	PortalInternalURL       string
+}
+
+// ReverseProxyHandler manages reverse proxy routing to backend services
+type ReverseProxyHandler struct {
+	orchestratorProxy *httputil.ReverseProxy
+	portalProxy       *httputil.ReverseProxy
+	orchestratorURL   *url.URL
+	portalURL         *url.URL
+}
+
+// NewReverseProxyHandler creates a new reverse proxy handler for backend services
+func NewReverseProxyHandler(config ProxyConfig) (*ReverseProxyHandler, error) {
+	handler := &ReverseProxyHandler{}
+
+	// Parse and configure Orchestrator proxy
+	if config.OrchestratorInternalURL != "" {
+		orchURL, err := url.Parse(config.OrchestratorInternalURL)
+		if err != nil {
+			return nil, err
+		}
+		handler.orchestratorURL = orchURL
+		handler.orchestratorProxy = createReverseProxy(orchURL, "orchestrator")
+		log.Printf("[Proxy] Orchestrator proxy configured: %s", config.OrchestratorInternalURL)
+	}
+
+	// Parse and configure Portal proxy
+	if config.PortalInternalURL != "" {
+		portalURL, err := url.Parse(config.PortalInternalURL)
+		if err != nil {
+			return nil, err
+		}
+		handler.portalURL = portalURL
+		handler.portalProxy = createReverseProxy(portalURL, "portal")
+		log.Printf("[Proxy] Portal proxy configured: %s", config.PortalInternalURL)
+	}
+
+	return handler, nil
+}
+
+// createReverseProxy creates a configured httputil.ReverseProxy for a target URL
+func createReverseProxy(target *url.URL, serviceName string) *httputil.ReverseProxy {
+	proxy := httputil.NewSingleHostReverseProxy(target)
+
+	// Custom director to preserve headers and set correct host
+	originalDirector := proxy.Director
+	proxy.Director = func(req *http.Request) {
+		originalDirector(req)
+		// Preserve original headers that are important for tenant isolation
+		// X-Tenant-ID, X-User-ID, Authorization, X-License-Key are already in the request
+		// Just ensure Host header is set correctly for the target
+		req.Host = target.Host
+	}
+
+	// Custom error handler for logging and 502 responses
+	proxy.ErrorHandler = func(w http.ResponseWriter, r *http.Request, err error) {
+		log.Printf("[Proxy] Error proxying to %s: %v (path: %s)", serviceName, err, r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte(`{"error":"Backend service unavailable","service":"` + serviceName + `"}`))
+	}
+
+	// Custom ModifyResponse for logging successful proxied responses
+	proxy.ModifyResponse = func(resp *http.Response) error {
+		log.Printf("[Proxy] %s responded: %d %s (path: %s)", serviceName, resp.StatusCode, resp.Status, resp.Request.URL.Path)
+		return nil
+	}
+
+	return proxy
+}
+
+// ProxyToOrchestrator handles requests that should be proxied to Orchestrator
+func (h *ReverseProxyHandler) ProxyToOrchestrator(w http.ResponseWriter, r *http.Request) {
+	if h.orchestratorProxy == nil {
+		log.Printf("[Proxy] Orchestrator proxy not configured, returning 503")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(`{"error":"Orchestrator service not configured"}`))
+		return
+	}
+
+	start := time.Now()
+	log.Printf("[Proxy] Proxying to Orchestrator: %s %s", r.Method, r.URL.Path)
+	h.orchestratorProxy.ServeHTTP(w, r)
+	log.Printf("[Proxy] Orchestrator request completed in %v", time.Since(start))
+}
+
+// ProxyToPortal handles requests that should be proxied to Portal
+func (h *ReverseProxyHandler) ProxyToPortal(w http.ResponseWriter, r *http.Request) {
+	if h.portalProxy == nil {
+		log.Printf("[Proxy] Portal proxy not configured, returning 503")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(`{"error":"Portal service not configured"}`))
+		return
+	}
+
+	start := time.Now()
+	log.Printf("[Proxy] Proxying to Portal: %s %s", r.Method, r.URL.Path)
+	h.portalProxy.ServeHTTP(w, r)
+	log.Printf("[Proxy] Portal request completed in %v", time.Since(start))
+}
+
+// RegisterProxyRoutes registers all proxy routes on the provided router
+// This enables Single Entry Point Architecture (ADR-026)
+func (h *ReverseProxyHandler) RegisterProxyRoutes(r *mux.Router) {
+	// Routes proxied to Orchestrator (port 8081)
+	// Dynamic policies - new consistent path
+	r.PathPrefix("/api/v1/dynamic-policies").HandlerFunc(h.ProxyToOrchestrator).Methods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+
+	// Connectors
+	r.PathPrefix("/api/v1/connectors").HandlerFunc(h.ProxyToOrchestrator).Methods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+
+	// Cost Controls
+	r.PathPrefix("/api/v1/cost").HandlerFunc(h.ProxyToOrchestrator).Methods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+	r.PathPrefix("/api/v1/budgets").HandlerFunc(h.ProxyToOrchestrator).Methods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+	r.PathPrefix("/api/v1/usage").HandlerFunc(h.ProxyToOrchestrator).Methods("GET", "POST", "OPTIONS")
+
+	// Execution Replay
+	r.PathPrefix("/api/v1/executions").HandlerFunc(h.ProxyToOrchestrator).Methods("GET", "POST", "OPTIONS")
+
+	// LLM Providers
+	r.PathPrefix("/api/v1/llm-providers").HandlerFunc(h.ProxyToOrchestrator).Methods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+
+	// Routes proxied to Portal (port 8082)
+	// Code Governance
+	r.PathPrefix("/api/v1/code-governance").HandlerFunc(h.ProxyToPortal).Methods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+
+	// Portal Auth & Management
+	r.PathPrefix("/api/v1/portal").HandlerFunc(h.ProxyToPortal).Methods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+
+	// Git Providers
+	r.PathPrefix("/api/v1/git-providers").HandlerFunc(h.ProxyToPortal).Methods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+
+	log.Println("[Proxy] Registered proxy routes for Single Entry Point Architecture (ADR-026)")
+}
+
+// GetProxyConfig returns proxy configuration using internal service discovery.
+// In Docker environments, services communicate via container names on axonflow-network.
+// For local development, falls back to localhost.
+// Uses isRunningInDocker() and constants from run.go (same package).
+func GetProxyConfig() ProxyConfig {
+	if isRunningInDocker() {
+		return ProxyConfig{
+			OrchestratorInternalURL: DefaultOrchestratorURL,
+			PortalInternalURL:       DefaultPortalURL,
+		}
+	}
+
+	// Local development - use localhost
+	return ProxyConfig{
+		OrchestratorInternalURL: LocalOrchestratorURL,
+		PortalInternalURL:       LocalPortalURL,
+	}
+}
+
+// IsProxiedPath returns true if the path should be proxied to a backend service
+func IsProxiedPath(path string) bool {
+	// Orchestrator paths
+	if strings.HasPrefix(path, "/api/v1/dynamic-policies") ||
+		strings.HasPrefix(path, "/api/v1/connectors") ||
+		strings.HasPrefix(path, "/api/v1/cost") ||
+		strings.HasPrefix(path, "/api/v1/budgets") ||
+		strings.HasPrefix(path, "/api/v1/usage") ||
+		strings.HasPrefix(path, "/api/v1/executions") ||
+		strings.HasPrefix(path, "/api/v1/llm-providers") {
+		return true
+	}
+
+	// Portal paths
+	if strings.HasPrefix(path, "/api/v1/code-governance") ||
+		strings.HasPrefix(path, "/api/v1/portal") ||
+		strings.HasPrefix(path, "/api/v1/git-providers") {
+		return true
+	}
+
+	return false
+}

--- a/platform/agent/proxy_test.go
+++ b/platform/agent/proxy_test.go
@@ -1,0 +1,342 @@
+// Copyright 2025 AxonFlow
+// SPDX-License-Identifier: BUSL-1.1
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+)
+
+func TestNewReverseProxyHandler(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  ProxyConfig
+		wantErr bool
+	}{
+		{
+			name: "valid orchestrator URL",
+			config: ProxyConfig{
+				OrchestratorInternalURL: "http://localhost:8081",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid portal URL",
+			config: ProxyConfig{
+				PortalInternalURL: "http://localhost:8082",
+			},
+			wantErr: false,
+		},
+		{
+			name: "both URLs valid",
+			config: ProxyConfig{
+				OrchestratorInternalURL: "http://orchestrator:8081",
+				PortalInternalURL:       "http://portal:8082",
+			},
+			wantErr: false,
+		},
+		{
+			name: "empty config",
+			config: ProxyConfig{},
+			wantErr: false,
+		},
+		{
+			name: "invalid orchestrator URL",
+			config: ProxyConfig{
+				OrchestratorInternalURL: "://invalid-url",
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid portal URL",
+			config: ProxyConfig{
+				PortalInternalURL: "://invalid-url",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler, err := NewReverseProxyHandler(tt.config)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewReverseProxyHandler() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && handler == nil {
+				t.Error("NewReverseProxyHandler() returned nil handler without error")
+			}
+		})
+	}
+}
+
+func TestProxyToOrchestrator_NotConfigured(t *testing.T) {
+	handler := &ReverseProxyHandler{}
+
+	req := httptest.NewRequest("GET", "/api/v1/dynamic-policies", nil)
+	w := httptest.NewRecorder()
+
+	handler.ProxyToOrchestrator(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("Expected status 503, got %d", w.Code)
+	}
+
+	var response map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("Failed to unmarshal response: %v", err)
+	}
+
+	if response["error"] != "Orchestrator service not configured" {
+		t.Errorf("Unexpected error message: %s", response["error"])
+	}
+}
+
+func TestProxyToPortal_NotConfigured(t *testing.T) {
+	handler := &ReverseProxyHandler{}
+
+	req := httptest.NewRequest("GET", "/api/v1/code-governance/metrics", nil)
+	w := httptest.NewRecorder()
+
+	handler.ProxyToPortal(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("Expected status 503, got %d", w.Code)
+	}
+
+	var response map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("Failed to unmarshal response: %v", err)
+	}
+
+	if response["error"] != "Portal service not configured" {
+		t.Errorf("Unexpected error message: %s", response["error"])
+	}
+}
+
+func TestProxyToOrchestrator_Success(t *testing.T) {
+	// Create a mock backend server
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify headers are preserved
+		if r.Header.Get("X-Tenant-ID") != "test-tenant" {
+			t.Errorf("X-Tenant-ID header not preserved, got: %s", r.Header.Get("X-Tenant-ID"))
+		}
+		if r.Header.Get("Authorization") != "Bearer test-token" {
+			t.Errorf("Authorization header not preserved, got: %s", r.Header.Get("Authorization"))
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"policies":[],"pagination":{"page":1,"page_size":20,"total_items":0,"total_pages":0}}`))
+	}))
+	defer backend.Close()
+
+	handler, err := NewReverseProxyHandler(ProxyConfig{
+		OrchestratorInternalURL: backend.URL,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create handler: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", "/api/v1/dynamic-policies", nil)
+	req.Header.Set("X-Tenant-ID", "test-tenant")
+	req.Header.Set("Authorization", "Bearer test-token")
+	w := httptest.NewRecorder()
+
+	handler.ProxyToOrchestrator(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", w.Code)
+	}
+}
+
+func TestProxyToPortal_Success(t *testing.T) {
+	// Create a mock backend server
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	}))
+	defer backend.Close()
+
+	handler, err := NewReverseProxyHandler(ProxyConfig{
+		PortalInternalURL: backend.URL,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create handler: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", "/api/v1/portal/status", nil)
+	w := httptest.NewRecorder()
+
+	handler.ProxyToPortal(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", w.Code)
+	}
+}
+
+func TestProxyToOrchestrator_BackendDown(t *testing.T) {
+	// Configure proxy with URL that will fail
+	handler, err := NewReverseProxyHandler(ProxyConfig{
+		OrchestratorInternalURL: "http://localhost:99999", // Invalid port
+	})
+	if err != nil {
+		t.Fatalf("Failed to create handler: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", "/api/v1/dynamic-policies", nil)
+	w := httptest.NewRecorder()
+
+	handler.ProxyToOrchestrator(w, req)
+
+	if w.Code != http.StatusBadGateway {
+		t.Errorf("Expected status 502, got %d", w.Code)
+	}
+
+	var response map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("Failed to unmarshal response: %v", err)
+	}
+
+	if response["error"] != "Backend service unavailable" {
+		t.Errorf("Unexpected error message: %s", response["error"])
+	}
+	if response["service"] != "orchestrator" {
+		t.Errorf("Unexpected service: %s", response["service"])
+	}
+}
+
+func TestRegisterProxyRoutes(t *testing.T) {
+	handler, err := NewReverseProxyHandler(ProxyConfig{
+		OrchestratorInternalURL: "http://localhost:8081",
+		PortalInternalURL:       "http://localhost:8082",
+	})
+	if err != nil {
+		t.Fatalf("Failed to create handler: %v", err)
+	}
+
+	r := mux.NewRouter()
+	handler.RegisterProxyRoutes(r)
+
+	// Test that routes are registered by checking they match
+	routeTests := []struct {
+		method string
+		path   string
+		want   bool
+	}{
+		// Orchestrator routes
+		{"GET", "/api/v1/dynamic-policies", true},
+		{"POST", "/api/v1/dynamic-policies", true},
+		{"GET", "/api/v1/connectors", true},
+		{"GET", "/api/v1/cost/budgets", true},
+		{"GET", "/api/v1/executions", true},
+		{"GET", "/api/v1/llm-providers", true},
+		// Portal routes
+		{"GET", "/api/v1/code-governance/metrics", true},
+		{"GET", "/api/v1/portal/status", true},
+		{"GET", "/api/v1/git-providers", true},
+		// Non-proxied routes should not match
+		{"GET", "/api/v1/policies", false},
+		{"GET", "/health", false},
+	}
+
+	for _, tt := range routeTests {
+		t.Run(tt.method+" "+tt.path, func(t *testing.T) {
+			req := httptest.NewRequest(tt.method, tt.path, nil)
+			var match mux.RouteMatch
+			matched := r.Match(req, &match)
+
+			if matched != tt.want {
+				t.Errorf("Route %s %s matched=%v, want=%v", tt.method, tt.path, matched, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsProxiedPath(t *testing.T) {
+	tests := []struct {
+		path string
+		want bool
+	}{
+		// Orchestrator paths
+		{"/api/v1/dynamic-policies", true},
+		{"/api/v1/dynamic-policies/123", true},
+		{"/api/v1/connectors", true},
+		{"/api/v1/connectors/amadeus", true},
+		{"/api/v1/cost/budgets", true},
+		{"/api/v1/budgets", true},
+		{"/api/v1/usage", true},
+		{"/api/v1/executions", true},
+		{"/api/v1/executions/123", true},
+		{"/api/v1/llm-providers", true},
+		{"/api/v1/llm-providers/openai", true},
+		// Portal paths
+		{"/api/v1/code-governance/metrics", true},
+		{"/api/v1/portal/auth", true},
+		{"/api/v1/git-providers", true},
+		{"/api/v1/git-providers/github", true},
+		// Non-proxied paths
+		{"/api/v1/policies", false},
+		{"/api/v1/static-policies", false},
+		{"/health", false},
+		{"/metrics", false},
+		{"/api/request", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			got := IsProxiedPath(tt.path)
+			if got != tt.want {
+				t.Errorf("IsProxiedPath(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetProxyConfig(t *testing.T) {
+	// Test that GetProxyConfig returns valid configuration
+	// In test environment (not Docker), should return localhost URLs
+	config := GetProxyConfig()
+
+	// Should be either Docker or local URLs
+	validOrchestratorURLs := map[string]bool{
+		LocalOrchestratorURL:   true,
+		DefaultOrchestratorURL: true,
+	}
+	validPortalURLs := map[string]bool{
+		LocalPortalURL:   true,
+		DefaultPortalURL: true,
+	}
+
+	if !validOrchestratorURLs[config.OrchestratorInternalURL] {
+		t.Errorf("OrchestratorInternalURL = %s, want either %s or %s",
+			config.OrchestratorInternalURL, LocalOrchestratorURL, DefaultOrchestratorURL)
+	}
+	if !validPortalURLs[config.PortalInternalURL] {
+		t.Errorf("PortalInternalURL = %s, want either %s or %s",
+			config.PortalInternalURL, LocalPortalURL, DefaultPortalURL)
+	}
+}
+
+func TestIsRunningInDocker(t *testing.T) {
+	// In test environment, should detect correctly
+	// We can't fully test Docker detection in non-Docker environment,
+	// but we can verify the function doesn't panic
+	result := isRunningInDocker()
+	// Just verify it returns a boolean without panicking
+	_ = result
+}

--- a/platform/agent/run.go
+++ b/platform/agent/run.go
@@ -56,11 +56,29 @@ func isCommunityMode() bool {
 	return mode == "community" || mode == ""
 }
 
+// Internal service URLs - auto-discovered based on environment (ADR-026: Single Entry Point)
+// Docker Compose services communicate via service names on the axonflow-network.
+// No configuration required - the Agent detects Docker and uses appropriate URLs.
+const (
+	// DefaultOrchestratorURL is the internal URL for the Orchestrator service in Docker
+	DefaultOrchestratorURL = "http://axonflow-orchestrator:8081"
+
+	// DefaultPortalURL is the internal URL for the Customer Portal service in Docker
+	// Service name: axonflow-customer-portal, internal port: 8080 (mapped to 8082 externally)
+	DefaultPortalURL = "http://axonflow-customer-portal:8080"
+
+	// LocalOrchestratorURL is used for local development without Docker
+	LocalOrchestratorURL = "http://localhost:8081"
+
+	// LocalPortalURL is used for local development without Docker
+	LocalPortalURL = "http://localhost:8082"
+)
+
 // Configuration
 var (
 	jwtSecret              = []byte(os.Getenv("JWT_SECRET"))
-	orchestratorURL        = getEnv("ORCHESTRATOR_URL", "http://localhost:8081")
-	authDB                 *sql.DB // Database for Option 3 authentication
+	orchestratorURL        = getOrchestratorURL() // Auto-discovered based on environment
+	authDB                 *sql.DB                // Database for Option 3 authentication
 	usageDB                *sql.DB // Database for usage metering
 	staticPolicyEngine     *StaticPolicyEngine
 	dbPolicyEngine         *DatabasePolicyEngine
@@ -815,6 +833,18 @@ func Run() {
 	cbHandler.RegisterRoutes(globalRouter)
 	// Note: In community edition, RegisterRoutes is a no-op (Circuit Breaker is an enterprise feature)
 
+	// Register Reverse Proxy routes (ADR-026: Single Entry Point Architecture)
+	// Proxies requests to Orchestrator and Portal based on path
+	proxyConfig := GetProxyConfig()
+	proxyHandler, err := NewReverseProxyHandler(proxyConfig)
+	if err != nil {
+		log.Printf("⚠️  Failed to initialize reverse proxy: %v", err)
+		log.Println("   SDK clients will need to connect directly to backend services")
+	} else {
+		proxyHandler.RegisterProxyRoutes(globalRouter)
+		log.Println("✅ Reverse proxy initialized (ADR-026: Single Entry Point)")
+	}
+
 	// Mark application as ready - /health will now return "healthy"
 	appReady.Store(true)
 	log.Println("✅ All initialization complete - application ready")
@@ -1505,6 +1535,41 @@ func getEnv(key, defaultValue string) string {
 		return value
 	}
 	return defaultValue
+}
+
+// getOrchestratorURL returns the Orchestrator URL based on environment detection.
+// In Docker environments, services communicate via container names on the axonflow-network.
+// For local development, falls back to localhost.
+func getOrchestratorURL() string {
+	if isRunningInDocker() {
+		return DefaultOrchestratorURL
+	}
+	return LocalOrchestratorURL
+}
+
+// isRunningInDocker detects if the process is running inside a Docker container
+func isRunningInDocker() bool {
+	// Method 1: Check for /.dockerenv file (most reliable)
+	if _, err := os.Stat("/.dockerenv"); err == nil {
+		return true
+	}
+
+	// Method 2: Check if HOSTNAME looks like a container ID (12+ hex chars)
+	hostname := os.Getenv("HOSTNAME")
+	if len(hostname) >= 12 {
+		isHex := true
+		for _, c := range hostname[:12] {
+			if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
+				isHex = false
+				break
+			}
+		}
+		if isHex {
+			return true
+		}
+	}
+
+	return false
 }
 
 func getClaimString(claims jwt.MapClaims, key string) string {

--- a/platform/agent/sqli/config.go
+++ b/platform/agent/sqli/config.go
@@ -76,7 +76,17 @@ const (
 	// EnvSQLIBlockMode sets whether to block or warn on detection.
 	// Valid values: "block", "warn"
 	// Default: "block"
+	//
+	// Deprecated: Use SQLI_ACTION instead for unified detection configuration.
+	// SQLI_ACTION supports: "block", "warn", "log"
+	// This env var will be removed in a future release.
 	EnvSQLIBlockMode = "SQLI_BLOCK_MODE"
+
+	// EnvSQLIAction is the new unified env var for SQL injection action.
+	// Valid values: "block", "warn", "log"
+	// Default: "block"
+	// Takes precedence over SQLI_BLOCK_MODE if both are set.
+	EnvSQLIAction = "SQLI_ACTION"
 )
 
 // ConfigFromEnv creates a configuration from environment variables.
@@ -84,7 +94,8 @@ const (
 //
 // Environment variables:
 //   - SQLI_SCANNER_MODE: off, basic, advanced (default: basic)
-//   - SQLI_BLOCK_MODE: block, warn (default: block)
+//   - SQLI_ACTION: block, warn, log (default: block) - NEW, takes precedence
+//   - SQLI_BLOCK_MODE: block, warn (default: block) - DEPRECATED
 //
 // Invalid values are logged and fall back to defaults.
 func ConfigFromEnv() Config {
@@ -103,8 +114,24 @@ func ConfigFromEnv() Config {
 		}
 	}
 
-	// Parse SQLI_BLOCK_MODE
-	if blockStr := os.Getenv(EnvSQLIBlockMode); blockStr != "" {
+	// Parse SQLI_ACTION (new) or SQLI_BLOCK_MODE (deprecated)
+	// SQLI_ACTION takes precedence if both are set
+	if actionStr := os.Getenv(EnvSQLIAction); actionStr != "" {
+		switch strings.ToLower(actionStr) {
+		case "block":
+			cfg.BlockOnDetection = true
+			log.Printf("[SQLi] Action=block - detections will be blocked")
+		case "warn", "log":
+			cfg.BlockOnDetection = false
+			log.Printf("[SQLi] Action=%s - detections will be logged but not blocked", strings.ToLower(actionStr))
+		default:
+			log.Printf("[SQLi] WARNING: Invalid %s=%q, using default 'block'. Valid values: block, warn, log",
+				EnvSQLIAction, actionStr)
+			cfg.BlockOnDetection = true
+		}
+	} else if blockStr := os.Getenv(EnvSQLIBlockMode); blockStr != "" {
+		// Deprecated: SQLI_BLOCK_MODE
+		log.Printf("[SQLi] WARNING: %s is deprecated. Use %s instead.", EnvSQLIBlockMode, EnvSQLIAction)
 		switch strings.ToLower(blockStr) {
 		case "block":
 			cfg.BlockOnDetection = true
@@ -115,7 +142,7 @@ func ConfigFromEnv() Config {
 		default:
 			log.Printf("[SQLi] WARNING: Invalid %s=%q, using default 'block'. Valid values: block, warn",
 				EnvSQLIBlockMode, blockStr)
-			cfg.BlockOnDetection = true // Default to block for security
+			cfg.BlockOnDetection = true
 		}
 	} else {
 		// Default to block mode for security-first approach

--- a/platform/agent/static_policies.go
+++ b/platform/agent/static_policies.go
@@ -15,7 +15,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"os"
 	"regexp"
 	"strings"
 	"time"
@@ -28,9 +27,9 @@ import (
 type StaticPolicyEngine struct {
 	sqliScanner         sqli.Scanner      // Unified SQL injection + dangerous query scanner
 	sqliConfig          sqli.Config       // SQL injection configuration (mode, block/warn)
+	detectionConfig     DetectionConfig   // Unified detection configuration (Issue #891)
 	adminAccessPatterns []*PolicyPattern
 	piiPatterns         []*PolicyPattern // PII detection (passports, credit cards, etc.)
-	piiBlockCritical    bool             // Block critical PII (SSN, credit cards) - default: true
 }
 
 // PolicyPattern represents a static policy rule
@@ -52,16 +51,14 @@ type StaticPolicyResult struct {
 	ChecksPerformed    []string
 	ProcessingTimeMs   int64
 	Severity           string
+	RequiresRedaction  bool   // True if PII detected and should be redacted (Issue #891)
 }
 
 // NewStaticPolicyEngine creates a new static policy engine with default rules
 func NewStaticPolicyEngine() *StaticPolicyEngine {
-	// PII blocking is ON by default; set PII_BLOCK_CRITICAL=false to disable
-	piiBlock := true
-	if val := os.Getenv("PII_BLOCK_CRITICAL"); val == "false" || val == "0" {
-		piiBlock = false
-		log.Println("[StaticPolicyEngine] PII blocking DISABLED - critical PII will be logged but not blocked")
-	}
+	// Load unified detection configuration from environment (Issue #891)
+	// This handles both new env vars (PII_ACTION) and deprecated ones (PII_BLOCK_CRITICAL)
+	detectionCfg := DetectionConfigFromEnv()
 
 	// Load SQL injection config from environment
 	sqliCfg := sqli.ConfigFromEnv()
@@ -80,9 +77,9 @@ func NewStaticPolicyEngine() *StaticPolicyEngine {
 	}
 
 	engine := &StaticPolicyEngine{
-		sqliScanner:      scanner,
-		sqliConfig:       sqliCfg,
-		piiBlockCritical: piiBlock,
+		sqliScanner:     scanner,
+		sqliConfig:      sqliCfg,
+		detectionConfig: detectionCfg,
 	}
 	engine.loadDefaultPolicies()
 	return engine
@@ -165,17 +162,29 @@ func (spe *StaticPolicyEngine) EvaluateStaticPolicies(user *User, query string, 
 	}
 	result.ChecksPerformed = append(result.ChecksPerformed, "basic_validation")
 
-	// 6. PII Detection
-	// Critical PII (SSN, credit cards, Aadhaar, PAN) - block if piiBlockCritical is enabled
+	// 6. PII Detection (Issue #891 - tiered defaults)
+	// Action controlled by PII_ACTION env var (default: redact)
+	// Critical PII (SSN, credit cards, Aadhaar, PAN) - action based on config
 	// Non-critical PII (email, phone) - log and flag for redaction in Orchestrator
 	if piiPattern := spe.checkPatterns(query, spe.piiPatterns); piiPattern != nil {
 		result.TriggeredPolicies = append(result.TriggeredPolicies, piiPattern.ID)
-		if piiPattern.Severity == "critical" && spe.piiBlockCritical {
-			result.Blocked = true
-			result.Reason = piiPattern.Description
-			result.Severity = piiPattern.Severity
-			result.ProcessingTimeMs = time.Since(startTime).Nanoseconds() / 1000000
-			return result
+		if piiPattern.Severity == "critical" {
+			switch spe.detectionConfig.PIIAction {
+			case DetectionActionBlock:
+				result.Blocked = true
+				result.Reason = piiPattern.Description
+				result.Severity = piiPattern.Severity
+				result.ProcessingTimeMs = time.Since(startTime).Nanoseconds() / 1000000
+				return result
+			case DetectionActionRedact:
+				// Flag for redaction but don't block - handled by Orchestrator
+				log.Printf("[PII] Detected %s - flagged for redaction (action=redact)", piiPattern.ID)
+				result.RequiresRedaction = true
+			case DetectionActionWarn:
+				log.Printf("[PII] WARNING: Detected %s (action=warn)", piiPattern.ID)
+			case DetectionActionLog:
+				log.Printf("[PII] Detected %s (action=log)", piiPattern.ID)
+			}
 		}
 		// For non-critical PII, allow with redaction in Orchestrator
 	}

--- a/platform/agent/static_policies_test.go
+++ b/platform/agent/static_policies_test.go
@@ -516,6 +516,7 @@ func TestEmptyQueryValidation(t *testing.T) {
 
 // TestPIIDetection tests PII pattern detection
 func TestPIIDetection(t *testing.T) {
+	// Default behavior: PII_ACTION=redact (redacts but doesn't block)
 	engine := NewStaticPolicyEngine()
 	user := &User{
 		ID:          1,
@@ -524,45 +525,51 @@ func TestPIIDetection(t *testing.T) {
 	}
 
 	tests := []struct {
-		name                string
-		query               string
-		shouldBlock         bool
-		shouldTriggerPolicy bool
-		policyID            string
+		name                 string
+		query                string
+		shouldBlock          bool
+		shouldRequireRedact  bool
+		shouldTriggerPolicy  bool
+		policyID             string
 	}{
 		{
-			name:                "Passport number",
-			query:               "Book flight for passenger with passport AB123456",
-			shouldBlock:         false, // PII detection doesn't block
-			shouldTriggerPolicy: true,
-			policyID:            "passport_number_detection",
+			name:                 "Passport number",
+			query:                "Book flight for passenger with passport AB123456",
+			shouldBlock:          false,
+			shouldRequireRedact:  false, // Passport has "high" severity, not "critical" - no redaction
+			shouldTriggerPolicy:  true,
+			policyID:             "passport_number_detection",
 		},
 		{
-			name:                "Credit card (Visa)",
-			query:               "Payment with card 4532015112830366",
-			shouldBlock:         true, // Critical PII blocks by default (PII_BLOCK_CRITICAL=true)
-			shouldTriggerPolicy: true,
-			policyID:            "credit_card_detection",
+			name:                 "Credit card (Visa)",
+			query:                "Payment with card 4532015112830366",
+			shouldBlock:          false, // Default PII_ACTION=redact doesn't block
+			shouldRequireRedact:  true,  // Critical PII flagged for redaction
+			shouldTriggerPolicy:  true,
+			policyID:             "credit_card_detection",
 		},
 		{
-			name:                "SSN",
-			query:               "Customer SSN is 123-45-6789",
-			shouldBlock:         true, // Critical PII blocks by default (PII_BLOCK_CRITICAL=true)
-			shouldTriggerPolicy: true,
-			policyID:            "ssn_detection",
+			name:                 "SSN",
+			query:                "Customer SSN is 123-45-6789",
+			shouldBlock:          false, // Default PII_ACTION=redact doesn't block
+			shouldRequireRedact:  true,  // Critical PII flagged for redaction
+			shouldTriggerPolicy:  true,
+			policyID:             "ssn_detection",
 		},
 		{
-			name:                "Booking reference",
-			query:               "Retrieve booking ABC123",
-			shouldBlock:         false,
-			shouldTriggerPolicy: true,
-			policyID:            "booking_reference_logging",
+			name:                 "Booking reference",
+			query:                "Retrieve booking ABC123",
+			shouldBlock:          false,
+			shouldRequireRedact:  false, // Non-critical PII
+			shouldTriggerPolicy:  true,
+			policyID:             "booking_reference_logging",
 		},
 		{
-			name:                "No PII",
-			query:               "SELECT * FROM flights WHERE departure='JFK'",
-			shouldBlock:         false,
-			shouldTriggerPolicy: false,
+			name:                 "No PII",
+			query:                "SELECT * FROM flights WHERE departure='JFK'",
+			shouldBlock:          false,
+			shouldRequireRedact:  false,
+			shouldTriggerPolicy:  false,
 		},
 	}
 
@@ -575,6 +582,11 @@ func TestPIIDetection(t *testing.T) {
 					tt.query, tt.shouldBlock, result.Blocked)
 			}
 
+			if result.RequiresRedaction != tt.shouldRequireRedact {
+				t.Errorf("Query: %s\nExpected requiresRedaction=%v, got requiresRedaction=%v",
+					tt.query, tt.shouldRequireRedact, result.RequiresRedaction)
+			}
+
 			if tt.shouldTriggerPolicy {
 				if !containsPolicy(result.TriggeredPolicies, tt.policyID) {
 					t.Errorf("Expected policy '%s' to be triggered for PII detection, got: %v",
@@ -582,7 +594,7 @@ func TestPIIDetection(t *testing.T) {
 				}
 			}
 
-			// Verify PII detection check was performed (not present if blocked early)
+			// Verify PII detection check was performed
 			if !tt.shouldBlock && !containsCheck(result.ChecksPerformed, "pii_detection") {
 				t.Error("Expected 'pii_detection' in checks performed")
 			}
@@ -590,11 +602,48 @@ func TestPIIDetection(t *testing.T) {
 	}
 }
 
+// TestPIIDetection_BlockMode tests that PII blocks when PII_ACTION=block
+func TestPIIDetection_BlockMode(t *testing.T) {
+	// Set env var to enable PII blocking
+	os.Setenv("PII_ACTION", "block")
+	defer os.Unsetenv("PII_ACTION")
+
+	engine := NewStaticPolicyEngine()
+	user := &User{
+		ID:          1,
+		Email:       "user1@test.com",
+		Permissions: []string{"query"},
+	}
+
+	tests := []struct {
+		name  string
+		query string
+	}{
+		{
+			name:  "SSN should block when PII_ACTION=block",
+			query: "Customer SSN is 123-45-6789",
+		},
+		{
+			name:  "Credit card should block when PII_ACTION=block",
+			query: "Payment with card 4532015112830366",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := engine.EvaluateStaticPolicies(user, tt.query, "llm_chat")
+			if !result.Blocked {
+				t.Errorf("Expected query to be blocked with PII_ACTION=block, but it wasn't: %s", tt.query)
+			}
+		})
+	}
+}
+
 // TestPIIDetection_Disabled tests that PII blocking can be disabled via env var
 func TestPIIDetection_Disabled(t *testing.T) {
-	// Set env var to disable PII blocking
-	os.Setenv("PII_BLOCK_CRITICAL", "false")
-	defer os.Unsetenv("PII_BLOCK_CRITICAL")
+	// Set env var to log-only mode (no blocking or redaction)
+	os.Setenv("PII_ACTION", "log")
+	defer os.Unsetenv("PII_ACTION")
 
 	engine := NewStaticPolicyEngine()
 	user := &User{
@@ -1405,9 +1454,9 @@ func TestMultiplePIIInSingleQuery(t *testing.T) {
 
 	result := engine.EvaluateStaticPolicies(user, query, "llm_chat")
 
-	// Should block - contains critical PII (SSN, credit card)
-	if !result.Blocked {
-		t.Error("Multiple critical PII detection should block (PII_BLOCK_CRITICAL=true)")
+	// Should flag for redaction - contains critical PII (SSN, credit card) (PII_ACTION=redact by default)
+	if !result.RequiresRedaction {
+		t.Error("Multiple critical PII detection should flag for redaction (PII_ACTION=redact)")
 	}
 
 	// Static engine returns after first PII match found
@@ -1595,12 +1644,12 @@ func TestStaticPANDetection(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := engine.EvaluateStaticPolicies(user, tt.query, "llm_chat")
 
-			// PAN is critical severity - should block by default (PII_BLOCK_CRITICAL=true)
-			if tt.shouldTriggerPolicy && !result.Blocked {
-				t.Errorf("PAN detection should block queries (critical PII), got not blocked")
+			// PAN is critical severity - flagged for redaction by default (PII_ACTION=redact)
+			if tt.shouldTriggerPolicy && !result.RequiresRedaction {
+				t.Errorf("PAN detection should flag for redaction (critical PII), got not flagged")
 			}
-			if !tt.shouldTriggerPolicy && result.Blocked {
-				t.Errorf("Should not block when no PAN detected, got blocked: %s", result.Reason)
+			if !tt.shouldTriggerPolicy && result.RequiresRedaction {
+				t.Errorf("Should not flag when no PAN detected, got flagged: %s", result.Reason)
 			}
 
 			// Check if policy was triggered
@@ -1727,12 +1776,12 @@ func TestStaticAadhaarDetection(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := engine.EvaluateStaticPolicies(user, tt.query, "llm_chat")
 
-			// Aadhaar is critical severity - should block by default (PII_BLOCK_CRITICAL=true)
-			if tt.shouldTriggerPolicy && !result.Blocked {
-				t.Errorf("Aadhaar detection should block queries (critical PII), got not blocked")
+			// Aadhaar is critical severity - flagged for redaction by default (PII_ACTION=redact)
+			if tt.shouldTriggerPolicy && !result.RequiresRedaction {
+				t.Errorf("Aadhaar detection should flag for redaction (critical PII), got not flagged")
 			}
-			if !tt.shouldTriggerPolicy && result.Blocked {
-				t.Errorf("Should not block when no Aadhaar detected, got blocked: %s", result.Reason)
+			if !tt.shouldTriggerPolicy && result.RequiresRedaction {
+				t.Errorf("Should not flag when no Aadhaar detected, got flagged: %s", result.Reason)
 			}
 
 			// Check if policy was triggered
@@ -1874,9 +1923,9 @@ func TestCombinedIndianPII(t *testing.T) {
 	query := "KYC Details - PAN: ABCPD1234E, Aadhaar: 2345 6789 0123, Name: John Doe"
 	result := engine.EvaluateStaticPolicies(user, query, "llm_chat")
 
-	// Should block - both PAN and Aadhaar are critical severity PII
-	if !result.Blocked {
-		t.Error("Indian PII detection should block queries (critical PII, PII_BLOCK_CRITICAL=true)")
+	// Should flag for redaction - both PAN and Aadhaar are critical severity PII (PII_ACTION=redact by default)
+	if !result.RequiresRedaction {
+		t.Error("Indian PII detection should flag for redaction (critical PII, PII_ACTION=redact)")
 	}
 
 	// At least one Indian PII policy should be triggered (first match wins in static engine)

--- a/platform/agent/static_policy_api_handlers.go
+++ b/platform/agent/static_policy_api_handlers.go
@@ -231,8 +231,13 @@ func (h *StaticPolicyAPIHandler) HandleCreateStaticPolicy(w http.ResponseWriter,
 	}
 
 	// Set organization ID for org-tier policies
-	if tier == TierOrganization && orgID != "" {
-		policy.OrganizationID = &orgID
+	// Prefer request body organization_id over header
+	effectiveOrgID := req.OrganizationID
+	if effectiveOrgID == "" {
+		effectiveOrgID = orgID // Fall back to X-Organization-ID header
+	}
+	if tier == TierOrganization && effectiveOrgID != "" {
+		policy.OrganizationID = &effectiveOrgID
 	}
 
 	// Create policy using repository

--- a/platform/orchestrator/Dockerfile
+++ b/platform/orchestrator/Dockerfile
@@ -21,7 +21,9 @@ RUN go mod download
 COPY platform/ .
 
 # For enterprise builds from enterprise repo, copy ee/ agent code
-# The orchestrator imports agent/node_enforcement which needs enterprise code
+# The orchestrator imports agent package which needs enterprise code for:
+# - license, marketplace, node_enforcement (always)
+# - rbi, hitl, circuitbreaker (EU AI Act Article 14, Issue #891)
 # ADR-013: Enterprise repo always has ee/, Community repo doesn't have ee/
 RUN --mount=type=bind,source=.,target=/src \
     if [ "$EDITION" = "enterprise" ] && [ -d "/src/ee/platform/agent/node_enforcement" ]; then \
@@ -29,6 +31,20 @@ RUN --mount=type=bind,source=.,target=/src \
       cp -r /src/ee/platform/agent/license/* ./agent/license/ && \
       cp -r /src/ee/platform/agent/marketplace/* ./agent/marketplace/ && \
       cp -r /src/ee/platform/agent/node_enforcement/* ./agent/node_enforcement/ && \
+      if [ -d "/src/ee/platform/agent/rbi" ]; then \
+        cp -r /src/ee/platform/agent/rbi/* ./agent/rbi/ && \
+        echo "  Copied enterprise RBI agent module"; \
+      fi && \
+      if [ -d "/src/ee/platform/agent/hitl" ]; then \
+        mkdir -p ./agent/hitl && \
+        cp -r /src/ee/platform/agent/hitl/* ./agent/hitl/ && \
+        echo "  Copied enterprise HITL module (EU AI Act Article 14)"; \
+      fi && \
+      if [ -d "/src/ee/platform/agent/circuitbreaker" ]; then \
+        mkdir -p ./agent/circuitbreaker && \
+        cp -r /src/ee/platform/agent/circuitbreaker/* ./agent/circuitbreaker/ && \
+        echo "  Copied enterprise Circuit Breaker module (EU AI Act Article 14)"; \
+      fi && \
       echo "Enterprise agent code copied successfully" && \
       echo "=== Copying EE compliance modules ===" && \
       if [ -d "/src/ee/platform/orchestrator/sebi" ]; then \

--- a/platform/orchestrator/cost/postgres_repository_test.go
+++ b/platform/orchestrator/cost/postgres_repository_test.go
@@ -1,0 +1,433 @@
+// Copyright 2025 AxonFlow
+// SPDX-License-Identifier: BUSL-1.1
+
+package cost
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestNewPostgresRepository(t *testing.T) {
+	db, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("Failed to create mock: %v", err)
+	}
+	defer db.Close()
+
+	repo := NewPostgresRepository(db)
+	if repo == nil {
+		t.Fatal("Expected non-nil repository")
+	}
+	if repo.db != db {
+		t.Error("Expected db to be set")
+	}
+}
+
+func TestPostgresRepository_CreateBudget(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("Failed to create mock: %v", err)
+	}
+	defer db.Close()
+
+	repo := NewPostgresRepository(db)
+
+	t.Run("successful creation", func(t *testing.T) {
+		budget := &Budget{
+			ID:              "budget-001",
+			Name:            "Test Budget",
+			Description:     "Test description",
+			Scope:           ScopeOrganization,
+			ScopeID:         "org-123",
+			LimitUSD:        1000.0,
+			Period:          PeriodMonthly,
+			OnExceed:        OnExceedWarn,
+			AlertThresholds: []int{50, 80, 100},
+			Enabled:         true,
+			OrgID:           "org-123",
+			TenantID:        "tenant-456",
+			CreatedBy:       "user-789",
+			UpdatedBy:       "user-789",
+			CreatedAt:       time.Now(),
+			UpdatedAt:       time.Now(),
+		}
+
+		mock.ExpectExec("INSERT INTO budgets").
+			WithArgs(
+				budget.ID, budget.Name, budget.Description, budget.Scope, budget.ScopeID,
+				budget.LimitUSD, budget.Period, budget.OnExceed, sqlmock.AnyArg(), budget.Enabled,
+				sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(),
+				sqlmock.AnyArg(), sqlmock.AnyArg(),
+			).
+			WillReturnResult(sqlmock.NewResult(1, 1))
+
+		err := repo.CreateBudget(context.Background(), budget)
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Errorf("Unfulfilled expectations: %v", err)
+		}
+	})
+
+	t.Run("duplicate key error", func(t *testing.T) {
+		budget := &Budget{
+			ID:              "budget-duplicate",
+			Name:            "Duplicate Budget",
+			Scope:           ScopeOrganization,
+			LimitUSD:        500.0,
+			Period:          PeriodMonthly,
+			OnExceed:        OnExceedWarn,
+			AlertThresholds: []int{80},
+			Enabled:         true,
+			CreatedAt:       time.Now(),
+			UpdatedAt:       time.Now(),
+		}
+
+		mock.ExpectExec("INSERT INTO budgets").
+			WillReturnError(sql.ErrConnDone) // Simulate error
+
+		err := repo.CreateBudget(context.Background(), budget)
+		if err == nil {
+			t.Error("Expected error for duplicate key")
+		}
+	})
+}
+
+func TestPostgresRepository_GetBudget(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("Failed to create mock: %v", err)
+	}
+	defer db.Close()
+
+	repo := NewPostgresRepository(db)
+
+	t.Run("budget found", func(t *testing.T) {
+		thresholds, _ := json.Marshal([]int{50, 80, 100})
+		rows := sqlmock.NewRows([]string{
+			"id", "name", "description", "scope", "scope_id", "limit_usd", "period",
+			"on_exceed", "alert_thresholds", "enabled", "org_id", "tenant_id",
+			"created_by", "updated_by", "created_at", "updated_at",
+		}).AddRow(
+			"budget-001", "Test Budget", "Description", ScopeOrganization, "org-123",
+			1000.0, PeriodMonthly, OnExceedWarn, thresholds, true,
+			"org-123", "tenant-456", "user-789", "user-789",
+			time.Now(), time.Now(),
+		)
+
+		mock.ExpectQuery("SELECT .+ FROM budgets").
+			WithArgs("budget-001").
+			WillReturnRows(rows)
+
+		budget, err := repo.GetBudget(context.Background(), "budget-001")
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+		if budget == nil {
+			t.Fatal("Expected budget to be returned")
+		}
+		if budget.ID != "budget-001" {
+			t.Errorf("Expected ID budget-001, got %s", budget.ID)
+		}
+		if budget.LimitUSD != 1000.0 {
+			t.Errorf("Expected LimitUSD 1000.0, got %f", budget.LimitUSD)
+		}
+	})
+
+	t.Run("budget not found", func(t *testing.T) {
+		mock.ExpectQuery("SELECT .+ FROM budgets").
+			WithArgs("nonexistent").
+			WillReturnError(sql.ErrNoRows)
+
+		budget, err := repo.GetBudget(context.Background(), "nonexistent")
+		if err != ErrBudgetNotFound {
+			t.Errorf("Expected ErrBudgetNotFound, got %v", err)
+		}
+		if budget != nil {
+			t.Error("Expected nil budget")
+		}
+	})
+}
+
+func TestPostgresRepository_Ping(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.MonitorPingsOption(true))
+	if err != nil {
+		t.Fatalf("Failed to create mock: %v", err)
+	}
+	defer db.Close()
+
+	repo := NewPostgresRepository(db)
+
+	t.Run("ping success", func(t *testing.T) {
+		mock.ExpectPing()
+
+		err := repo.Ping(context.Background())
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+	})
+}
+
+func TestPostgresRepository_UpdateBudget(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("Failed to create mock: %v", err)
+	}
+	defer db.Close()
+
+	repo := NewPostgresRepository(db)
+
+	t.Run("successful update", func(t *testing.T) {
+		budget := &Budget{
+			ID:              "budget-001",
+			Name:            "Updated Budget",
+			Description:     "Updated description",
+			Scope:           ScopeOrganization,
+			ScopeID:         "org-123",
+			LimitUSD:        2000.0,
+			Period:          PeriodMonthly,
+			OnExceed:        OnExceedBlock,
+			AlertThresholds: []int{75, 90},
+			Enabled:         true,
+			UpdatedBy:       "user-789",
+		}
+
+		mock.ExpectExec("UPDATE budgets SET").
+			WithArgs(
+				budget.ID, budget.Name, budget.Description, budget.Scope, budget.ScopeID,
+				budget.LimitUSD, budget.Period, budget.OnExceed, sqlmock.AnyArg(),
+				budget.Enabled, sqlmock.AnyArg(), sqlmock.AnyArg(),
+			).
+			WillReturnResult(sqlmock.NewResult(0, 1))
+
+		err := repo.UpdateBudget(context.Background(), budget)
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Errorf("Unfulfilled expectations: %v", err)
+		}
+	})
+
+	t.Run("budget not found", func(t *testing.T) {
+		budget := &Budget{
+			ID:              "nonexistent",
+			Name:            "Not Found Budget",
+			AlertThresholds: []int{80},
+		}
+
+		mock.ExpectExec("UPDATE budgets SET").
+			WillReturnResult(sqlmock.NewResult(0, 0))
+
+		err := repo.UpdateBudget(context.Background(), budget)
+		if err != ErrBudgetNotFound {
+			t.Errorf("Expected ErrBudgetNotFound, got %v", err)
+		}
+	})
+}
+
+func TestPostgresRepository_DeleteBudget(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("Failed to create mock: %v", err)
+	}
+	defer db.Close()
+
+	repo := NewPostgresRepository(db)
+
+	t.Run("successful delete", func(t *testing.T) {
+		mock.ExpectExec("DELETE FROM budgets WHERE").
+			WithArgs("budget-001").
+			WillReturnResult(sqlmock.NewResult(0, 1))
+
+		err := repo.DeleteBudget(context.Background(), "budget-001")
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Errorf("Unfulfilled expectations: %v", err)
+		}
+	})
+
+	t.Run("budget not found", func(t *testing.T) {
+		mock.ExpectExec("DELETE FROM budgets WHERE").
+			WithArgs("nonexistent").
+			WillReturnResult(sqlmock.NewResult(0, 0))
+
+		err := repo.DeleteBudget(context.Background(), "nonexistent")
+		if err != ErrBudgetNotFound {
+			t.Errorf("Expected ErrBudgetNotFound, got %v", err)
+		}
+	})
+}
+
+func TestPostgresRepository_SaveUsage(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("Failed to create mock: %v", err)
+	}
+	defer db.Close()
+
+	repo := NewPostgresRepository(db)
+
+	t.Run("successful save", func(t *testing.T) {
+		record := &UsageRecord{
+			RequestID:   "req-001",
+			Timestamp:   time.Now(),
+			OrgID:       "org-123",
+			TenantID:    "tenant-456",
+			TeamID:      "team-789",
+			AgentID:     "agent-001",
+			WorkflowID:  "workflow-001",
+			UserID:      "user-001",
+			Provider:    "openai",
+			Model:       "gpt-4",
+			TokensIn:    100,
+			TokensOut:   50,
+			CostUSD:     0.05,
+			RequestType: "completion",
+			Cached:      false,
+		}
+
+		rows := sqlmock.NewRows([]string{"id"}).AddRow(int64(1))
+		mock.ExpectQuery("INSERT INTO usage_records").
+			WithArgs(
+				record.RequestID, sqlmock.AnyArg(),
+				sqlmock.AnyArg(), sqlmock.AnyArg(),
+				sqlmock.AnyArg(), sqlmock.AnyArg(),
+				sqlmock.AnyArg(), sqlmock.AnyArg(),
+				record.Provider, record.Model,
+				record.TokensIn, record.TokensOut, record.CostUSD,
+				sqlmock.AnyArg(), record.Cached,
+			).
+			WillReturnRows(rows)
+
+		err := repo.SaveUsage(context.Background(), record)
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+		if record.ID != 1 {
+			t.Errorf("Expected ID 1, got %d", record.ID)
+		}
+
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Errorf("Unfulfilled expectations: %v", err)
+		}
+	})
+
+	t.Run("save error", func(t *testing.T) {
+		record := &UsageRecord{
+			RequestID: "req-fail",
+			Provider:  "openai",
+			Model:     "gpt-4",
+		}
+
+		mock.ExpectQuery("INSERT INTO usage_records").
+			WillReturnError(sql.ErrConnDone)
+
+		err := repo.SaveUsage(context.Background(), record)
+		if err == nil {
+			t.Error("Expected error, got nil")
+		}
+	})
+}
+
+func TestPostgresRepository_AcknowledgeAlert(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("Failed to create mock: %v", err)
+	}
+	defer db.Close()
+
+	repo := NewPostgresRepository(db)
+
+	t.Run("successful acknowledge", func(t *testing.T) {
+		mock.ExpectExec("UPDATE budget_alerts").
+			WithArgs(int64(1), "admin-user", sqlmock.AnyArg()).
+			WillReturnResult(sqlmock.NewResult(0, 1))
+
+		err := repo.AcknowledgeAlert(context.Background(), 1, "admin-user")
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Errorf("Unfulfilled expectations: %v", err)
+		}
+	})
+}
+
+func TestPostgresRepository_GetUsageForPeriod(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("Failed to create mock: %v", err)
+	}
+	defer db.Close()
+
+	repo := NewPostgresRepository(db)
+
+	testCases := []struct {
+		name   string
+		scope  BudgetScope
+		column string
+	}{
+		{"organization scope", ScopeOrganization, "org_id"},
+		{"team scope", ScopeTeam, "team_id"},
+		{"agent scope", ScopeAgent, "agent_id"},
+		{"workflow scope", ScopeWorkflow, "workflow_id"},
+		{"user scope", ScopeUser, "user_id"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			rows := sqlmock.NewRows([]string{"total"}).AddRow(125.50)
+			mock.ExpectQuery("SELECT COALESCE\\(SUM\\(cost_usd\\), 0\\)").
+				WithArgs("scope-123", sqlmock.AnyArg(), "org-123", "tenant-456").
+				WillReturnRows(rows)
+
+			total, err := repo.GetUsageForPeriod(
+				context.Background(),
+				tc.scope,
+				"scope-123",
+				time.Now().AddDate(0, -1, 0),
+				"org-123",
+				"tenant-456",
+			)
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+			if total != 125.50 {
+				t.Errorf("Expected 125.50, got %f", total)
+			}
+		})
+	}
+}
+
+func TestNullString(t *testing.T) {
+	t.Run("empty string returns null", func(t *testing.T) {
+		result := nullString("")
+		if result.Valid {
+			t.Error("Expected invalid for empty string")
+		}
+	})
+
+	t.Run("non-empty string returns valid", func(t *testing.T) {
+		result := nullString("test")
+		if !result.Valid {
+			t.Error("Expected valid for non-empty string")
+		}
+		if result.String != "test" {
+			t.Errorf("Expected 'test', got '%s'", result.String)
+		}
+	})
+}

--- a/platform/orchestrator/db_dynamic_policies.go
+++ b/platform/orchestrator/db_dynamic_policies.go
@@ -18,6 +18,9 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"regexp"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -447,8 +450,8 @@ func (e *DatabaseDynamicPolicyEngine) EvaluateDynamicPolicies(ctx context.Contex
 
 	// Apply policies based on tenant/client
 	tenantID := ""
-	if req.Client.ID != "" {
-		tenantID = req.Client.ID
+	if req.Client.TenantID != "" {
+		tenantID = req.Client.TenantID
 	}
 	if tenantID == "" && req.User.TenantID != "" {
 		tenantID = req.User.TenantID
@@ -470,6 +473,42 @@ func (e *DatabaseDynamicPolicyEngine) EvaluateDynamicPolicies(ctx context.Contex
 			}
 		}
 
+		// CRITICAL: Evaluate conditions BEFORE applying actions
+		// Parse conditions from policy
+		var conditions []map[string]interface{}
+		switch condRaw := policyMap["conditions"].(type) {
+		case json.RawMessage:
+			if err := json.Unmarshal(condRaw, &conditions); err != nil {
+				log.Printf("[POLICY_EVAL] Failed to parse conditions for %s: %v", name, err)
+				continue
+			}
+		case []byte:
+			if err := json.Unmarshal(condRaw, &conditions); err != nil {
+				log.Printf("[POLICY_EVAL] Failed to parse conditions for %s: %v", name, err)
+				continue
+			}
+		case []interface{}:
+			for _, c := range condRaw {
+				if cm, ok := c.(map[string]interface{}); ok {
+					conditions = append(conditions, cm)
+				}
+			}
+		}
+
+		// If policy has conditions, ALL must match (AND logic)
+		if len(conditions) > 0 {
+			allMatch := true
+			for _, cond := range conditions {
+				if !e.evaluateCondition(cond, req) {
+					allMatch = false
+					break
+				}
+			}
+			if !allMatch {
+				continue // Skip this policy - conditions don't match
+			}
+		}
+
 		// Apply rate limiting if present
 		if rules, ok := policyMap["rules"].(map[string]interface{}); ok {
 			// Check for required actions
@@ -485,6 +524,91 @@ func (e *DatabaseDynamicPolicyEngine) EvaluateDynamicPolicies(ctx context.Contex
 			if riskScore, ok := rules["risk_score"].(float64); ok {
 				if riskScore > result.RiskScore {
 					result.RiskScore = riskScore
+				}
+			}
+		}
+
+		// Apply actions from the new JSON format (Issue #883 - strict provider enforcement)
+		// Actions may be stored as json.RawMessage ([]byte), so we need to parse it first
+		var actions []interface{}
+		switch actionsRaw := policyMap["actions"].(type) {
+		case json.RawMessage:
+			if err := json.Unmarshal(actionsRaw, &actions); err != nil {
+				log.Printf("[POLICY_ROUTE] Failed to parse actions JSON: %v", err)
+			}
+		case []byte:
+			if err := json.Unmarshal(actionsRaw, &actions); err != nil {
+				log.Printf("[POLICY_ROUTE] Failed to parse actions bytes: %v", err)
+			}
+		case []interface{}:
+			actions = actionsRaw
+		}
+
+		for _, action := range actions {
+			actionMap, ok := action.(map[string]interface{})
+			if !ok {
+				continue
+			}
+
+			actionType, _ := actionMap["type"].(string)
+			actionConfig, _ := actionMap["config"].(map[string]interface{})
+
+			switch actionType {
+			case "route":
+				// Handle LLM routing override for compliance
+				if preferred, ok := actionConfig["preferred_provider"].(string); ok && preferred != "" {
+					result.PreferredProvider = preferred
+				}
+				if reason, ok := actionConfig["reason"].(string); ok {
+					result.RoutingReason = reason
+				}
+				// Handle allowed_providers for strict compliance
+				// Use INTERSECTION logic: if multiple policies specify allowed_providers,
+				// only providers in ALL lists are allowed (most restrictive wins)
+				if allowedRaw, ok := actionConfig["allowed_providers"]; ok {
+					var policyAllowed []string
+					switch v := allowedRaw.(type) {
+					case []interface{}:
+						for _, p := range v {
+							if ps, ok := p.(string); ok {
+								policyAllowed = append(policyAllowed, ps)
+							}
+						}
+					case []string:
+						policyAllowed = v
+					}
+
+					if len(policyAllowed) > 0 {
+						if len(result.AllowedProviders) == 0 {
+							// First policy with allowed_providers - set the initial list
+							result.AllowedProviders = policyAllowed
+						} else {
+							// Compute intersection with existing allowed list
+							intersection := make([]string, 0)
+							for _, p := range result.AllowedProviders {
+								for _, ap := range policyAllowed {
+									if p == ap {
+										intersection = append(intersection, p)
+										break
+									}
+								}
+							}
+							result.AllowedProviders = intersection
+						}
+					}
+				}
+				log.Printf("[POLICY_ROUTE] Applied routing: preferred=%s, allowed=%v, reason=%s",
+					result.PreferredProvider, result.AllowedProviders, result.RoutingReason)
+
+			case "block":
+				result.Allowed = false
+				if reason, ok := actionConfig["reason"].(string); ok {
+					result.RequiredActions = append(result.RequiredActions, "blocked: "+reason)
+				}
+
+			case "modify_risk":
+				if add, ok := actionConfig["add"].(float64); ok {
+					result.RiskScore += add
 				}
 			}
 		}
@@ -510,6 +634,234 @@ func (e *DatabaseDynamicPolicyEngine) EvaluateDynamicPolicies(ctx context.Contex
 		time.Since(startTime), len(result.AppliedPolicies), time.Since(lastRefresh))
 
 	return result
+}
+
+// evaluateCondition checks if a single condition matches the request.
+// Supports operators: equals, not_equals, contains, not_contains, contains_any, regex, greater_than, less_than, in, not_in
+func (e *DatabaseDynamicPolicyEngine) evaluateCondition(cond map[string]interface{}, req OrchestratorRequest) bool {
+	field, _ := cond["field"].(string)
+	operator, _ := cond["operator"].(string)
+	value := cond["value"]
+
+	// Get the field value from the request
+	fieldValue := e.getFieldValue(field, req)
+
+	switch operator {
+	case "equals":
+		return fmt.Sprintf("%v", fieldValue) == fmt.Sprintf("%v", value)
+
+	case "not_equals":
+		return fmt.Sprintf("%v", fieldValue) != fmt.Sprintf("%v", value)
+
+	case "contains":
+		fieldStr, ok := fieldValue.(string)
+		if !ok {
+			fieldStr = fmt.Sprintf("%v", fieldValue)
+		}
+		valueStr, ok := value.(string)
+		if !ok {
+			valueStr = fmt.Sprintf("%v", value)
+		}
+		return strings.Contains(strings.ToLower(fieldStr), strings.ToLower(valueStr))
+
+	case "not_contains":
+		fieldStr, ok := fieldValue.(string)
+		if !ok {
+			fieldStr = fmt.Sprintf("%v", fieldValue)
+		}
+		valueStr, ok := value.(string)
+		if !ok {
+			valueStr = fmt.Sprintf("%v", value)
+		}
+		return !strings.Contains(strings.ToLower(fieldStr), strings.ToLower(valueStr))
+
+	case "contains_any":
+		fieldStr, ok := fieldValue.(string)
+		if !ok {
+			fieldStr = fmt.Sprintf("%v", fieldValue)
+		}
+		fieldLower := strings.ToLower(fieldStr)
+		// Value should be an array of strings
+		switch v := value.(type) {
+		case []interface{}:
+			for _, item := range v {
+				if itemStr, ok := item.(string); ok {
+					if strings.Contains(fieldLower, strings.ToLower(itemStr)) {
+						return true
+					}
+				}
+			}
+		case []string:
+			for _, item := range v {
+				if strings.Contains(fieldLower, strings.ToLower(item)) {
+					return true
+				}
+			}
+		}
+		return false
+
+	case "regex":
+		fieldStr, ok := fieldValue.(string)
+		if !ok {
+			fieldStr = fmt.Sprintf("%v", fieldValue)
+		}
+		pattern, ok := value.(string)
+		if !ok {
+			return false
+		}
+		matched, err := regexp.MatchString(pattern, fieldStr)
+		if err != nil {
+			log.Printf("[POLICY_EVAL] Regex error for pattern %s: %v", pattern, err)
+			return false
+		}
+		return matched
+
+	case "greater_than":
+		fieldFloat := e.toFloat64(fieldValue)
+		valueFloat := e.toFloat64(value)
+		return fieldFloat > valueFloat
+
+	case "less_than":
+		fieldFloat := e.toFloat64(fieldValue)
+		valueFloat := e.toFloat64(value)
+		return fieldFloat < valueFloat
+
+	case "in":
+		fieldStr := fmt.Sprintf("%v", fieldValue)
+		switch v := value.(type) {
+		case []interface{}:
+			for _, item := range v {
+				if fmt.Sprintf("%v", item) == fieldStr {
+					return true
+				}
+			}
+		case []string:
+			for _, item := range v {
+				if item == fieldStr {
+					return true
+				}
+			}
+		}
+		return false
+
+	case "not_in":
+		fieldStr := fmt.Sprintf("%v", fieldValue)
+		switch v := value.(type) {
+		case []interface{}:
+			for _, item := range v {
+				if fmt.Sprintf("%v", item) == fieldStr {
+					return false
+				}
+			}
+		case []string:
+			for _, item := range v {
+				if item == fieldStr {
+					return false
+				}
+			}
+		}
+		return true
+
+	default:
+		log.Printf("[POLICY_EVAL] Unknown operator: %s", operator)
+		return false
+	}
+}
+
+// getFieldValue extracts the value of a field from the request.
+// Supports dotted notation like "user.role" or "client.tenant_id"
+func (e *DatabaseDynamicPolicyEngine) getFieldValue(field string, req OrchestratorRequest) interface{} {
+	switch field {
+	// Top-level fields
+	case "query":
+		return req.Query
+	case "request_type":
+		return req.RequestType
+	case "request_id":
+		return req.RequestID
+
+	// User fields
+	case "user.id", "user_id":
+		return req.User.ID
+	case "user.email", "user_email":
+		return req.User.Email
+	case "user.role", "user_role":
+		return req.User.Role
+	case "user.region", "user_region", "region":
+		return req.User.Region
+	case "user.tenant_id":
+		return req.User.TenantID
+
+	// Client fields
+	case "client.id", "client_id", "agent_id":
+		return req.Client.ID
+	case "client.org_id", "org_id":
+		return req.Client.OrgID
+	case "client.tenant_id", "tenant_id":
+		return req.Client.TenantID
+
+	// Context fields (from map)
+	case "environment", "env":
+		if req.Context != nil {
+			if env, ok := req.Context["environment"].(string); ok {
+				return env
+			}
+		}
+		// Also check environment variable
+		return os.Getenv("ENVIRONMENT")
+
+	case "risk_score":
+		if req.Context != nil {
+			if rs, ok := req.Context["risk_score"].(float64); ok {
+				return rs
+			}
+		}
+		return 0.0
+
+	case "cost_estimate":
+		if req.Context != nil {
+			if ce, ok := req.Context["cost_estimate"].(float64); ok {
+				return ce
+			}
+		}
+		return 0.0
+
+	default:
+		// Try to get from context map for custom fields
+		if req.Context != nil {
+			// Handle dotted notation like "user.access_pattern"
+			parts := strings.Split(field, ".")
+			if len(parts) == 2 && parts[0] == "context" {
+				if val, ok := req.Context[parts[1]]; ok {
+					return val
+				}
+			}
+			// Direct lookup
+			if val, ok := req.Context[field]; ok {
+				return val
+			}
+		}
+		return nil
+	}
+}
+
+// toFloat64 converts various types to float64 for numeric comparisons
+func (e *DatabaseDynamicPolicyEngine) toFloat64(v interface{}) float64 {
+	switch val := v.(type) {
+	case float64:
+		return val
+	case float32:
+		return float64(val)
+	case int:
+		return float64(val)
+	case int64:
+		return float64(val)
+	case string:
+		f, _ := strconv.ParseFloat(val, 64)
+		return f
+	default:
+		return 0
+	}
 }
 
 func (e *DatabaseDynamicPolicyEngine) ListActivePolicies() []DynamicPolicy {

--- a/platform/orchestrator/db_dynamic_policies_test.go
+++ b/platform/orchestrator/db_dynamic_policies_test.go
@@ -476,7 +476,7 @@ func TestEvaluateDynamicPolicies(t *testing.T) {
 					WillReturnResult(sqlmock.NewResult(1, 1))
 			},
 			req: OrchestratorRequest{
-				Client: ClientContext{ID: "test-tenant"},
+				Client: ClientContext{ID: "test-client", TenantID: "test-tenant"},
 				Query:  "test query",
 			},
 			expectedAllowed:  true,
@@ -502,7 +502,7 @@ func TestEvaluateDynamicPolicies(t *testing.T) {
 					WillReturnResult(sqlmock.NewResult(1, 1))
 			},
 			req: OrchestratorRequest{
-				Client: ClientContext{ID: "any-tenant"},
+				Client: ClientContext{ID: "any-client", TenantID: "any-tenant"},
 				Query:  "test query",
 			},
 			expectedAllowed:  true,
@@ -555,7 +555,7 @@ func TestEvaluateDynamicPolicies(t *testing.T) {
 					WillReturnResult(sqlmock.NewResult(1, 1))
 			},
 			req: OrchestratorRequest{
-				Client: ClientContext{ID: "my-tenant"},
+				Client: ClientContext{ID: "my-client", TenantID: "my-tenant"},
 				Query:  "test query",
 			},
 			expectedAllowed:  true,
@@ -941,5 +941,904 @@ func TestLoadDefaultPolicies(t *testing.T) {
 		}
 	} else {
 		t.Error("Expected default policy to be a map")
+	}
+}
+
+// =============================================================================
+// Issue #883: Tests for evaluateCondition and getFieldValue
+// =============================================================================
+
+// TestEvaluateCondition_Equals tests the equals operator
+func TestEvaluateCondition_Equals(t *testing.T) {
+	engine := &DatabaseDynamicPolicyEngine{}
+
+	tests := []struct {
+		name      string
+		condition map[string]interface{}
+		request   OrchestratorRequest
+		expected  bool
+	}{
+		{
+			name: "equals - string match",
+			condition: map[string]interface{}{
+				"field":    "user.role",
+				"operator": "equals",
+				"value":    "admin",
+			},
+			request:  OrchestratorRequest{User: UserContext{Role: "admin"}},
+			expected: true,
+		},
+		{
+			name: "equals - string no match",
+			condition: map[string]interface{}{
+				"field":    "user.role",
+				"operator": "equals",
+				"value":    "admin",
+			},
+			request:  OrchestratorRequest{User: UserContext{Role: "user"}},
+			expected: false,
+		},
+		{
+			name: "equals - region match",
+			condition: map[string]interface{}{
+				"field":    "user.region",
+				"operator": "equals",
+				"value":    "EU",
+			},
+			request:  OrchestratorRequest{User: UserContext{Region: "EU"}},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := engine.evaluateCondition(tt.condition, tt.request)
+			if result != tt.expected {
+				t.Errorf("Expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}
+
+// TestEvaluateCondition_NotEquals tests the not_equals operator
+func TestEvaluateCondition_NotEquals(t *testing.T) {
+	engine := &DatabaseDynamicPolicyEngine{}
+
+	tests := []struct {
+		name      string
+		condition map[string]interface{}
+		request   OrchestratorRequest
+		expected  bool
+	}{
+		{
+			name: "not_equals - different values",
+			condition: map[string]interface{}{
+				"field":    "user.role",
+				"operator": "not_equals",
+				"value":    "admin",
+			},
+			request:  OrchestratorRequest{User: UserContext{Role: "user"}},
+			expected: true,
+		},
+		{
+			name: "not_equals - same values",
+			condition: map[string]interface{}{
+				"field":    "user.role",
+				"operator": "not_equals",
+				"value":    "admin",
+			},
+			request:  OrchestratorRequest{User: UserContext{Role: "admin"}},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := engine.evaluateCondition(tt.condition, tt.request)
+			if result != tt.expected {
+				t.Errorf("Expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}
+
+// TestEvaluateCondition_Contains tests the contains operator
+func TestEvaluateCondition_Contains(t *testing.T) {
+	engine := &DatabaseDynamicPolicyEngine{}
+
+	tests := []struct {
+		name      string
+		condition map[string]interface{}
+		request   OrchestratorRequest
+		expected  bool
+	}{
+		{
+			name: "contains - query contains keyword",
+			condition: map[string]interface{}{
+				"field":    "query",
+				"operator": "contains",
+				"value":    "PII",
+			},
+			request:  OrchestratorRequest{Query: "Process this PII data"},
+			expected: true,
+		},
+		{
+			name: "contains - case insensitive",
+			condition: map[string]interface{}{
+				"field":    "query",
+				"operator": "contains",
+				"value":    "pii",
+			},
+			request:  OrchestratorRequest{Query: "Process this PII data"},
+			expected: true,
+		},
+		{
+			name: "contains - no match",
+			condition: map[string]interface{}{
+				"field":    "query",
+				"operator": "contains",
+				"value":    "secret",
+			},
+			request:  OrchestratorRequest{Query: "Hello world"},
+			expected: false,
+		},
+		{
+			name: "contains - client ID contains substring",
+			condition: map[string]interface{}{
+				"field":    "client.id",
+				"operator": "contains",
+				"value":    "eu-",
+			},
+			request:  OrchestratorRequest{Client: ClientContext{ID: "eu-support-agent"}},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := engine.evaluateCondition(tt.condition, tt.request)
+			if result != tt.expected {
+				t.Errorf("Expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}
+
+// TestEvaluateCondition_ContainsAny tests the contains_any operator
+func TestEvaluateCondition_ContainsAny(t *testing.T) {
+	engine := &DatabaseDynamicPolicyEngine{}
+
+	tests := []struct {
+		name      string
+		condition map[string]interface{}
+		request   OrchestratorRequest
+		expected  bool
+	}{
+		{
+			name: "contains_any - matches first item",
+			condition: map[string]interface{}{
+				"field":    "query",
+				"operator": "contains_any",
+				"value":    []interface{}{"SSN", "credit card", "password"},
+			},
+			request:  OrchestratorRequest{Query: "My SSN is 123-45-6789"},
+			expected: true,
+		},
+		{
+			name: "contains_any - matches middle item",
+			condition: map[string]interface{}{
+				"field":    "query",
+				"operator": "contains_any",
+				"value":    []interface{}{"SSN", "credit card", "password"},
+			},
+			request:  OrchestratorRequest{Query: "My credit card number is"},
+			expected: true,
+		},
+		{
+			name: "contains_any - no match",
+			condition: map[string]interface{}{
+				"field":    "query",
+				"operator": "contains_any",
+				"value":    []interface{}{"SSN", "credit card", "password"},
+			},
+			request:  OrchestratorRequest{Query: "What is the weather?"},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := engine.evaluateCondition(tt.condition, tt.request)
+			if result != tt.expected {
+				t.Errorf("Expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}
+
+// TestEvaluateCondition_Regex tests the regex operator
+func TestEvaluateCondition_Regex(t *testing.T) {
+	engine := &DatabaseDynamicPolicyEngine{}
+
+	tests := []struct {
+		name      string
+		condition map[string]interface{}
+		request   OrchestratorRequest
+		expected  bool
+	}{
+		{
+			name: "regex - SSN pattern match",
+			condition: map[string]interface{}{
+				"field":    "query",
+				"operator": "regex",
+				"value":    `\d{3}-\d{2}-\d{4}`,
+			},
+			request:  OrchestratorRequest{Query: "My SSN is 123-45-6789"},
+			expected: true,
+		},
+		{
+			name: "regex - no match",
+			condition: map[string]interface{}{
+				"field":    "query",
+				"operator": "regex",
+				"value":    `\d{3}-\d{2}-\d{4}`,
+			},
+			request:  OrchestratorRequest{Query: "Hello world"},
+			expected: false,
+		},
+		{
+			name: "regex - email pattern",
+			condition: map[string]interface{}{
+				"field":    "query",
+				"operator": "regex",
+				"value":    `[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}`,
+			},
+			request:  OrchestratorRequest{Query: "Contact me at user@example.com"},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := engine.evaluateCondition(tt.condition, tt.request)
+			if result != tt.expected {
+				t.Errorf("Expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}
+
+// TestEvaluateCondition_GreaterThan tests the greater_than operator
+func TestEvaluateCondition_GreaterThan(t *testing.T) {
+	engine := &DatabaseDynamicPolicyEngine{}
+
+	tests := []struct {
+		name      string
+		condition map[string]interface{}
+		request   OrchestratorRequest
+		expected  bool
+	}{
+		{
+			name: "greater_than - true",
+			condition: map[string]interface{}{
+				"field":    "risk_score",
+				"operator": "greater_than",
+				"value":    0.5,
+			},
+			request: OrchestratorRequest{
+				Context: map[string]interface{}{"risk_score": 0.8},
+			},
+			expected: true,
+		},
+		{
+			name: "greater_than - false",
+			condition: map[string]interface{}{
+				"field":    "risk_score",
+				"operator": "greater_than",
+				"value":    0.5,
+			},
+			request: OrchestratorRequest{
+				Context: map[string]interface{}{"risk_score": 0.3},
+			},
+			expected: false,
+		},
+		{
+			name: "greater_than - equal is false",
+			condition: map[string]interface{}{
+				"field":    "risk_score",
+				"operator": "greater_than",
+				"value":    0.5,
+			},
+			request: OrchestratorRequest{
+				Context: map[string]interface{}{"risk_score": 0.5},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := engine.evaluateCondition(tt.condition, tt.request)
+			if result != tt.expected {
+				t.Errorf("Expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}
+
+// TestEvaluateCondition_In tests the in operator
+func TestEvaluateCondition_In(t *testing.T) {
+	engine := &DatabaseDynamicPolicyEngine{}
+
+	tests := []struct {
+		name      string
+		condition map[string]interface{}
+		request   OrchestratorRequest
+		expected  bool
+	}{
+		{
+			name: "in - region in list",
+			condition: map[string]interface{}{
+				"field":    "user.region",
+				"operator": "in",
+				"value":    []interface{}{"EU", "UK", "CH"},
+			},
+			request:  OrchestratorRequest{User: UserContext{Region: "EU"}},
+			expected: true,
+		},
+		{
+			name: "in - region not in list",
+			condition: map[string]interface{}{
+				"field":    "user.region",
+				"operator": "in",
+				"value":    []interface{}{"EU", "UK", "CH"},
+			},
+			request:  OrchestratorRequest{User: UserContext{Region: "US"}},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := engine.evaluateCondition(tt.condition, tt.request)
+			if result != tt.expected {
+				t.Errorf("Expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}
+
+// TestDatabaseDynamicPolicyEngine_GetFieldValue tests field extraction from requests
+func TestDatabaseDynamicPolicyEngine_GetFieldValue(t *testing.T) {
+	engine := &DatabaseDynamicPolicyEngine{}
+
+	request := OrchestratorRequest{
+		Query:       "Test query",
+		RequestType: "chat",
+		User: UserContext{
+			ID:       1,
+			Email:    "user@example.com",
+			Role:     "admin",
+			Region:   "EU",
+			TenantID: "tenant-123",
+		},
+		Client: ClientContext{
+			ID:       "client-456",
+			OrgID:    "org-789",
+			TenantID: "tenant-123",
+		},
+		Context: map[string]interface{}{
+			"risk_score":    0.75,
+			"cost_estimate": 0.05,
+			"environment":   "production",
+		},
+	}
+
+	tests := []struct {
+		name     string
+		field    string
+		expected interface{}
+	}{
+		{"query", "query", "Test query"},
+		{"request_type", "request_type", "chat"},
+		{"user.role", "user.role", "admin"},
+		{"user.email", "user.email", "user@example.com"},
+		{"user.region", "user.region", "EU"},
+		{"user.tenant_id", "user.tenant_id", "tenant-123"},
+		{"client.id", "client.id", "client-456"},
+		{"client.org_id", "client.org_id", "org-789"},
+		{"client.tenant_id", "client.tenant_id", "tenant-123"},
+		{"risk_score", "risk_score", 0.75},
+		{"cost_estimate", "cost_estimate", 0.05},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := engine.getFieldValue(tt.field, request)
+			// For float comparison
+			if expectedFloat, ok := tt.expected.(float64); ok {
+				if resultFloat, ok := result.(float64); ok {
+					if resultFloat != expectedFloat {
+						t.Errorf("Expected %v, got %v", tt.expected, result)
+					}
+					return
+				}
+			}
+			if result != tt.expected {
+				t.Errorf("Expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}
+
+// TestEvaluateCondition_UnknownOperator tests handling of unknown operators
+func TestEvaluateCondition_UnknownOperator(t *testing.T) {
+	engine := &DatabaseDynamicPolicyEngine{}
+
+	condition := map[string]interface{}{
+		"field":    "user.role",
+		"operator": "unknown_operator",
+		"value":    "admin",
+	}
+	request := OrchestratorRequest{User: UserContext{Role: "admin"}}
+
+	result := engine.evaluateCondition(condition, request)
+	if result != false {
+		t.Error("Unknown operator should return false")
+	}
+}
+
+// TestDatabaseDynamicPolicyEngine_ToFloat64 tests conversion of various types to float64
+func TestDatabaseDynamicPolicyEngine_ToFloat64(t *testing.T) {
+	engine := &DatabaseDynamicPolicyEngine{}
+
+	tests := []struct {
+		name     string
+		input    interface{}
+		expected float64
+	}{
+		{"float64", float64(3.14), 3.14},
+		{"float32", float32(2.5), 2.5},
+		{"int", int(42), 42.0},
+		{"int64", int64(100), 100.0},
+		{"string valid", "3.14159", 3.14159},
+		{"string invalid", "not a number", 0.0},
+		{"nil", nil, 0.0},
+		{"bool", true, 0.0},
+		{"struct", struct{}{}, 0.0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := engine.toFloat64(tt.input)
+			if result != tt.expected {
+				t.Errorf("toFloat64(%v) = %v, want %v", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+// TestGetFieldValue_EdgeCases tests edge cases for field value extraction
+func TestGetFieldValue_EdgeCases(t *testing.T) {
+	engine := &DatabaseDynamicPolicyEngine{}
+
+	t.Run("request_id field", func(t *testing.T) {
+		request := OrchestratorRequest{RequestID: "req-12345"}
+		result := engine.getFieldValue("request_id", request)
+		if result != "req-12345" {
+			t.Errorf("Expected req-12345, got %v", result)
+		}
+	})
+
+	t.Run("user_id alias", func(t *testing.T) {
+		request := OrchestratorRequest{User: UserContext{ID: 456}}
+		result := engine.getFieldValue("user_id", request)
+		if result != 456 {
+			t.Errorf("Expected 456, got %v", result)
+		}
+	})
+
+	t.Run("user_email alias", func(t *testing.T) {
+		request := OrchestratorRequest{User: UserContext{Email: "test@test.com"}}
+		result := engine.getFieldValue("user_email", request)
+		if result != "test@test.com" {
+			t.Errorf("Expected test@test.com, got %v", result)
+		}
+	})
+
+	t.Run("region alias", func(t *testing.T) {
+		request := OrchestratorRequest{User: UserContext{Region: "US"}}
+		result := engine.getFieldValue("region", request)
+		if result != "US" {
+			t.Errorf("Expected US, got %v", result)
+		}
+	})
+
+	t.Run("client_id alias", func(t *testing.T) {
+		request := OrchestratorRequest{Client: ClientContext{ID: "client-789"}}
+		result := engine.getFieldValue("client_id", request)
+		if result != "client-789" {
+			t.Errorf("Expected client-789, got %v", result)
+		}
+	})
+
+	t.Run("agent_id alias", func(t *testing.T) {
+		request := OrchestratorRequest{Client: ClientContext{ID: "agent-001"}}
+		result := engine.getFieldValue("agent_id", request)
+		if result != "agent-001" {
+			t.Errorf("Expected agent-001, got %v", result)
+		}
+	})
+
+	t.Run("org_id alias", func(t *testing.T) {
+		request := OrchestratorRequest{Client: ClientContext{OrgID: "org-999"}}
+		result := engine.getFieldValue("org_id", request)
+		if result != "org-999" {
+			t.Errorf("Expected org-999, got %v", result)
+		}
+	})
+
+	t.Run("tenant_id alias", func(t *testing.T) {
+		request := OrchestratorRequest{Client: ClientContext{TenantID: "tenant-abc"}}
+		result := engine.getFieldValue("tenant_id", request)
+		if result != "tenant-abc" {
+			t.Errorf("Expected tenant-abc, got %v", result)
+		}
+	})
+
+	t.Run("environment from context", func(t *testing.T) {
+		request := OrchestratorRequest{
+			Context: map[string]interface{}{"environment": "production"},
+		}
+		result := engine.getFieldValue("environment", request)
+		if result != "production" {
+			t.Errorf("Expected production, got %v", result)
+		}
+	})
+
+	t.Run("env alias from context", func(t *testing.T) {
+		request := OrchestratorRequest{
+			Context: map[string]interface{}{"environment": "staging"},
+		}
+		result := engine.getFieldValue("env", request)
+		if result != "staging" {
+			t.Errorf("Expected staging, got %v", result)
+		}
+	})
+
+	t.Run("risk_score missing from context", func(t *testing.T) {
+		request := OrchestratorRequest{Context: map[string]interface{}{}}
+		result := engine.getFieldValue("risk_score", request)
+		if result != 0.0 {
+			t.Errorf("Expected 0.0, got %v", result)
+		}
+	})
+
+	t.Run("cost_estimate missing from context", func(t *testing.T) {
+		request := OrchestratorRequest{Context: map[string]interface{}{}}
+		result := engine.getFieldValue("cost_estimate", request)
+		if result != 0.0 {
+			t.Errorf("Expected 0.0, got %v", result)
+		}
+	})
+
+	t.Run("custom field from context", func(t *testing.T) {
+		request := OrchestratorRequest{
+			Context: map[string]interface{}{"custom_field": "custom_value"},
+		}
+		result := engine.getFieldValue("custom_field", request)
+		if result != "custom_value" {
+			t.Errorf("Expected custom_value, got %v", result)
+		}
+	})
+
+	t.Run("context.prefixed field", func(t *testing.T) {
+		request := OrchestratorRequest{
+			Context: map[string]interface{}{"nested_data": "nested_value"},
+		}
+		result := engine.getFieldValue("context.nested_data", request)
+		if result != "nested_value" {
+			t.Errorf("Expected nested_value, got %v", result)
+		}
+	})
+
+	t.Run("unknown field returns nil", func(t *testing.T) {
+		request := OrchestratorRequest{}
+		result := engine.getFieldValue("nonexistent_field", request)
+		if result != nil {
+			t.Errorf("Expected nil, got %v", result)
+		}
+	})
+
+	t.Run("nil context returns nil for custom field", func(t *testing.T) {
+		request := OrchestratorRequest{Context: nil}
+		result := engine.getFieldValue("some_custom_field", request)
+		if result != nil {
+			t.Errorf("Expected nil, got %v", result)
+		}
+	})
+}
+
+// TestEvaluateCondition_LessThan tests less_than operator
+func TestEvaluateCondition_LessThan(t *testing.T) {
+	engine := &DatabaseDynamicPolicyEngine{}
+
+	tests := []struct {
+		name      string
+		condition map[string]interface{}
+		request   OrchestratorRequest
+		expected  bool
+	}{
+		{
+			name: "less_than - true",
+			condition: map[string]interface{}{
+				"field":    "risk_score",
+				"operator": "less_than",
+				"value":    0.5,
+			},
+			request:  OrchestratorRequest{Context: map[string]interface{}{"risk_score": 0.3}},
+			expected: true,
+		},
+		{
+			name: "less_than - false",
+			condition: map[string]interface{}{
+				"field":    "risk_score",
+				"operator": "less_than",
+				"value":    0.5,
+			},
+			request:  OrchestratorRequest{Context: map[string]interface{}{"risk_score": 0.7}},
+			expected: false,
+		},
+		{
+			name: "less_than - equal is false",
+			condition: map[string]interface{}{
+				"field":    "risk_score",
+				"operator": "less_than",
+				"value":    0.5,
+			},
+			request:  OrchestratorRequest{Context: map[string]interface{}{"risk_score": 0.5}},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := engine.evaluateCondition(tt.condition, tt.request)
+			if result != tt.expected {
+				t.Errorf("Expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}
+
+// TestEvaluateCondition_NotContains tests not_contains operator
+func TestEvaluateCondition_NotContains(t *testing.T) {
+	engine := &DatabaseDynamicPolicyEngine{}
+
+	tests := []struct {
+		name      string
+		condition map[string]interface{}
+		request   OrchestratorRequest
+		expected  bool
+	}{
+		{
+			name: "not_contains - true (substring not present)",
+			condition: map[string]interface{}{
+				"field":    "query",
+				"operator": "not_contains",
+				"value":    "DROP TABLE",
+			},
+			request:  OrchestratorRequest{Query: "SELECT * FROM users"},
+			expected: true,
+		},
+		{
+			name: "not_contains - false (substring present)",
+			condition: map[string]interface{}{
+				"field":    "query",
+				"operator": "not_contains",
+				"value":    "DROP",
+			},
+			request:  OrchestratorRequest{Query: "DROP TABLE users"},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := engine.evaluateCondition(tt.condition, tt.request)
+			if result != tt.expected {
+				t.Errorf("Expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}
+
+// TestEvaluateCondition_NotIn tests not_in operator
+func TestEvaluateCondition_NotIn(t *testing.T) {
+	engine := &DatabaseDynamicPolicyEngine{}
+
+	tests := []struct {
+		name      string
+		condition map[string]interface{}
+		request   OrchestratorRequest
+		expected  bool
+	}{
+		{
+			name: "not_in - true (not in list)",
+			condition: map[string]interface{}{
+				"field":    "user.region",
+				"operator": "not_in",
+				"value":    []interface{}{"EU", "UK"},
+			},
+			request:  OrchestratorRequest{User: UserContext{Region: "US"}},
+			expected: true,
+		},
+		{
+			name: "not_in - false (in list)",
+			condition: map[string]interface{}{
+				"field":    "user.region",
+				"operator": "not_in",
+				"value":    []interface{}{"EU", "UK", "US"},
+			},
+			request:  OrchestratorRequest{User: UserContext{Region: "US"}},
+			expected: false,
+		},
+		{
+			name: "not_in - string list",
+			condition: map[string]interface{}{
+				"field":    "user.role",
+				"operator": "not_in",
+				"value":    []string{"admin", "superuser"},
+			},
+			request:  OrchestratorRequest{User: UserContext{Role: "viewer"}},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := engine.evaluateCondition(tt.condition, tt.request)
+			if result != tt.expected {
+				t.Errorf("Expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}
+
+// TestEvaluateCondition_RegexEdgeCases tests additional regex operator edge cases
+func TestEvaluateCondition_RegexEdgeCases(t *testing.T) {
+	engine := &DatabaseDynamicPolicyEngine{}
+
+	tests := []struct {
+		name      string
+		condition map[string]interface{}
+		request   OrchestratorRequest
+		expected  bool
+	}{
+		{
+			name: "regex - invalid pattern returns false",
+			condition: map[string]interface{}{
+				"field":    "query",
+				"operator": "regex",
+				"value":    "[invalid(regex",
+			},
+			request:  OrchestratorRequest{Query: "any query"},
+			expected: false,
+		},
+		{
+			name: "regex - non-string value returns false",
+			condition: map[string]interface{}{
+				"field":    "query",
+				"operator": "regex",
+				"value":    123, // not a string
+			},
+			request:  OrchestratorRequest{Query: "any query"},
+			expected: false,
+		},
+		{
+			name: "regex - non-string field value converts to string",
+			condition: map[string]interface{}{
+				"field":    "risk_score",
+				"operator": "regex",
+				"value":    "0\\.8",
+			},
+			request: OrchestratorRequest{
+				Context: map[string]interface{}{"risk_score": 0.8},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := engine.evaluateCondition(tt.condition, tt.request)
+			if result != tt.expected {
+				t.Errorf("Expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}
+
+// TestEvaluateCondition_ContainsAnyStringSlice tests contains_any with []string type
+func TestEvaluateCondition_ContainsAnyStringSlice(t *testing.T) {
+	engine := &DatabaseDynamicPolicyEngine{}
+
+	tests := []struct {
+		name      string
+		condition map[string]interface{}
+		request   OrchestratorRequest
+		expected  bool
+	}{
+		{
+			name: "contains_any - match with string slice",
+			condition: map[string]interface{}{
+				"field":    "query",
+				"operator": "contains_any",
+				"value":    []string{"drop", "delete", "truncate"},
+			},
+			request:  OrchestratorRequest{Query: "DROP TABLE users"},
+			expected: true,
+		},
+		{
+			name: "contains_any - no match with string slice",
+			condition: map[string]interface{}{
+				"field":    "query",
+				"operator": "contains_any",
+				"value":    []string{"drop", "delete"},
+			},
+			request:  OrchestratorRequest{Query: "SELECT * FROM users"},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := engine.evaluateCondition(tt.condition, tt.request)
+			if result != tt.expected {
+				t.Errorf("Expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}
+
+// TestEvaluateCondition_InOperator_StringSlice tests in operator with []string type
+func TestEvaluateCondition_InOperator_StringSlice(t *testing.T) {
+	engine := &DatabaseDynamicPolicyEngine{}
+
+	tests := []struct {
+		name      string
+		condition map[string]interface{}
+		request   OrchestratorRequest
+		expected  bool
+	}{
+		{
+			name: "in - match with string slice",
+			condition: map[string]interface{}{
+				"field":    "user.role",
+				"operator": "in",
+				"value":    []string{"admin", "operator", "viewer"},
+			},
+			request:  OrchestratorRequest{User: UserContext{Role: "admin"}},
+			expected: true,
+		},
+		{
+			name: "in - no match with string slice",
+			condition: map[string]interface{}{
+				"field":    "user.role",
+				"operator": "in",
+				"value":    []string{"admin", "operator"},
+			},
+			request:  OrchestratorRequest{User: UserContext{Role: "viewer"}},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := engine.evaluateCondition(tt.condition, tt.request)
+			if result != tt.expected {
+				t.Errorf("Expected %v, got %v", tt.expected, result)
+			}
+		})
 	}
 }

--- a/platform/orchestrator/db_policy_engine_integration_test.go
+++ b/platform/orchestrator/db_policy_engine_integration_test.go
@@ -236,9 +236,19 @@ func TestDatabaseDynamicPolicyEngine_EvaluatePolicies(t *testing.T) {
 }
 
 func TestDatabaseDynamicPolicyEngine_InvalidDBURL(t *testing.T) {
+	// Save original DATABASE_URL to restore after test (avoid polluting parallel tests)
+	originalDBURL := os.Getenv("DATABASE_URL")
+	defer func() {
+		if originalDBURL != "" {
+			_ = os.Setenv("DATABASE_URL", originalDBURL)
+		} else {
+			_ = os.Unsetenv("DATABASE_URL")
+		}
+	}()
+
 	// Test with invalid database URL - should return error
-	_ = os.Setenv("DATABASE_URL", "postgresql://invalid:invalid@nonexistent:5432/invalid")
-	defer func() { _ = os.Unsetenv("DATABASE_URL") }()
+	// Use 127.0.0.1 with invalid port to fail fast without DNS lookup
+	_ = os.Setenv("DATABASE_URL", "postgresql://invalid:invalid@127.0.0.1:59999/invalid?connect_timeout=1")
 
 	_, err := NewDatabaseDynamicPolicyEngine()
 
@@ -276,3 +286,249 @@ func TestDatabaseDynamicPolicyEngine_HealthCheck(t *testing.T) {
 		t.Error("Expected engine to be unhealthy after close")
 	}
 }
+
+func TestDatabaseDynamicPolicyEngine_EvaluatePoliciesWithConditions(t *testing.T) {
+	dbURL := os.Getenv("DATABASE_URL")
+	if dbURL == "" {
+		t.Skip("Skipping integration test - DATABASE_URL not set")
+	}
+
+	_ = os.Setenv("DATABASE_URL", dbURL)
+	defer func() { _ = os.Unsetenv("DATABASE_URL") }()
+
+	db, err := sql.Open("postgres", dbURL)
+	if err != nil {
+		t.Fatalf("Failed to connect to database: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	// Insert policy with conditions that should match
+	testPolicyName := "test_cond_policy_" + time.Now().Format("20060102150405")
+	conditions := `[{"field": "user.region", "operator": "equals", "value": "EU"}]`
+	actions := `{"require_human_review": true, "reason": "EU data protection"}`
+
+	_, err = db.Exec(`
+		INSERT INTO dynamic_policies (policy_id, name, description, policy_type, conditions, actions, tenant_id, priority, enabled)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+		ON CONFLICT (policy_id) DO NOTHING
+	`, testPolicyName, "Test Conditions Policy", "Policy with EU condition", "region_policy", conditions, actions, "global", 100, true)
+	if err != nil {
+		t.Fatalf("Failed to insert test policy: %v", err)
+	}
+	defer func() { _, _ = db.Exec("DELETE FROM dynamic_policies WHERE policy_id = $1", testPolicyName) }()
+
+	engine, err := NewDatabaseDynamicPolicyEngine()
+	if err != nil {
+		t.Fatalf("Failed to initialize DB policy engine: %v", err)
+	}
+	defer func() { _ = engine.Close() }()
+
+	// Test with EU user - should match condition
+	ctx := context.Background()
+	req := OrchestratorRequest{
+		RequestID: "test-eu-req",
+		Query:     "Show me data",
+		User: UserContext{
+			Region:   "EU",
+			TenantID: "test-tenant",
+		},
+		Client: ClientContext{
+			TenantID: "test-tenant",
+		},
+	}
+
+	result := engine.EvaluateDynamicPolicies(ctx, req)
+	if result == nil {
+		t.Fatal("Expected non-nil policy evaluation result")
+	}
+
+	// Test with non-EU user - should not match condition
+	reqUS := OrchestratorRequest{
+		RequestID: "test-us-req",
+		Query:     "Show me data",
+		User: UserContext{
+			Region:   "US",
+			TenantID: "test-tenant",
+		},
+		Client: ClientContext{
+			TenantID: "test-tenant",
+		},
+	}
+
+	resultUS := engine.EvaluateDynamicPolicies(ctx, reqUS)
+	if resultUS == nil {
+		t.Fatal("Expected non-nil policy evaluation result for US user")
+	}
+}
+
+func TestDatabaseDynamicPolicyEngine_EvaluatePoliciesWithAllowedProviders(t *testing.T) {
+	dbURL := os.Getenv("DATABASE_URL")
+	if dbURL == "" {
+		t.Skip("Skipping integration test - DATABASE_URL not set")
+	}
+
+	_ = os.Setenv("DATABASE_URL", dbURL)
+	defer func() { _ = os.Unsetenv("DATABASE_URL") }()
+
+	db, err := sql.Open("postgres", dbURL)
+	if err != nil {
+		t.Fatalf("Failed to connect to database: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	// Insert policy with allowed_providers action
+	testPolicyName := "test_providers_policy_" + time.Now().Format("20060102150405")
+	conditions := `[{"field": "user.region", "operator": "in", "value": ["EU", "UK"]}]`
+	actions := `{"allowed_providers": ["anthropic", "azure"], "reason": "EU data sovereignty"}`
+
+	_, err = db.Exec(`
+		INSERT INTO dynamic_policies (policy_id, name, description, policy_type, conditions, actions, tenant_id, priority, enabled)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+		ON CONFLICT (policy_id) DO NOTHING
+	`, testPolicyName, "Test Providers Policy", "Policy with allowed_providers", "provider_policy", conditions, actions, "global", 100, true)
+	if err != nil {
+		t.Fatalf("Failed to insert test policy: %v", err)
+	}
+	defer func() { _, _ = db.Exec("DELETE FROM dynamic_policies WHERE policy_id = $1", testPolicyName) }()
+
+	engine, err := NewDatabaseDynamicPolicyEngine()
+	if err != nil {
+		t.Fatalf("Failed to initialize DB policy engine: %v", err)
+	}
+	defer func() { _ = engine.Close() }()
+
+	ctx := context.Background()
+	req := OrchestratorRequest{
+		RequestID: "test-providers-req",
+		Query:     "Show me EU data",
+		User: UserContext{
+			Region:   "EU",
+			TenantID: "test-tenant",
+		},
+		Client: ClientContext{
+			TenantID: "test-tenant",
+		},
+	}
+
+	result := engine.EvaluateDynamicPolicies(ctx, req)
+	if result == nil {
+		t.Fatal("Expected non-nil policy evaluation result")
+	}
+
+	// Verify allowed_providers is set
+	if len(result.AllowedProviders) > 0 {
+		t.Logf("AllowedProviders set: %v", result.AllowedProviders)
+	}
+}
+
+func TestDatabaseDynamicPolicyEngine_EvaluatePoliciesWithBlockAction(t *testing.T) {
+	dbURL := os.Getenv("DATABASE_URL")
+	if dbURL == "" {
+		t.Skip("Skipping integration test - DATABASE_URL not set")
+	}
+
+	_ = os.Setenv("DATABASE_URL", dbURL)
+	defer func() { _ = os.Unsetenv("DATABASE_URL") }()
+
+	db, err := sql.Open("postgres", dbURL)
+	if err != nil {
+		t.Fatalf("Failed to connect to database: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	// Insert policy that blocks requests
+	testPolicyName := "test_block_policy_" + time.Now().Format("20060102150405")
+	conditions := `[{"field": "query", "operator": "contains", "value": "BLOCK_ME"}]`
+	actions := `{"block": true, "reason": "Test block policy"}`
+
+	_, err = db.Exec(`
+		INSERT INTO dynamic_policies (policy_id, name, description, policy_type, conditions, actions, tenant_id, priority, enabled)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+		ON CONFLICT (policy_id) DO NOTHING
+	`, testPolicyName, "Test Block Policy", "Policy that blocks", "block_policy", conditions, actions, "global", 100, true)
+	if err != nil {
+		t.Fatalf("Failed to insert test policy: %v", err)
+	}
+	defer func() { _, _ = db.Exec("DELETE FROM dynamic_policies WHERE policy_id = $1", testPolicyName) }()
+
+	engine, err := NewDatabaseDynamicPolicyEngine()
+	if err != nil {
+		t.Fatalf("Failed to initialize DB policy engine: %v", err)
+	}
+	defer func() { _ = engine.Close() }()
+
+	ctx := context.Background()
+
+	// Request that should be blocked
+	reqBlocked := OrchestratorRequest{
+		RequestID: "test-block-req",
+		Query:     "BLOCK_ME please",
+		User: UserContext{
+			TenantID: "test-tenant",
+		},
+		Client: ClientContext{
+			TenantID: "test-tenant",
+		},
+	}
+
+	resultBlocked := engine.EvaluateDynamicPolicies(ctx, reqBlocked)
+	if resultBlocked == nil {
+		t.Fatal("Expected non-nil policy evaluation result")
+	}
+
+	// Request that should be allowed
+	reqAllowed := OrchestratorRequest{
+		RequestID: "test-allow-req",
+		Query:     "Normal query",
+		User: UserContext{
+			TenantID: "test-tenant",
+		},
+		Client: ClientContext{
+			TenantID: "test-tenant",
+		},
+	}
+
+	resultAllowed := engine.EvaluateDynamicPolicies(ctx, reqAllowed)
+	if resultAllowed == nil {
+		t.Fatal("Expected non-nil policy evaluation result")
+	}
+
+	// Normal query should be allowed
+	if !resultAllowed.Allowed {
+		t.Error("Expected normal query to be allowed")
+	}
+}
+
+func TestDatabaseDynamicPolicyEngine_ListActivePolicies(t *testing.T) {
+	dbURL := os.Getenv("DATABASE_URL")
+	if dbURL == "" {
+		t.Skip("Skipping integration test - DATABASE_URL not set")
+	}
+
+	_ = os.Setenv("DATABASE_URL", dbURL)
+	defer func() { _ = os.Unsetenv("DATABASE_URL") }()
+
+	engine, err := NewDatabaseDynamicPolicyEngine()
+	if err != nil {
+		t.Fatalf("Failed to initialize DB policy engine: %v", err)
+	}
+	defer func() { _ = engine.Close() }()
+
+	policies := engine.ListActivePolicies()
+
+	// Should have at least some system policies
+	if len(policies) == 0 {
+		t.Log("No active policies found - this may be expected in a fresh database")
+	} else {
+		t.Logf("Found %d active policies", len(policies))
+
+		// Verify policy structure
+		for _, p := range policies[:min(3, len(policies))] {
+			if p.Name == "" {
+				t.Error("Policy name should not be empty")
+			}
+			t.Logf("Policy: %s (priority: %d, tenant: %s)", p.Name, p.Priority, p.TenantID)
+		}
+	}
+}
+

--- a/platform/orchestrator/dynamic_policy_engine.go
+++ b/platform/orchestrator/dynamic_policy_engine.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 	"time"
 
+	"axonflow/platform/agent"
 	"axonflow/platform/agent/sqli"
 
 	_ "github.com/lib/pq"
@@ -116,9 +117,10 @@ type PolicyAction struct {
 //   - Admin role: +0.5
 //   - SELECT * queries: +0.3
 type RiskCalculator struct {
-	sqliScanner        sqli.Scanner       // Unified SQL injection scanner from sqli package
-	sensitivePatterns  []*regexp.Regexp   // Non-SQLi sensitive data patterns (passwords, secrets)
+	sqliScanner        sqli.Scanner           // Unified SQL injection scanner from sqli package
+	sensitivePatterns  []*regexp.Regexp       // Non-SQLi sensitive data patterns (passwords, secrets)
 	riskWeights        map[string]float64
+	detectionConfig    agent.DetectionConfig  // Unified detection configuration (Issue #891)
 }
 
 // PolicyCache caches policy evaluation results to improve performance.
@@ -350,6 +352,8 @@ func (e *DynamicPolicyEngine) getFieldValue(field string, req OrchestratorReques
 				return req.User.Role
 			case "email":
 				return req.User.Email
+			case "region":
+				return req.User.Region
 			case "tenant_id":
 				return req.User.TenantID
 			case "permissions":
@@ -399,29 +403,72 @@ func (e *DynamicPolicyEngine) applyPolicyAction(ctx context.Context, action Poli
 		if modifier, ok := action.Config["modifier"].(float64); ok {
 			result.RiskScore *= modifier
 		}
+	case "route":
+		// LLM routing override for compliance (GDPR, PII, cost control)
+		fmt.Printf("!!!! ROUTE ACTION TRIGGERED !!!!\n")
+		if preferred, ok := action.Config["preferred_provider"].(string); ok && preferred != "" {
+			result.PreferredProvider = preferred
+			fmt.Printf("!!!! PREFERRED PROVIDER SET: %s !!!!\n", preferred)
+		}
+		if reason, ok := action.Config["reason"].(string); ok {
+			result.RoutingReason = reason
+		}
+		// Handle allowed_providers for strict compliance
+		// This ensures failover only happens within compliant providers
+		if allowedRaw, ok := action.Config["allowed_providers"]; ok {
+			switch v := allowedRaw.(type) {
+			case []interface{}:
+				for _, p := range v {
+					if ps, ok := p.(string); ok {
+						result.AllowedProviders = append(result.AllowedProviders, ps)
+					}
+				}
+			case []string:
+				result.AllowedProviders = append(result.AllowedProviders, v...)
+			}
+		}
+		// If no explicit allowed_providers, build from preferred + fallback
+		if len(result.AllowedProviders) == 0 {
+			if result.PreferredProvider != "" {
+				result.AllowedProviders = append(result.AllowedProviders, result.PreferredProvider)
+			}
+			if fallback, ok := action.Config["fallback_provider"].(string); ok && fallback != "" {
+				result.AllowedProviders = append(result.AllowedProviders, fallback)
+			}
+		}
+		log.Printf("[POLICY] Route action applied: preferred=%s, allowed=%v, reason=%s",
+			result.PreferredProvider, result.AllowedProviders, result.RoutingReason)
 	}
 }
 
 // getApplicablePolicies returns policies that should be evaluated for this request
 func (e *DynamicPolicyEngine) getApplicablePolicies(req OrchestratorRequest) []DynamicPolicy {
 	var applicable []DynamicPolicy
-	
+
+	// Determine effective tenant ID from User.TenantID or Client.ID (SDK uses ClientID)
+	effectiveTenantID := req.User.TenantID
+	if effectiveTenantID == "" {
+		effectiveTenantID = req.Client.ID
+	}
+
 	for _, policy := range e.policies {
 		if !policy.Enabled {
 			continue
 		}
-		
+
 		// Check tenant-specific policies
-		if policy.TenantID != "" && policy.TenantID != req.User.TenantID {
+		// Policies with empty TenantID apply to all requests (community mode)
+		// Policies with TenantID only apply if it matches User.TenantID or Client.ID
+		if policy.TenantID != "" && policy.TenantID != effectiveTenantID {
 			continue
 		}
-		
+
 		applicable = append(applicable, policy)
 	}
-	
+
 	// Sort by priority (higher priority first)
 	// Implement sorting logic here if needed
-	
+
 	return applicable
 }
 
@@ -510,6 +557,13 @@ func (e *DynamicPolicyEngine) loadPoliciesFromDB() error {
 			log.Printf("Error parsing actions for policy %s: %v", policy.ID, err)
 			continue
 		}
+		// DEBUG: Log loaded actions for route policies
+		for _, action := range policy.Actions {
+			if action.Type == "route" {
+				fmt.Printf("!!!! LOADED ROUTE POLICY: %s, action_type=%s, config=%v !!!!\n",
+					policy.Name, action.Type, action.Config)
+			}
+		}
 
 		if tenantID.Valid {
 			policy.TenantID = tenantID.String
@@ -533,6 +587,7 @@ func (e *DynamicPolicyEngine) loadPoliciesFromDB() error {
 	e.lastDBRefresh = time.Now()
 	e.policyMutex.Unlock()
 
+	fmt.Printf("!!!! XXXX DEBUG: Loaded %d policies from DB (marker to verify build) XXXX !!!!\n", policiesLoaded)
 	log.Printf("Loaded %d dynamic policies from database (+ %d defaults)", policiesLoaded, len(defaultPolicies))
 
 	// Log audit event
@@ -576,12 +631,16 @@ func (e *DynamicPolicyEngine) reloadPoliciesRoutine() {
 
 // RiskCalculator implementation
 func NewRiskCalculator() *RiskCalculator {
+	// Load unified detection configuration from environment (Issue #891)
+	detectionCfg := agent.DetectionConfigFromEnv()
+
 	return &RiskCalculator{
 		// Use unified sqli package for SQL injection detection
 		// This provides 35+ patterns with category-based severity classification
 		// and consistent detection across input and response scanning
 		sqliScanner: sqli.NewBasicScanner(),
 		// Sensitive data patterns (non-SQLi) for risk calculation
+		// TODO: Issue #891 - migrate these to database for customization
 		sensitivePatterns: []*regexp.Regexp{
 			regexp.MustCompile(`(?i)(password|secret|key|token)`),
 		},
@@ -591,6 +650,7 @@ func NewRiskCalculator() *RiskCalculator {
 			"large_result_set": 0.3,
 			"admin_query":      0.5,
 		},
+		detectionConfig: detectionCfg,
 	}
 }
 
@@ -722,4 +782,4 @@ func contains(slice interface{}, item interface{}) bool {
 		}
 	}
 	return false
-}
+}// Build marker: 1767635481

--- a/platform/orchestrator/dynamic_policy_handlers.go
+++ b/platform/orchestrator/dynamic_policy_handlers.go
@@ -1,0 +1,603 @@
+// Copyright 2025 AxonFlow
+// SPDX-License-Identifier: BUSL-1.1
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package orchestrator
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/gorilla/mux"
+)
+
+// DynamicPolicyAPIHandler handles HTTP requests for dynamic policy management.
+// This provides the /api/v1/dynamic-policies endpoints for ADR-026 Single Entry Point.
+// It delegates to the existing PolicyAPIHandler service but filters for dynamic policies.
+type DynamicPolicyAPIHandler struct {
+	service PolicyServicer
+}
+
+// NewDynamicPolicyAPIHandler creates a new dynamic policy API handler
+func NewDynamicPolicyAPIHandler(service PolicyServicer) *DynamicPolicyAPIHandler {
+	return &DynamicPolicyAPIHandler{service: service}
+}
+
+// RegisterRoutes registers dynamic policy API routes with the provided mux router
+// These routes are for /api/v1/dynamic-policies (ADR-026: Single Entry Point)
+func (h *DynamicPolicyAPIHandler) RegisterRoutes(r *mux.Router) {
+	// List and Create
+	r.HandleFunc("/api/v1/dynamic-policies", h.handleDynamicPolicies).Methods("GET", "POST", "OPTIONS")
+
+	// Import/Export
+	r.HandleFunc("/api/v1/dynamic-policies/import", h.handleImport).Methods("POST", "OPTIONS")
+	r.HandleFunc("/api/v1/dynamic-policies/export", h.handleExport).Methods("GET", "OPTIONS")
+
+	// Get effective policies
+	r.HandleFunc("/api/v1/dynamic-policies/effective", h.handleEffective).Methods("GET", "OPTIONS")
+
+	// Single policy operations (must come after specific routes)
+	r.HandleFunc("/api/v1/dynamic-policies/{id}", h.handleDynamicPolicyByID).Methods("GET", "PUT", "DELETE", "OPTIONS")
+	r.HandleFunc("/api/v1/dynamic-policies/{id}/test", h.handleTest).Methods("POST", "OPTIONS")
+	r.HandleFunc("/api/v1/dynamic-policies/{id}/versions", h.handleVersions).Methods("GET", "OPTIONS")
+
+	log.Println("[DynamicPolicyAPI] Routes registered for /api/v1/dynamic-policies")
+}
+
+// handleDynamicPolicies handles GET (list) and POST (create) for /api/v1/dynamic-policies
+func (h *DynamicPolicyAPIHandler) handleDynamicPolicies(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodOptions {
+		h.handleCORS(w, r)
+		return
+	}
+
+	tenantID := h.getTenantID(r)
+	if tenantID == "" {
+		h.writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "Missing tenant ID")
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.listDynamicPolicies(w, r, tenantID)
+	case http.MethodPost:
+		h.createDynamicPolicy(w, r, tenantID)
+	default:
+		h.writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "Method not allowed")
+	}
+}
+
+// listDynamicPolicies handles GET /api/v1/dynamic-policies
+// Filters to only return policies with category starting with "dynamic-"
+func (h *DynamicPolicyAPIHandler) listDynamicPolicies(w http.ResponseWriter, r *http.Request, tenantID string) {
+	params := ListPoliciesParams{
+		Type:     r.URL.Query().Get("type"),
+		Search:   r.URL.Query().Get("search"),
+		SortBy:   r.URL.Query().Get("sort_by"),
+		SortDir:  r.URL.Query().Get("sort_dir"),
+		Page:     1,
+		PageSize: 20,
+	}
+
+	// Always filter by dynamic category
+	// If category is provided in query, validate it starts with "dynamic-"
+	category := r.URL.Query().Get("category")
+	if category != "" {
+		if !strings.HasPrefix(category, "dynamic-") {
+			h.writeError(w, http.StatusBadRequest, "VALIDATION_ERROR", "Category must start with 'dynamic-' for this endpoint")
+			return
+		}
+		params.Category = category
+	} else {
+		// Default: return all dynamic categories
+		params.Category = "dynamic-%" // Service should handle this as LIKE pattern
+	}
+
+	if pageStr := r.URL.Query().Get("page"); pageStr != "" {
+		if page, err := strconv.Atoi(pageStr); err == nil && page > 0 {
+			params.Page = page
+		}
+	}
+
+	if pageSizeStr := r.URL.Query().Get("page_size"); pageSizeStr != "" {
+		if pageSize, err := strconv.Atoi(pageSizeStr); err == nil && pageSize > 0 && pageSize <= 100 {
+			params.PageSize = pageSize
+		}
+	}
+
+	if enabledStr := r.URL.Query().Get("enabled"); enabledStr != "" {
+		enabled := enabledStr == "true"
+		params.Enabled = &enabled
+	}
+
+	response, err := h.service.ListPolicies(r.Context(), tenantID, params)
+	if err != nil {
+		log.Printf("[DynamicPolicyAPI] ListDynamicPolicies error for tenant %s: %v", tenantID, err)
+		h.writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to list dynamic policies")
+		return
+	}
+
+	h.writeJSON(w, http.StatusOK, response)
+}
+
+// createDynamicPolicy handles POST /api/v1/dynamic-policies
+// Validates that the policy has a dynamic category
+func (h *DynamicPolicyAPIHandler) createDynamicPolicy(w http.ResponseWriter, r *http.Request, tenantID string) {
+	// Limit request body size
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodySize)
+
+	var req CreatePolicyRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		h.writeError(w, http.StatusBadRequest, "INVALID_JSON", "Invalid JSON body")
+		return
+	}
+
+	// Validate that category is a dynamic category
+	if req.Category == "" {
+		h.writeError(w, http.StatusBadRequest, "VALIDATION_ERROR", "Category is required and must start with 'dynamic-'")
+		return
+	}
+	if !strings.HasPrefix(req.Category, "dynamic-") {
+		h.writeError(w, http.StatusBadRequest, "VALIDATION_ERROR", "Category must start with 'dynamic-' (e.g., dynamic-risk, dynamic-cost)")
+		return
+	}
+
+	userID := h.getUserID(r)
+	policy, err := h.service.CreatePolicy(r.Context(), tenantID, &req, userID)
+	if err != nil {
+		if validationErr, ok := err.(*ValidationError); ok {
+			h.writeValidationError(w, validationErr.Errors)
+			return
+		}
+		if tierErr, ok := err.(*TierValidationError); ok {
+			log.Printf("[DynamicPolicyAPI] CreateDynamicPolicy tier error for tenant %s: %v", tenantID, err)
+			h.writeError(w, http.StatusForbidden, tierErr.Code, tierErr.Message)
+			return
+		}
+		log.Printf("[DynamicPolicyAPI] CreateDynamicPolicy error for tenant %s: %v", tenantID, err)
+		h.writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to create dynamic policy")
+		return
+	}
+
+	h.writeJSON(w, http.StatusCreated, PolicyResponse{Policy: policy})
+}
+
+// handleDynamicPolicyByID handles individual dynamic policy operations
+func (h *DynamicPolicyAPIHandler) handleDynamicPolicyByID(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodOptions {
+		h.handleCORS(w, r)
+		return
+	}
+
+	tenantID := h.getTenantID(r)
+	if tenantID == "" {
+		h.writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "Missing tenant ID")
+		return
+	}
+
+	// Extract policy ID from mux vars
+	vars := mux.Vars(r)
+	policyID := vars["id"]
+
+	if policyID == "" {
+		h.writeError(w, http.StatusBadRequest, "BAD_REQUEST", "Policy ID is required")
+		return
+	}
+
+	// Validate policy ID is a valid UUID format
+	if _, err := uuid.Parse(policyID); err != nil {
+		h.writeError(w, http.StatusBadRequest, "BAD_REQUEST", "Invalid policy ID format")
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getDynamicPolicy(w, r, tenantID, policyID)
+	case http.MethodPut:
+		h.updateDynamicPolicy(w, r, tenantID, policyID)
+	case http.MethodDelete:
+		h.deleteDynamicPolicy(w, r, tenantID, policyID)
+	default:
+		h.writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "Method not allowed")
+	}
+}
+
+// getDynamicPolicy handles GET /api/v1/dynamic-policies/{id}
+func (h *DynamicPolicyAPIHandler) getDynamicPolicy(w http.ResponseWriter, r *http.Request, tenantID, policyID string) {
+	policy, err := h.service.GetPolicy(r.Context(), tenantID, policyID)
+	if err != nil {
+		log.Printf("[DynamicPolicyAPI] GetDynamicPolicy error for tenant %s, policy %s: %v", tenantID, policyID, err)
+		h.writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to get dynamic policy")
+		return
+	}
+
+	if policy == nil {
+		h.writeError(w, http.StatusNotFound, "NOT_FOUND", "Dynamic policy not found")
+		return
+	}
+
+	// Verify this is actually a dynamic policy
+	if !strings.HasPrefix(policy.Category, "dynamic-") {
+		h.writeError(w, http.StatusNotFound, "NOT_FOUND", "Policy is not a dynamic policy")
+		return
+	}
+
+	h.writeJSON(w, http.StatusOK, PolicyResponse{Policy: policy})
+}
+
+// updateDynamicPolicy handles PUT /api/v1/dynamic-policies/{id}
+func (h *DynamicPolicyAPIHandler) updateDynamicPolicy(w http.ResponseWriter, r *http.Request, tenantID, policyID string) {
+	// First check that the existing policy is a dynamic policy
+	existingPolicy, err := h.service.GetPolicy(r.Context(), tenantID, policyID)
+	if err != nil {
+		log.Printf("[DynamicPolicyAPI] UpdateDynamicPolicy check error for tenant %s, policy %s: %v", tenantID, policyID, err)
+		h.writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to update dynamic policy")
+		return
+	}
+	if existingPolicy == nil {
+		h.writeError(w, http.StatusNotFound, "NOT_FOUND", "Dynamic policy not found")
+		return
+	}
+	if !strings.HasPrefix(existingPolicy.Category, "dynamic-") {
+		h.writeError(w, http.StatusNotFound, "NOT_FOUND", "Policy is not a dynamic policy")
+		return
+	}
+
+	// Limit request body size
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodySize)
+
+	var req UpdatePolicyRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		h.writeError(w, http.StatusBadRequest, "INVALID_JSON", "Invalid JSON body")
+		return
+	}
+
+	// If category is being changed, validate it's still a dynamic category
+	if req.Category != nil && !strings.HasPrefix(*req.Category, "dynamic-") {
+		h.writeError(w, http.StatusBadRequest, "VALIDATION_ERROR", "Category must start with 'dynamic-'")
+		return
+	}
+
+	userID := h.getUserID(r)
+	policy, err := h.service.UpdatePolicy(r.Context(), tenantID, policyID, &req, userID)
+	if err != nil {
+		if validationErr, ok := err.(*ValidationError); ok {
+			h.writeValidationError(w, validationErr.Errors)
+			return
+		}
+		if tierErr, ok := err.(*TierValidationError); ok {
+			log.Printf("[DynamicPolicyAPI] UpdateDynamicPolicy tier error for tenant %s, policy %s: %v", tenantID, policyID, err)
+			h.writeError(w, http.StatusForbidden, tierErr.Code, tierErr.Message)
+			return
+		}
+		log.Printf("[DynamicPolicyAPI] UpdateDynamicPolicy error for tenant %s, policy %s: %v", tenantID, policyID, err)
+		h.writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to update dynamic policy")
+		return
+	}
+
+	if policy == nil {
+		h.writeError(w, http.StatusNotFound, "NOT_FOUND", "Dynamic policy not found")
+		return
+	}
+
+	h.writeJSON(w, http.StatusOK, PolicyResponse{Policy: policy})
+}
+
+// deleteDynamicPolicy handles DELETE /api/v1/dynamic-policies/{id}
+func (h *DynamicPolicyAPIHandler) deleteDynamicPolicy(w http.ResponseWriter, r *http.Request, tenantID, policyID string) {
+	// First check that the existing policy is a dynamic policy
+	existingPolicy, err := h.service.GetPolicy(r.Context(), tenantID, policyID)
+	if err != nil {
+		log.Printf("[DynamicPolicyAPI] DeleteDynamicPolicy check error for tenant %s, policy %s: %v", tenantID, policyID, err)
+		h.writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to delete dynamic policy")
+		return
+	}
+	if existingPolicy == nil {
+		h.writeError(w, http.StatusNotFound, "NOT_FOUND", "Dynamic policy not found")
+		return
+	}
+	if !strings.HasPrefix(existingPolicy.Category, "dynamic-") {
+		h.writeError(w, http.StatusNotFound, "NOT_FOUND", "Policy is not a dynamic policy")
+		return
+	}
+
+	userID := h.getUserID(r)
+	if err := h.service.DeletePolicy(r.Context(), tenantID, policyID, userID); err != nil {
+		if tierErr, ok := err.(*TierValidationError); ok {
+			log.Printf("[DynamicPolicyAPI] DeleteDynamicPolicy tier error for tenant %s, policy %s: %v", tenantID, policyID, err)
+			h.writeError(w, http.StatusForbidden, tierErr.Code, tierErr.Message)
+			return
+		}
+		log.Printf("[DynamicPolicyAPI] DeleteDynamicPolicy error for tenant %s, policy %s: %v", tenantID, policyID, err)
+		h.writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to delete dynamic policy")
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// handleTest handles POST /api/v1/dynamic-policies/{id}/test
+func (h *DynamicPolicyAPIHandler) handleTest(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodOptions {
+		h.handleCORS(w, r)
+		return
+	}
+
+	tenantID := h.getTenantID(r)
+	if tenantID == "" {
+		h.writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "Missing tenant ID")
+		return
+	}
+
+	vars := mux.Vars(r)
+	policyID := vars["id"]
+
+	if _, err := uuid.Parse(policyID); err != nil {
+		h.writeError(w, http.StatusBadRequest, "BAD_REQUEST", "Invalid policy ID format")
+		return
+	}
+
+	// Verify this is a dynamic policy
+	policy, err := h.service.GetPolicy(r.Context(), tenantID, policyID)
+	if err != nil || policy == nil {
+		h.writeError(w, http.StatusNotFound, "NOT_FOUND", "Dynamic policy not found")
+		return
+	}
+	if !strings.HasPrefix(policy.Category, "dynamic-") {
+		h.writeError(w, http.StatusNotFound, "NOT_FOUND", "Policy is not a dynamic policy")
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodySize)
+
+	var req TestPolicyRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		h.writeError(w, http.StatusBadRequest, "INVALID_JSON", "Invalid JSON body")
+		return
+	}
+
+	if req.Query == "" {
+		h.writeError(w, http.StatusBadRequest, "VALIDATION_ERROR", "Query is required for testing")
+		return
+	}
+
+	response, err := h.service.TestPolicy(r.Context(), tenantID, policyID, &req)
+	if err != nil {
+		log.Printf("[DynamicPolicyAPI] TestPolicy error for tenant %s, policy %s: %v", tenantID, policyID, err)
+		h.writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to test dynamic policy")
+		return
+	}
+
+	h.writeJSON(w, http.StatusOK, response)
+}
+
+// handleVersions handles GET /api/v1/dynamic-policies/{id}/versions
+func (h *DynamicPolicyAPIHandler) handleVersions(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodOptions {
+		h.handleCORS(w, r)
+		return
+	}
+
+	tenantID := h.getTenantID(r)
+	if tenantID == "" {
+		h.writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "Missing tenant ID")
+		return
+	}
+
+	vars := mux.Vars(r)
+	policyID := vars["id"]
+
+	if _, err := uuid.Parse(policyID); err != nil {
+		h.writeError(w, http.StatusBadRequest, "BAD_REQUEST", "Invalid policy ID format")
+		return
+	}
+
+	// Verify this is a dynamic policy
+	policy, err := h.service.GetPolicy(r.Context(), tenantID, policyID)
+	if err != nil || policy == nil {
+		h.writeError(w, http.StatusNotFound, "NOT_FOUND", "Dynamic policy not found")
+		return
+	}
+	if !strings.HasPrefix(policy.Category, "dynamic-") {
+		h.writeError(w, http.StatusNotFound, "NOT_FOUND", "Policy is not a dynamic policy")
+		return
+	}
+
+	response, err := h.service.GetPolicyVersions(r.Context(), tenantID, policyID)
+	if err != nil {
+		log.Printf("[DynamicPolicyAPI] GetPolicyVersions error for tenant %s, policy %s: %v", tenantID, policyID, err)
+		h.writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to get policy versions")
+		return
+	}
+
+	h.writeJSON(w, http.StatusOK, response)
+}
+
+// handleImport handles POST /api/v1/dynamic-policies/import
+func (h *DynamicPolicyAPIHandler) handleImport(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodOptions {
+		h.handleCORS(w, r)
+		return
+	}
+
+	tenantID := h.getTenantID(r)
+	if tenantID == "" {
+		h.writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "Missing tenant ID")
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxImportBodySize)
+
+	var req ImportPoliciesRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		h.writeError(w, http.StatusBadRequest, "INVALID_JSON", "Invalid JSON body")
+		return
+	}
+
+	if len(req.Policies) == 0 {
+		h.writeError(w, http.StatusBadRequest, "VALIDATION_ERROR", "At least one policy is required")
+		return
+	}
+
+	if len(req.Policies) > 100 {
+		h.writeError(w, http.StatusBadRequest, "VALIDATION_ERROR", "Maximum 100 policies per import")
+		return
+	}
+
+	// Validate all policies have dynamic categories
+	for i, policy := range req.Policies {
+		if !strings.HasPrefix(policy.Category, "dynamic-") {
+			h.writeError(w, http.StatusBadRequest, "VALIDATION_ERROR",
+				"Policy at index "+strconv.Itoa(i)+" has invalid category: must start with 'dynamic-'")
+			return
+		}
+	}
+
+	userID := h.getUserID(r)
+	response, err := h.service.ImportPolicies(r.Context(), tenantID, &req, userID)
+	if err != nil {
+		if validationErr, ok := err.(*ValidationError); ok {
+			h.writeValidationError(w, validationErr.Errors)
+			return
+		}
+		log.Printf("[DynamicPolicyAPI] ImportPolicies error for tenant %s: %v", tenantID, err)
+		h.writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to import dynamic policies")
+		return
+	}
+
+	h.writeJSON(w, http.StatusOK, response)
+}
+
+// handleExport handles GET /api/v1/dynamic-policies/export
+func (h *DynamicPolicyAPIHandler) handleExport(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodOptions {
+		h.handleCORS(w, r)
+		return
+	}
+
+	tenantID := h.getTenantID(r)
+	if tenantID == "" {
+		h.writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "Missing tenant ID")
+		return
+	}
+
+	// Export only dynamic policies - the service will need to filter
+	// For now, we'll get all and filter client-side (or update service to accept category filter)
+	response, err := h.service.ExportPolicies(r.Context(), tenantID)
+	if err != nil {
+		log.Printf("[DynamicPolicyAPI] ExportPolicies error for tenant %s: %v", tenantID, err)
+		h.writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to export dynamic policies")
+		return
+	}
+
+	// Filter to only include dynamic policies in the export
+	if response != nil {
+		filtered := make([]PolicyResource, 0)
+		for _, p := range response.Policies {
+			if strings.HasPrefix(p.Category, "dynamic-") {
+				filtered = append(filtered, p)
+			}
+		}
+		response.Policies = filtered
+	}
+
+	h.writeJSON(w, http.StatusOK, response)
+}
+
+// handleEffective handles GET /api/v1/dynamic-policies/effective
+func (h *DynamicPolicyAPIHandler) handleEffective(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodOptions {
+		h.handleCORS(w, r)
+		return
+	}
+
+	tenantID := h.getTenantID(r)
+	if tenantID == "" {
+		h.writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "Missing tenant ID")
+		return
+	}
+
+	// Get effective policies (enabled, sorted by priority)
+	params := ListPoliciesParams{
+		Category: "dynamic-%",
+		Page:     1,
+		PageSize: 100, // Return all effective policies
+		SortBy:   "priority",
+		SortDir:  "asc",
+	}
+	enabled := true
+	params.Enabled = &enabled
+
+	response, err := h.service.ListPolicies(r.Context(), tenantID, params)
+	if err != nil {
+		log.Printf("[DynamicPolicyAPI] GetEffectivePolicies error for tenant %s: %v", tenantID, err)
+		h.writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to get effective dynamic policies")
+		return
+	}
+
+	h.writeJSON(w, http.StatusOK, response)
+}
+
+// Helper methods (same pattern as PolicyAPIHandler)
+
+func (h *DynamicPolicyAPIHandler) getTenantID(r *http.Request) string {
+	// Check X-Tenant-ID header first
+	if tenantID := r.Header.Get("X-Tenant-ID"); tenantID != "" {
+		return tenantID
+	}
+	// Fallback to X-Org-ID for backward compatibility
+	return r.Header.Get("X-Org-ID")
+}
+
+func (h *DynamicPolicyAPIHandler) getUserID(r *http.Request) string {
+	return r.Header.Get("X-User-ID")
+}
+
+func (h *DynamicPolicyAPIHandler) writeJSON(w http.ResponseWriter, status int, data interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(data); err != nil {
+		log.Printf("[DynamicPolicyAPI] Error encoding JSON response: %v", err)
+	}
+}
+
+func (h *DynamicPolicyAPIHandler) writeError(w http.ResponseWriter, status int, code, message string) {
+	h.writeJSON(w, status, map[string]interface{}{
+		"error": map[string]string{
+			"code":    code,
+			"message": message,
+		},
+	})
+}
+
+func (h *DynamicPolicyAPIHandler) writeValidationError(w http.ResponseWriter, errors []PolicyFieldError) {
+	h.writeJSON(w, http.StatusBadRequest, map[string]interface{}{
+		"error": map[string]interface{}{
+			"code":    "VALIDATION_ERROR",
+			"message": "Validation failed",
+			"fields":  errors,
+		},
+	})
+}
+
+func (h *DynamicPolicyAPIHandler) handleCORS(w http.ResponseWriter, r *http.Request) {
+	origin := r.Header.Get("Origin")
+	if origin != "" && allowedOrigins[origin] {
+		w.Header().Set("Access-Control-Allow-Origin", origin)
+	}
+	w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Tenant-ID, X-User-ID, X-Org-ID")
+	w.Header().Set("Access-Control-Max-Age", "86400")
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/platform/orchestrator/dynamic_policy_handlers_test.go
+++ b/platform/orchestrator/dynamic_policy_handlers_test.go
@@ -1,0 +1,1673 @@
+// Copyright 2025 AxonFlow
+// SPDX-License-Identifier: BUSL-1.1
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package orchestrator
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/gorilla/mux"
+)
+
+// mockDynamicPolicyService implements PolicyServicer for testing
+type mockDynamicPolicyService struct {
+	listFunc     func(ctx context.Context, tenantID string, params ListPoliciesParams) (*PoliciesListResponse, error)
+	getFunc      func(ctx context.Context, tenantID, policyID string) (*PolicyResource, error)
+	createFunc   func(ctx context.Context, tenantID string, req *CreatePolicyRequest, userID string) (*PolicyResource, error)
+	updateFunc   func(ctx context.Context, tenantID, policyID string, req *UpdatePolicyRequest, userID string) (*PolicyResource, error)
+	deleteFunc   func(ctx context.Context, tenantID, policyID, userID string) error
+	testFunc     func(ctx context.Context, tenantID, policyID string, req *TestPolicyRequest) (*TestPolicyResponse, error)
+	versionsFunc func(ctx context.Context, tenantID, policyID string) (*PolicyVersionResponse, error)
+	importFunc   func(ctx context.Context, tenantID string, req *ImportPoliciesRequest, userID string) (*ImportPoliciesResponse, error)
+	exportFunc   func(ctx context.Context, tenantID string) (*ExportPoliciesResponse, error)
+}
+
+func (m *mockDynamicPolicyService) ListPolicies(ctx context.Context, tenantID string, params ListPoliciesParams) (*PoliciesListResponse, error) {
+	if m.listFunc != nil {
+		return m.listFunc(ctx, tenantID, params)
+	}
+	return &PoliciesListResponse{}, nil
+}
+
+func (m *mockDynamicPolicyService) GetPolicy(ctx context.Context, tenantID, policyID string) (*PolicyResource, error) {
+	if m.getFunc != nil {
+		return m.getFunc(ctx, tenantID, policyID)
+	}
+	return nil, nil
+}
+
+func (m *mockDynamicPolicyService) CreatePolicy(ctx context.Context, tenantID string, req *CreatePolicyRequest, userID string) (*PolicyResource, error) {
+	if m.createFunc != nil {
+		return m.createFunc(ctx, tenantID, req, userID)
+	}
+	return nil, nil
+}
+
+func (m *mockDynamicPolicyService) UpdatePolicy(ctx context.Context, tenantID, policyID string, req *UpdatePolicyRequest, userID string) (*PolicyResource, error) {
+	if m.updateFunc != nil {
+		return m.updateFunc(ctx, tenantID, policyID, req, userID)
+	}
+	return nil, nil
+}
+
+func (m *mockDynamicPolicyService) DeletePolicy(ctx context.Context, tenantID, policyID, userID string) error {
+	if m.deleteFunc != nil {
+		return m.deleteFunc(ctx, tenantID, policyID, userID)
+	}
+	return nil
+}
+
+func (m *mockDynamicPolicyService) TestPolicy(ctx context.Context, tenantID, policyID string, req *TestPolicyRequest) (*TestPolicyResponse, error) {
+	if m.testFunc != nil {
+		return m.testFunc(ctx, tenantID, policyID, req)
+	}
+	return nil, nil
+}
+
+func (m *mockDynamicPolicyService) GetPolicyVersions(ctx context.Context, tenantID, policyID string) (*PolicyVersionResponse, error) {
+	if m.versionsFunc != nil {
+		return m.versionsFunc(ctx, tenantID, policyID)
+	}
+	return nil, nil
+}
+
+func (m *mockDynamicPolicyService) ImportPolicies(ctx context.Context, tenantID string, req *ImportPoliciesRequest, userID string) (*ImportPoliciesResponse, error) {
+	if m.importFunc != nil {
+		return m.importFunc(ctx, tenantID, req, userID)
+	}
+	return nil, nil
+}
+
+func (m *mockDynamicPolicyService) ExportPolicies(ctx context.Context, tenantID string) (*ExportPoliciesResponse, error) {
+	if m.exportFunc != nil {
+		return m.exportFunc(ctx, tenantID)
+	}
+	return nil, nil
+}
+
+func TestDynamicPolicyAPI_ListDynamicPolicies(t *testing.T) {
+	mockService := &mockDynamicPolicyService{
+		listFunc: func(ctx context.Context, tenantID string, params ListPoliciesParams) (*PoliciesListResponse, error) {
+			// Verify category filter is applied
+			if params.Category != "dynamic-%" {
+				t.Errorf("Expected category filter 'dynamic-%%', got '%s'", params.Category)
+			}
+			return &PoliciesListResponse{
+				Policies: []PolicyResource{
+					{
+						ID:       uuid.New().String(),
+						Name:     "Cost Limit Policy",
+						Category: "dynamic-cost",
+						Type:     "cost",
+						Enabled:  true,
+					},
+				},
+				Pagination: PaginationMeta{Page: 1, PageSize: 20, TotalItems: 1, TotalPages: 1},
+			}, nil
+		},
+	}
+
+	handler := NewDynamicPolicyAPIHandler(mockService)
+	r := mux.NewRouter()
+	handler.RegisterRoutes(r)
+
+	req := httptest.NewRequest("GET", "/api/v1/dynamic-policies", nil)
+	req.Header.Set("X-Tenant-ID", "test-tenant")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", w.Code)
+	}
+
+	var resp PoliciesListResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("Failed to unmarshal response: %v", err)
+	}
+
+	if len(resp.Policies) != 1 {
+		t.Errorf("Expected 1 policy, got %d", len(resp.Policies))
+	}
+}
+
+func TestDynamicPolicyAPI_ListDynamicPolicies_MissingTenantID(t *testing.T) {
+	handler := NewDynamicPolicyAPIHandler(&mockDynamicPolicyService{})
+	r := mux.NewRouter()
+	handler.RegisterRoutes(r)
+
+	req := httptest.NewRequest("GET", "/api/v1/dynamic-policies", nil)
+	// No X-Tenant-ID header
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("Expected status 401, got %d", w.Code)
+	}
+}
+
+func TestDynamicPolicyAPI_CreateDynamicPolicy(t *testing.T) {
+	policyID := uuid.New().String()
+	mockService := &mockDynamicPolicyService{
+		createFunc: func(ctx context.Context, tenantID string, req *CreatePolicyRequest, userID string) (*PolicyResource, error) {
+			return &PolicyResource{
+				ID:        policyID,
+				Name:      req.Name,
+				Category:  req.Category,
+				Type:      req.Type,
+				Enabled:   req.Enabled,
+				CreatedAt: time.Now(),
+			}, nil
+		},
+	}
+
+	handler := NewDynamicPolicyAPIHandler(mockService)
+	r := mux.NewRouter()
+	handler.RegisterRoutes(r)
+
+	body := `{"name":"Cost Limit Policy","category":"dynamic-cost","type":"cost","conditions":[],"actions":[],"priority":100,"enabled":true}`
+	req := httptest.NewRequest("POST", "/api/v1/dynamic-policies", bytes.NewBufferString(body))
+	req.Header.Set("X-Tenant-ID", "test-tenant")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Errorf("Expected status 201, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestDynamicPolicyAPI_CreateDynamicPolicy_InvalidCategory(t *testing.T) {
+	handler := NewDynamicPolicyAPIHandler(&mockDynamicPolicyService{})
+	r := mux.NewRouter()
+	handler.RegisterRoutes(r)
+
+	// Try to create with non-dynamic category
+	body := `{"name":"Static Policy","category":"pii","type":"content","conditions":[],"actions":[],"priority":100,"enabled":true}`
+	req := httptest.NewRequest("POST", "/api/v1/dynamic-policies", bytes.NewBufferString(body))
+	req.Header.Set("X-Tenant-ID", "test-tenant")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("Expected status 400, got %d", w.Code)
+	}
+}
+
+func TestDynamicPolicyAPI_CreateDynamicPolicy_MissingCategory(t *testing.T) {
+	handler := NewDynamicPolicyAPIHandler(&mockDynamicPolicyService{})
+	r := mux.NewRouter()
+	handler.RegisterRoutes(r)
+
+	// Try to create without category
+	body := `{"name":"Policy Without Category","type":"cost","conditions":[],"actions":[],"priority":100,"enabled":true}`
+	req := httptest.NewRequest("POST", "/api/v1/dynamic-policies", bytes.NewBufferString(body))
+	req.Header.Set("X-Tenant-ID", "test-tenant")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("Expected status 400, got %d", w.Code)
+	}
+}
+
+func TestDynamicPolicyAPI_GetDynamicPolicy(t *testing.T) {
+	policyID := uuid.New().String()
+	mockService := &mockDynamicPolicyService{
+		getFunc: func(ctx context.Context, tenantID, id string) (*PolicyResource, error) {
+			return &PolicyResource{
+				ID:       policyID,
+				Name:     "Dynamic Risk Policy",
+				Category: "dynamic-risk",
+				Type:     "risk",
+				Enabled:  true,
+			}, nil
+		},
+	}
+
+	handler := NewDynamicPolicyAPIHandler(mockService)
+	r := mux.NewRouter()
+	handler.RegisterRoutes(r)
+
+	req := httptest.NewRequest("GET", "/api/v1/dynamic-policies/"+policyID, nil)
+	req.Header.Set("X-Tenant-ID", "test-tenant")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", w.Code)
+	}
+}
+
+func TestDynamicPolicyAPI_GetDynamicPolicy_NotDynamic(t *testing.T) {
+	policyID := uuid.New().String()
+	mockService := &mockDynamicPolicyService{
+		getFunc: func(ctx context.Context, tenantID, id string) (*PolicyResource, error) {
+			// Return a non-dynamic policy
+			return &PolicyResource{
+				ID:       policyID,
+				Name:     "Static PII Policy",
+				Category: "pii", // Not a dynamic category
+				Type:     "content",
+				Enabled:  true,
+			}, nil
+		},
+	}
+
+	handler := NewDynamicPolicyAPIHandler(mockService)
+	r := mux.NewRouter()
+	handler.RegisterRoutes(r)
+
+	req := httptest.NewRequest("GET", "/api/v1/dynamic-policies/"+policyID, nil)
+	req.Header.Set("X-Tenant-ID", "test-tenant")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("Expected status 404, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestDynamicPolicyAPI_GetDynamicPolicy_NotFound(t *testing.T) {
+	mockService := &mockDynamicPolicyService{
+		getFunc: func(ctx context.Context, tenantID, id string) (*PolicyResource, error) {
+			return nil, nil
+		},
+	}
+
+	handler := NewDynamicPolicyAPIHandler(mockService)
+	r := mux.NewRouter()
+	handler.RegisterRoutes(r)
+
+	policyID := uuid.New().String()
+	req := httptest.NewRequest("GET", "/api/v1/dynamic-policies/"+policyID, nil)
+	req.Header.Set("X-Tenant-ID", "test-tenant")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("Expected status 404, got %d", w.Code)
+	}
+}
+
+func TestDynamicPolicyAPI_GetDynamicPolicy_InvalidID(t *testing.T) {
+	handler := NewDynamicPolicyAPIHandler(&mockDynamicPolicyService{})
+	r := mux.NewRouter()
+	handler.RegisterRoutes(r)
+
+	req := httptest.NewRequest("GET", "/api/v1/dynamic-policies/not-a-uuid", nil)
+	req.Header.Set("X-Tenant-ID", "test-tenant")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("Expected status 400, got %d", w.Code)
+	}
+}
+
+func TestDynamicPolicyAPI_UpdateDynamicPolicy(t *testing.T) {
+	policyID := uuid.New().String()
+	mockService := &mockDynamicPolicyService{
+		getFunc: func(ctx context.Context, tenantID, id string) (*PolicyResource, error) {
+			return &PolicyResource{
+				ID:       policyID,
+				Name:     "Original Name",
+				Category: "dynamic-cost",
+				Type:     "cost",
+				Enabled:  true,
+			}, nil
+		},
+		updateFunc: func(ctx context.Context, tenantID, id string, req *UpdatePolicyRequest, userID string) (*PolicyResource, error) {
+			return &PolicyResource{
+				ID:        policyID,
+				Name:      *req.Name,
+				Category:  "dynamic-cost",
+				Type:      "cost",
+				Enabled:   true,
+				UpdatedAt: time.Now(),
+			}, nil
+		},
+	}
+
+	handler := NewDynamicPolicyAPIHandler(mockService)
+	r := mux.NewRouter()
+	handler.RegisterRoutes(r)
+
+	body := `{"name":"Updated Name"}`
+	req := httptest.NewRequest("PUT", "/api/v1/dynamic-policies/"+policyID, bytes.NewBufferString(body))
+	req.Header.Set("X-Tenant-ID", "test-tenant")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestDynamicPolicyAPI_UpdateDynamicPolicy_InvalidCategory(t *testing.T) {
+	policyID := uuid.New().String()
+	mockService := &mockDynamicPolicyService{
+		getFunc: func(ctx context.Context, tenantID, id string) (*PolicyResource, error) {
+			return &PolicyResource{
+				ID:       policyID,
+				Name:     "Dynamic Policy",
+				Category: "dynamic-cost",
+				Type:     "cost",
+				Enabled:  true,
+			}, nil
+		},
+	}
+
+	handler := NewDynamicPolicyAPIHandler(mockService)
+	r := mux.NewRouter()
+	handler.RegisterRoutes(r)
+
+	// Try to change category to non-dynamic
+	body := `{"category":"pii"}`
+	req := httptest.NewRequest("PUT", "/api/v1/dynamic-policies/"+policyID, bytes.NewBufferString(body))
+	req.Header.Set("X-Tenant-ID", "test-tenant")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("Expected status 400, got %d", w.Code)
+	}
+}
+
+func TestDynamicPolicyAPI_DeleteDynamicPolicy(t *testing.T) {
+	policyID := uuid.New().String()
+	deleted := false
+	mockService := &mockDynamicPolicyService{
+		getFunc: func(ctx context.Context, tenantID, id string) (*PolicyResource, error) {
+			return &PolicyResource{
+				ID:       policyID,
+				Name:     "Policy To Delete",
+				Category: "dynamic-risk",
+				Type:     "risk",
+				Enabled:  true,
+			}, nil
+		},
+		deleteFunc: func(ctx context.Context, tenantID, id, userID string) error {
+			deleted = true
+			return nil
+		},
+	}
+
+	handler := NewDynamicPolicyAPIHandler(mockService)
+	r := mux.NewRouter()
+	handler.RegisterRoutes(r)
+
+	req := httptest.NewRequest("DELETE", "/api/v1/dynamic-policies/"+policyID, nil)
+	req.Header.Set("X-Tenant-ID", "test-tenant")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Errorf("Expected status 204, got %d", w.Code)
+	}
+
+	if !deleted {
+		t.Error("Delete function was not called")
+	}
+}
+
+func TestDynamicPolicyAPI_Import(t *testing.T) {
+	mockService := &mockDynamicPolicyService{
+		importFunc: func(ctx context.Context, tenantID string, req *ImportPoliciesRequest, userID string) (*ImportPoliciesResponse, error) {
+			return &ImportPoliciesResponse{
+				Created: len(req.Policies),
+				Skipped: 0,
+				Errors:  nil,
+			}, nil
+		},
+	}
+
+	handler := NewDynamicPolicyAPIHandler(mockService)
+	r := mux.NewRouter()
+	handler.RegisterRoutes(r)
+
+	body := `{"policies":[{"name":"Policy 1","category":"dynamic-risk","type":"risk","conditions":[],"actions":[],"priority":1,"enabled":true}]}`
+	req := httptest.NewRequest("POST", "/api/v1/dynamic-policies/import", bytes.NewBufferString(body))
+	req.Header.Set("X-Tenant-ID", "test-tenant")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestDynamicPolicyAPI_Import_InvalidCategory(t *testing.T) {
+	handler := NewDynamicPolicyAPIHandler(&mockDynamicPolicyService{})
+	r := mux.NewRouter()
+	handler.RegisterRoutes(r)
+
+	// Import with non-dynamic category
+	body := `{"policies":[{"name":"Static Policy","category":"pii","type":"content","conditions":[],"actions":[],"priority":1,"enabled":true}]}`
+	req := httptest.NewRequest("POST", "/api/v1/dynamic-policies/import", bytes.NewBufferString(body))
+	req.Header.Set("X-Tenant-ID", "test-tenant")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("Expected status 400, got %d", w.Code)
+	}
+}
+
+func TestDynamicPolicyAPI_Export(t *testing.T) {
+	mockService := &mockDynamicPolicyService{
+		exportFunc: func(ctx context.Context, tenantID string) (*ExportPoliciesResponse, error) {
+			return &ExportPoliciesResponse{
+				Policies: []PolicyResource{
+					{ID: uuid.New().String(), Name: "Dynamic Policy", Category: "dynamic-risk"},
+					{ID: uuid.New().String(), Name: "Static Policy", Category: "pii"}, // Should be filtered out
+				},
+			}, nil
+		},
+	}
+
+	handler := NewDynamicPolicyAPIHandler(mockService)
+	r := mux.NewRouter()
+	handler.RegisterRoutes(r)
+
+	req := httptest.NewRequest("GET", "/api/v1/dynamic-policies/export", nil)
+	req.Header.Set("X-Tenant-ID", "test-tenant")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", w.Code)
+	}
+
+	var resp ExportPoliciesResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("Failed to unmarshal response: %v", err)
+	}
+
+	// Should only have dynamic policies
+	if len(resp.Policies) != 1 {
+		t.Errorf("Expected 1 dynamic policy in export, got %d", len(resp.Policies))
+	}
+}
+
+func TestDynamicPolicyAPI_Effective(t *testing.T) {
+	mockService := &mockDynamicPolicyService{
+		listFunc: func(ctx context.Context, tenantID string, params ListPoliciesParams) (*PoliciesListResponse, error) {
+			// Verify enabled filter is applied
+			if params.Enabled == nil || !*params.Enabled {
+				t.Error("Expected enabled=true filter for effective policies")
+			}
+			if params.SortBy != "priority" {
+				t.Errorf("Expected sort by priority, got %s", params.SortBy)
+			}
+			return &PoliciesListResponse{
+				Policies: []PolicyResource{
+					{ID: uuid.New().String(), Name: "High Priority", Priority: 1, Enabled: true, Category: "dynamic-risk"},
+					{ID: uuid.New().String(), Name: "Low Priority", Priority: 100, Enabled: true, Category: "dynamic-cost"},
+				},
+				Pagination: PaginationMeta{Page: 1, PageSize: 100, TotalItems: 2, TotalPages: 1},
+			}, nil
+		},
+	}
+
+	handler := NewDynamicPolicyAPIHandler(mockService)
+	r := mux.NewRouter()
+	handler.RegisterRoutes(r)
+
+	req := httptest.NewRequest("GET", "/api/v1/dynamic-policies/effective", nil)
+	req.Header.Set("X-Tenant-ID", "test-tenant")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", w.Code)
+	}
+}
+
+func TestDynamicPolicyAPI_CORS(t *testing.T) {
+	handler := NewDynamicPolicyAPIHandler(&mockDynamicPolicyService{})
+	r := mux.NewRouter()
+	handler.RegisterRoutes(r)
+
+	req := httptest.NewRequest("OPTIONS", "/api/v1/dynamic-policies", nil)
+	req.Header.Set("Origin", "http://localhost:3000")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Errorf("Expected status 204, got %d", w.Code)
+	}
+
+	if w.Header().Get("Access-Control-Allow-Methods") == "" {
+		t.Error("Expected CORS headers to be set")
+	}
+}
+
+func TestDynamicPolicyAPI_TestPolicy(t *testing.T) {
+	mockService := &mockDynamicPolicyService{
+		getFunc: func(ctx context.Context, tenantID, policyID string) (*PolicyResource, error) {
+			return &PolicyResource{ID: policyID, Name: "Test Policy", Category: "dynamic-risk"}, nil
+		},
+		testFunc: func(ctx context.Context, tenantID, policyID string, req *TestPolicyRequest) (*TestPolicyResponse, error) {
+			return &TestPolicyResponse{
+				Matched:     true,
+				Blocked:     false,
+				Actions:     []TriggeredAction{{Type: "log"}, {Type: "alert"}},
+				Explanation: "Policy matched",
+				EvalTimeMs:  1.5,
+			}, nil
+		},
+	}
+
+	handler := NewDynamicPolicyAPIHandler(mockService)
+	r := mux.NewRouter()
+	handler.RegisterRoutes(r)
+
+	testReq := TestPolicyRequest{
+		Query: "test query for policy evaluation",
+		Context: map[string]interface{}{
+			"prompt": "test prompt",
+			"model":  "gpt-4",
+		},
+	}
+	body, _ := json.Marshal(testReq)
+
+	policyID := uuid.New().String()
+	req := httptest.NewRequest("POST", "/api/v1/dynamic-policies/"+policyID+"/test", bytes.NewReader(body))
+	req.Header.Set("X-Tenant-ID", "test-tenant")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestDynamicPolicyAPI_TestPolicy_InvalidJSON(t *testing.T) {
+	mockService := &mockDynamicPolicyService{
+		getFunc: func(ctx context.Context, tenantID, policyID string) (*PolicyResource, error) {
+			return &PolicyResource{ID: policyID, Name: "Test Policy", Category: "dynamic-risk"}, nil
+		},
+	}
+	handler := NewDynamicPolicyAPIHandler(mockService)
+	r := mux.NewRouter()
+	handler.RegisterRoutes(r)
+
+	policyID := uuid.New().String()
+	req := httptest.NewRequest("POST", "/api/v1/dynamic-policies/"+policyID+"/test", bytes.NewReader([]byte("invalid json")))
+	req.Header.Set("X-Tenant-ID", "test-tenant")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("Expected status 400, got %d", w.Code)
+	}
+}
+
+func TestDynamicPolicyAPI_GetVersions(t *testing.T) {
+	mockService := &mockDynamicPolicyService{
+		getFunc: func(ctx context.Context, tenantID, policyID string) (*PolicyResource, error) {
+			return &PolicyResource{ID: policyID, Name: "Test Policy", Category: "dynamic-risk"}, nil
+		},
+		versionsFunc: func(ctx context.Context, tenantID, policyID string) (*PolicyVersionResponse, error) {
+			return &PolicyVersionResponse{
+				Versions: []PolicyVersionEntry{
+					{Version: 1, ChangedAt: time.Now().Add(-time.Hour), ChangedBy: "user1", ChangeType: "create"},
+					{Version: 2, ChangedAt: time.Now(), ChangedBy: "user2", ChangeType: "update"},
+				},
+			}, nil
+		},
+	}
+
+	handler := NewDynamicPolicyAPIHandler(mockService)
+	r := mux.NewRouter()
+	handler.RegisterRoutes(r)
+
+	policyID := uuid.New().String()
+	req := httptest.NewRequest("GET", "/api/v1/dynamic-policies/"+policyID+"/versions", nil)
+	req.Header.Set("X-Tenant-ID", "test-tenant")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestDynamicPolicyAPI_Delete_Success(t *testing.T) {
+	mockService := &mockDynamicPolicyService{
+		getFunc: func(ctx context.Context, tenantID, policyID string) (*PolicyResource, error) {
+			return &PolicyResource{ID: policyID, Name: "Test Policy", Category: "dynamic-risk"}, nil
+		},
+		deleteFunc: func(ctx context.Context, tenantID, policyID, userID string) error {
+			return nil
+		},
+	}
+
+	handler := NewDynamicPolicyAPIHandler(mockService)
+	r := mux.NewRouter()
+	handler.RegisterRoutes(r)
+
+	policyID := uuid.New().String()
+	req := httptest.NewRequest("DELETE", "/api/v1/dynamic-policies/"+policyID, nil)
+	req.Header.Set("X-Tenant-ID", "test-tenant")
+	req.Header.Set("X-User-ID", "user123")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Errorf("Expected status 204, got %d", w.Code)
+	}
+}
+
+func TestDynamicPolicyAPI_Update_InvalidJSON(t *testing.T) {
+	mockService := &mockDynamicPolicyService{
+		getFunc: func(ctx context.Context, tenantID, policyID string) (*PolicyResource, error) {
+			return &PolicyResource{ID: policyID, Name: "Test Policy", Category: "dynamic-risk"}, nil
+		},
+	}
+	handler := NewDynamicPolicyAPIHandler(mockService)
+	r := mux.NewRouter()
+	handler.RegisterRoutes(r)
+
+	policyID := uuid.New().String()
+	req := httptest.NewRequest("PUT", "/api/v1/dynamic-policies/"+policyID, bytes.NewReader([]byte("invalid json")))
+	req.Header.Set("X-Tenant-ID", "test-tenant")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("Expected status 400, got %d", w.Code)
+	}
+}
+
+func TestDynamicPolicyAPI_List_WithFilters(t *testing.T) {
+	mockService := &mockDynamicPolicyService{
+		listFunc: func(ctx context.Context, tenantID string, params ListPoliciesParams) (*PoliciesListResponse, error) {
+			// Verify filters are passed
+			if params.Type != "cost" {
+				t.Errorf("Expected type filter 'cost', got '%s'", params.Type)
+			}
+			if params.Category != "dynamic-cost" {
+				t.Errorf("Expected category filter 'dynamic-cost', got '%s'", params.Category)
+			}
+			return &PoliciesListResponse{
+				Policies:   []PolicyResource{},
+				Pagination: PaginationMeta{Page: 1, PageSize: 20},
+			}, nil
+		},
+	}
+
+	handler := NewDynamicPolicyAPIHandler(mockService)
+	r := mux.NewRouter()
+	handler.RegisterRoutes(r)
+
+	req := httptest.NewRequest("GET", "/api/v1/dynamic-policies?type=cost&category=dynamic-cost", nil)
+	req.Header.Set("X-Tenant-ID", "test-tenant")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", w.Code)
+	}
+}
+
+func TestDynamicPolicyAPI_Import_InvalidJSON(t *testing.T) {
+	handler := NewDynamicPolicyAPIHandler(&mockDynamicPolicyService{})
+	r := mux.NewRouter()
+	handler.RegisterRoutes(r)
+
+	req := httptest.NewRequest("POST", "/api/v1/dynamic-policies/import", bytes.NewReader([]byte("invalid json")))
+	req.Header.Set("X-Tenant-ID", "test-tenant")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("Expected status 400, got %d", w.Code)
+	}
+}
+
+func TestDynamicPolicyAPI_Create_ValidationError(t *testing.T) {
+	mockService := &mockDynamicPolicyService{
+		createFunc: func(ctx context.Context, tenantID string, req *CreatePolicyRequest, userID string) (*PolicyResource, error) {
+			return nil, &ValidationError{
+				Errors: []PolicyFieldError{
+					{Field: "name", Message: "Name is required"},
+					{Field: "category", Message: "Invalid category"},
+				},
+			}
+		},
+	}
+
+	handler := NewDynamicPolicyAPIHandler(mockService)
+	r := mux.NewRouter()
+	handler.RegisterRoutes(r)
+
+	createReq := CreatePolicyRequest{
+		Name:     "Test",
+		Category: "dynamic-risk",
+	}
+	body, _ := json.Marshal(createReq)
+
+	req := httptest.NewRequest("POST", "/api/v1/dynamic-policies", bytes.NewReader(body))
+	req.Header.Set("X-Tenant-ID", "test-tenant")
+	req.Header.Set("X-User-ID", "user123")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("Expected status 400, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Verify it's a validation error response
+	var resp map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err == nil {
+		if errObj, ok := resp["error"].(map[string]interface{}); ok {
+			if errObj["code"] != "VALIDATION_ERROR" {
+				t.Errorf("Expected VALIDATION_ERROR code, got %v", errObj["code"])
+			}
+		}
+	}
+}
+
+func TestDynamicPolicyAPI_Update_Success(t *testing.T) {
+	policyID := uuid.New().String()
+	name := "Updated Policy"
+	enabled := true
+	mockService := &mockDynamicPolicyService{
+		getFunc: func(ctx context.Context, tenantID, id string) (*PolicyResource, error) {
+			return &PolicyResource{ID: id, Name: "Test Policy", Category: "dynamic-risk"}, nil
+		},
+		updateFunc: func(ctx context.Context, tenantID, id string, req *UpdatePolicyRequest, userID string) (*PolicyResource, error) {
+			return &PolicyResource{
+				ID:       id,
+				Name:     name,
+				Category: "dynamic-risk",
+				Enabled:  enabled,
+			}, nil
+		},
+	}
+
+	handler := NewDynamicPolicyAPIHandler(mockService)
+	r := mux.NewRouter()
+	handler.RegisterRoutes(r)
+
+	updateReq := UpdatePolicyRequest{
+		Name:    &name,
+		Enabled: &enabled,
+	}
+	body, _ := json.Marshal(updateReq)
+
+	req := httptest.NewRequest("PUT", "/api/v1/dynamic-policies/"+policyID, bytes.NewReader(body))
+	req.Header.Set("X-Tenant-ID", "test-tenant")
+	req.Header.Set("X-User-ID", "user123")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestDynamicPolicyAPI_List_ServiceError(t *testing.T) {
+	mockService := &mockDynamicPolicyService{
+		listFunc: func(ctx context.Context, tenantID string, params ListPoliciesParams) (*PoliciesListResponse, error) {
+			return nil, errors.New("database connection failed")
+		},
+	}
+
+	handler := NewDynamicPolicyAPIHandler(mockService)
+	r := mux.NewRouter()
+	handler.RegisterRoutes(r)
+
+	req := httptest.NewRequest("GET", "/api/v1/dynamic-policies", nil)
+	req.Header.Set("X-Tenant-ID", "test-tenant")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("Expected status 500, got %d", w.Code)
+	}
+}
+
+func TestDynamicPolicyAPI_Export_ServiceError(t *testing.T) {
+	mockService := &mockDynamicPolicyService{
+		exportFunc: func(ctx context.Context, tenantID string) (*ExportPoliciesResponse, error) {
+			return nil, errors.New("database error")
+		},
+	}
+
+	handler := NewDynamicPolicyAPIHandler(mockService)
+	r := mux.NewRouter()
+	handler.RegisterRoutes(r)
+
+	req := httptest.NewRequest("GET", "/api/v1/dynamic-policies/export", nil)
+	req.Header.Set("X-Tenant-ID", "test-tenant")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("Expected status 500, got %d", w.Code)
+	}
+}
+
+func TestDynamicPolicyAPI_Create_TierError(t *testing.T) {
+	mockService := &mockDynamicPolicyService{
+		createFunc: func(ctx context.Context, tenantID string, req *CreatePolicyRequest, userID string) (*PolicyResource, error) {
+			return nil, NewTierValidationError("Cannot create system policies", ErrCodeSystemTierImmutable)
+		},
+	}
+
+	handler := NewDynamicPolicyAPIHandler(mockService)
+	r := mux.NewRouter()
+	handler.RegisterRoutes(r)
+
+	createReq := CreatePolicyRequest{
+		Name:     "System Policy",
+		Category: "dynamic-risk",
+		Tier:     TierSystem,
+	}
+	body, _ := json.Marshal(createReq)
+
+	req := httptest.NewRequest("POST", "/api/v1/dynamic-policies", bytes.NewReader(body))
+	req.Header.Set("X-Tenant-ID", "test-tenant")
+	req.Header.Set("X-User-ID", "user123")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("Expected status 403, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestDynamicPolicyAPI_Create_Success(t *testing.T) {
+	policyID := uuid.New().String()
+	mockService := &mockDynamicPolicyService{
+		createFunc: func(ctx context.Context, tenantID string, req *CreatePolicyRequest, userID string) (*PolicyResource, error) {
+			return &PolicyResource{
+				ID:       policyID,
+				Name:     req.Name,
+				Category: req.Category,
+				Enabled:  true,
+			}, nil
+		},
+	}
+
+	handler := NewDynamicPolicyAPIHandler(mockService)
+	r := mux.NewRouter()
+	handler.RegisterRoutes(r)
+
+	createReq := CreatePolicyRequest{
+		Name:     "New Policy",
+		Category: "dynamic-risk",
+	}
+	body, _ := json.Marshal(createReq)
+
+	req := httptest.NewRequest("POST", "/api/v1/dynamic-policies", bytes.NewReader(body))
+	req.Header.Set("X-Tenant-ID", "test-tenant")
+	req.Header.Set("X-User-ID", "user123")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Errorf("Expected status 201, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestDynamicPolicyAPI_Create_InternalError(t *testing.T) {
+	mockService := &mockDynamicPolicyService{
+		createFunc: func(ctx context.Context, tenantID string, req *CreatePolicyRequest, userID string) (*PolicyResource, error) {
+			return nil, errors.New("unexpected database error")
+		},
+	}
+
+	handler := NewDynamicPolicyAPIHandler(mockService)
+	r := mux.NewRouter()
+	handler.RegisterRoutes(r)
+
+	createReq := CreatePolicyRequest{
+		Name:     "New Policy",
+		Category: "dynamic-risk",
+	}
+	body, _ := json.Marshal(createReq)
+
+	req := httptest.NewRequest("POST", "/api/v1/dynamic-policies", bytes.NewReader(body))
+	req.Header.Set("X-Tenant-ID", "test-tenant")
+	req.Header.Set("X-User-ID", "user123")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("Expected status 500, got %d", w.Code)
+	}
+}
+
+func TestDynamicPolicyAPI_Get_ServiceError(t *testing.T) {
+	policyID := uuid.New().String()
+	mockService := &mockDynamicPolicyService{
+		getFunc: func(ctx context.Context, tenantID, id string) (*PolicyResource, error) {
+			return nil, errors.New("database error")
+		},
+	}
+
+	handler := NewDynamicPolicyAPIHandler(mockService)
+	r := mux.NewRouter()
+	handler.RegisterRoutes(r)
+
+	req := httptest.NewRequest("GET", "/api/v1/dynamic-policies/"+policyID, nil)
+	req.Header.Set("X-Tenant-ID", "test-tenant")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	// Generic errors are converted to 500
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("Expected status 500, got %d", w.Code)
+	}
+}
+
+func TestDynamicPolicyAPI_Effective_ServiceError(t *testing.T) {
+	mockService := &mockDynamicPolicyService{
+		listFunc: func(ctx context.Context, tenantID string, params ListPoliciesParams) (*PoliciesListResponse, error) {
+			return nil, errors.New("database error")
+		},
+	}
+
+	handler := NewDynamicPolicyAPIHandler(mockService)
+	r := mux.NewRouter()
+	handler.RegisterRoutes(r)
+
+	req := httptest.NewRequest("GET", "/api/v1/dynamic-policies/effective", nil)
+	req.Header.Set("X-Tenant-ID", "test-tenant")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("Expected status 500, got %d", w.Code)
+	}
+}
+
+func TestDynamicPolicyAPI_Delete_ServiceError(t *testing.T) {
+	policyID := uuid.New().String()
+	mockService := &mockDynamicPolicyService{
+		getFunc: func(ctx context.Context, tenantID, id string) (*PolicyResource, error) {
+			return &PolicyResource{ID: id, Name: "Test", Category: "dynamic-risk"}, nil
+		},
+		deleteFunc: func(ctx context.Context, tenantID, policyID, userID string) error {
+			return errors.New("database error")
+		},
+	}
+
+	handler := NewDynamicPolicyAPIHandler(mockService)
+	r := mux.NewRouter()
+	handler.RegisterRoutes(r)
+
+	req := httptest.NewRequest("DELETE", "/api/v1/dynamic-policies/"+policyID, nil)
+	req.Header.Set("X-Tenant-ID", "test-tenant")
+	req.Header.Set("X-User-ID", "user123")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("Expected status 500, got %d", w.Code)
+	}
+}
+
+func TestDynamicPolicyAPI_Update_ServiceError(t *testing.T) {
+	policyID := uuid.New().String()
+	name := "Updated"
+	mockService := &mockDynamicPolicyService{
+		getFunc: func(ctx context.Context, tenantID, id string) (*PolicyResource, error) {
+			return &PolicyResource{ID: id, Name: "Test", Category: "dynamic-risk"}, nil
+		},
+		updateFunc: func(ctx context.Context, tenantID, id string, req *UpdatePolicyRequest, userID string) (*PolicyResource, error) {
+			return nil, errors.New("database error")
+		},
+	}
+
+	handler := NewDynamicPolicyAPIHandler(mockService)
+	r := mux.NewRouter()
+	handler.RegisterRoutes(r)
+
+	updateReq := UpdatePolicyRequest{Name: &name}
+	body, _ := json.Marshal(updateReq)
+
+	req := httptest.NewRequest("PUT", "/api/v1/dynamic-policies/"+policyID, bytes.NewReader(body))
+	req.Header.Set("X-Tenant-ID", "test-tenant")
+	req.Header.Set("X-User-ID", "user123")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("Expected status 500, got %d", w.Code)
+	}
+}
+
+func TestDynamicPolicyAPI_TestPolicy_ServiceError(t *testing.T) {
+	policyID := uuid.New().String()
+	mockService := &mockDynamicPolicyService{
+		getFunc: func(ctx context.Context, tenantID, id string) (*PolicyResource, error) {
+			return &PolicyResource{ID: id, Name: "Test", Category: "dynamic-risk"}, nil
+		},
+		testFunc: func(ctx context.Context, tenantID, policyID string, req *TestPolicyRequest) (*TestPolicyResponse, error) {
+			return nil, errors.New("evaluation error")
+		},
+	}
+
+	handler := NewDynamicPolicyAPIHandler(mockService)
+	r := mux.NewRouter()
+	handler.RegisterRoutes(r)
+
+	testReq := TestPolicyRequest{Query: "test query"}
+	body, _ := json.Marshal(testReq)
+
+	req := httptest.NewRequest("POST", "/api/v1/dynamic-policies/"+policyID+"/test", bytes.NewReader(body))
+	req.Header.Set("X-Tenant-ID", "test-tenant")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("Expected status 500, got %d", w.Code)
+	}
+}
+
+func TestDynamicPolicyAPI_Versions_ServiceError(t *testing.T) {
+	policyID := uuid.New().String()
+	mockService := &mockDynamicPolicyService{
+		getFunc: func(ctx context.Context, tenantID, id string) (*PolicyResource, error) {
+			return &PolicyResource{ID: id, Name: "Test", Category: "dynamic-risk"}, nil
+		},
+		versionsFunc: func(ctx context.Context, tenantID, policyID string) (*PolicyVersionResponse, error) {
+			return nil, errors.New("database error")
+		},
+	}
+
+	handler := NewDynamicPolicyAPIHandler(mockService)
+	r := mux.NewRouter()
+	handler.RegisterRoutes(r)
+
+	req := httptest.NewRequest("GET", "/api/v1/dynamic-policies/"+policyID+"/versions", nil)
+	req.Header.Set("X-Tenant-ID", "test-tenant")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("Expected status 500, got %d", w.Code)
+	}
+}
+
+func TestDynamicPolicyAPI_Import_ServiceError(t *testing.T) {
+	mockService := &mockDynamicPolicyService{
+		importFunc: func(ctx context.Context, tenantID string, req *ImportPoliciesRequest, userID string) (*ImportPoliciesResponse, error) {
+			return nil, errors.New("database error")
+		},
+	}
+
+	handler := NewDynamicPolicyAPIHandler(mockService)
+	r := mux.NewRouter()
+	handler.RegisterRoutes(r)
+
+	importReq := ImportPoliciesRequest{
+		Policies: []CreatePolicyRequest{
+			{Name: "Policy 1", Category: "dynamic-risk"},
+		},
+	}
+	body, _ := json.Marshal(importReq)
+
+	req := httptest.NewRequest("POST", "/api/v1/dynamic-policies/import", bytes.NewReader(body))
+	req.Header.Set("X-Tenant-ID", "test-tenant")
+	req.Header.Set("X-User-ID", "user123")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("Expected status 500, got %d", w.Code)
+	}
+}
+
+func TestDynamicPolicyAPI_Update_NotFound(t *testing.T) {
+	policyID := uuid.New().String()
+	mockService := &mockDynamicPolicyService{
+		getFunc: func(ctx context.Context, tenantID, id string) (*PolicyResource, error) {
+			return nil, nil // Policy not found
+		},
+	}
+
+	handler := NewDynamicPolicyAPIHandler(mockService)
+	r := mux.NewRouter()
+	handler.RegisterRoutes(r)
+
+	name := "Updated Policy"
+	updateReq := UpdatePolicyRequest{Name: &name}
+	body, _ := json.Marshal(updateReq)
+
+	req := httptest.NewRequest("PUT", "/api/v1/dynamic-policies/"+policyID, bytes.NewReader(body))
+	req.Header.Set("X-Tenant-ID", "test-tenant")
+	req.Header.Set("X-User-ID", "user123")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("Expected status 404, got %d", w.Code)
+	}
+}
+
+func TestDynamicPolicyAPI_Update_NotDynamicPolicy(t *testing.T) {
+	policyID := uuid.New().String()
+	mockService := &mockDynamicPolicyService{
+		getFunc: func(ctx context.Context, tenantID, id string) (*PolicyResource, error) {
+			return &PolicyResource{ID: id, Name: "Test", Category: "static-security"}, nil // Not a dynamic policy
+		},
+	}
+
+	handler := NewDynamicPolicyAPIHandler(mockService)
+	r := mux.NewRouter()
+	handler.RegisterRoutes(r)
+
+	name := "Updated Policy"
+	updateReq := UpdatePolicyRequest{Name: &name}
+	body, _ := json.Marshal(updateReq)
+
+	req := httptest.NewRequest("PUT", "/api/v1/dynamic-policies/"+policyID, bytes.NewReader(body))
+	req.Header.Set("X-Tenant-ID", "test-tenant")
+	req.Header.Set("X-User-ID", "user123")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("Expected status 404, got %d", w.Code)
+	}
+}
+
+func TestDynamicPolicyAPI_Update_InvalidCategoryChange(t *testing.T) {
+	policyID := uuid.New().String()
+	mockService := &mockDynamicPolicyService{
+		getFunc: func(ctx context.Context, tenantID, id string) (*PolicyResource, error) {
+			return &PolicyResource{ID: id, Name: "Test", Category: "dynamic-risk"}, nil
+		},
+	}
+
+	handler := NewDynamicPolicyAPIHandler(mockService)
+	r := mux.NewRouter()
+	handler.RegisterRoutes(r)
+
+	newCategory := "static-security" // Invalid - not a dynamic category
+	updateReq := UpdatePolicyRequest{Category: &newCategory}
+	body, _ := json.Marshal(updateReq)
+
+	req := httptest.NewRequest("PUT", "/api/v1/dynamic-policies/"+policyID, bytes.NewReader(body))
+	req.Header.Set("X-Tenant-ID", "test-tenant")
+	req.Header.Set("X-User-ID", "user123")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("Expected status 400, got %d", w.Code)
+	}
+}
+
+func TestDynamicPolicyAPI_Update_ValidationError(t *testing.T) {
+	policyID := uuid.New().String()
+	mockService := &mockDynamicPolicyService{
+		getFunc: func(ctx context.Context, tenantID, id string) (*PolicyResource, error) {
+			return &PolicyResource{ID: id, Name: "Test", Category: "dynamic-risk"}, nil
+		},
+		updateFunc: func(ctx context.Context, tenantID, policyID string, req *UpdatePolicyRequest, userID string) (*PolicyResource, error) {
+			return nil, &ValidationError{Errors: []PolicyFieldError{{Field: "name", Message: "name is required"}}}
+		},
+	}
+
+	handler := NewDynamicPolicyAPIHandler(mockService)
+	r := mux.NewRouter()
+	handler.RegisterRoutes(r)
+
+	name := ""
+	updateReq := UpdatePolicyRequest{Name: &name}
+	body, _ := json.Marshal(updateReq)
+
+	req := httptest.NewRequest("PUT", "/api/v1/dynamic-policies/"+policyID, bytes.NewReader(body))
+	req.Header.Set("X-Tenant-ID", "test-tenant")
+	req.Header.Set("X-User-ID", "user123")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("Expected status 400, got %d", w.Code)
+	}
+}
+
+func TestDynamicPolicyAPI_Update_TierError(t *testing.T) {
+	policyID := uuid.New().String()
+	mockService := &mockDynamicPolicyService{
+		getFunc: func(ctx context.Context, tenantID, id string) (*PolicyResource, error) {
+			return &PolicyResource{ID: id, Name: "Test", Category: "dynamic-risk"}, nil
+		},
+		updateFunc: func(ctx context.Context, tenantID, policyID string, req *UpdatePolicyRequest, userID string) (*PolicyResource, error) {
+			return nil, NewTierValidationError("enterprise feature required", "ENTERPRISE_REQUIRED")
+		},
+	}
+
+	handler := NewDynamicPolicyAPIHandler(mockService)
+	r := mux.NewRouter()
+	handler.RegisterRoutes(r)
+
+	name := "Updated"
+	updateReq := UpdatePolicyRequest{Name: &name}
+	body, _ := json.Marshal(updateReq)
+
+	req := httptest.NewRequest("PUT", "/api/v1/dynamic-policies/"+policyID, bytes.NewReader(body))
+	req.Header.Set("X-Tenant-ID", "test-tenant")
+	req.Header.Set("X-User-ID", "user123")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("Expected status 403, got %d", w.Code)
+	}
+}
+
+func TestDynamicPolicyAPI_Update_NilPolicyAfterUpdate(t *testing.T) {
+	policyID := uuid.New().String()
+	mockService := &mockDynamicPolicyService{
+		getFunc: func(ctx context.Context, tenantID, id string) (*PolicyResource, error) {
+			return &PolicyResource{ID: id, Name: "Test", Category: "dynamic-risk"}, nil
+		},
+		updateFunc: func(ctx context.Context, tenantID, policyID string, req *UpdatePolicyRequest, userID string) (*PolicyResource, error) {
+			return nil, nil // Success but nil policy
+		},
+	}
+
+	handler := NewDynamicPolicyAPIHandler(mockService)
+	r := mux.NewRouter()
+	handler.RegisterRoutes(r)
+
+	name := "Updated"
+	updateReq := UpdatePolicyRequest{Name: &name}
+	body, _ := json.Marshal(updateReq)
+
+	req := httptest.NewRequest("PUT", "/api/v1/dynamic-policies/"+policyID, bytes.NewReader(body))
+	req.Header.Set("X-Tenant-ID", "test-tenant")
+	req.Header.Set("X-User-ID", "user123")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("Expected status 404, got %d", w.Code)
+	}
+}
+
+func TestDynamicPolicyAPI_Delete_NotFound(t *testing.T) {
+	policyID := uuid.New().String()
+	mockService := &mockDynamicPolicyService{
+		getFunc: func(ctx context.Context, tenantID, id string) (*PolicyResource, error) {
+			return nil, nil // Policy not found
+		},
+	}
+
+	handler := NewDynamicPolicyAPIHandler(mockService)
+	r := mux.NewRouter()
+	handler.RegisterRoutes(r)
+
+	req := httptest.NewRequest("DELETE", "/api/v1/dynamic-policies/"+policyID, nil)
+	req.Header.Set("X-Tenant-ID", "test-tenant")
+	req.Header.Set("X-User-ID", "user123")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("Expected status 404, got %d", w.Code)
+	}
+}
+
+func TestDynamicPolicyAPI_Delete_NotDynamicPolicy(t *testing.T) {
+	policyID := uuid.New().String()
+	mockService := &mockDynamicPolicyService{
+		getFunc: func(ctx context.Context, tenantID, id string) (*PolicyResource, error) {
+			return &PolicyResource{ID: id, Name: "Test", Category: "static-security"}, nil // Not dynamic
+		},
+	}
+
+	handler := NewDynamicPolicyAPIHandler(mockService)
+	r := mux.NewRouter()
+	handler.RegisterRoutes(r)
+
+	req := httptest.NewRequest("DELETE", "/api/v1/dynamic-policies/"+policyID, nil)
+	req.Header.Set("X-Tenant-ID", "test-tenant")
+	req.Header.Set("X-User-ID", "user123")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("Expected status 404, got %d", w.Code)
+	}
+}
+
+func TestDynamicPolicyAPI_Delete_TierError(t *testing.T) {
+	policyID := uuid.New().String()
+	mockService := &mockDynamicPolicyService{
+		getFunc: func(ctx context.Context, tenantID, id string) (*PolicyResource, error) {
+			return &PolicyResource{ID: id, Name: "Test", Category: "dynamic-risk"}, nil
+		},
+		deleteFunc: func(ctx context.Context, tenantID, policyID, userID string) error {
+			return NewTierValidationError("enterprise feature required", "ENTERPRISE_REQUIRED")
+		},
+	}
+
+	handler := NewDynamicPolicyAPIHandler(mockService)
+	r := mux.NewRouter()
+	handler.RegisterRoutes(r)
+
+	req := httptest.NewRequest("DELETE", "/api/v1/dynamic-policies/"+policyID, nil)
+	req.Header.Set("X-Tenant-ID", "test-tenant")
+	req.Header.Set("X-User-ID", "user123")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("Expected status 403, got %d", w.Code)
+	}
+}
+
+func TestDynamicPolicyAPI_Test_NotFound(t *testing.T) {
+	policyID := uuid.New().String()
+	mockService := &mockDynamicPolicyService{
+		getFunc: func(ctx context.Context, tenantID, id string) (*PolicyResource, error) {
+			return nil, nil // Policy not found
+		},
+	}
+
+	handler := NewDynamicPolicyAPIHandler(mockService)
+	r := mux.NewRouter()
+	handler.RegisterRoutes(r)
+
+	testReq := TestPolicyRequest{Query: "test query"}
+	body, _ := json.Marshal(testReq)
+
+	req := httptest.NewRequest("POST", "/api/v1/dynamic-policies/"+policyID+"/test", bytes.NewReader(body))
+	req.Header.Set("X-Tenant-ID", "test-tenant")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("Expected status 404, got %d", w.Code)
+	}
+}
+
+func TestDynamicPolicyAPI_Test_NotDynamicPolicy(t *testing.T) {
+	policyID := uuid.New().String()
+	mockService := &mockDynamicPolicyService{
+		getFunc: func(ctx context.Context, tenantID, id string) (*PolicyResource, error) {
+			return &PolicyResource{ID: id, Name: "Test", Category: "static-security"}, nil
+		},
+	}
+
+	handler := NewDynamicPolicyAPIHandler(mockService)
+	r := mux.NewRouter()
+	handler.RegisterRoutes(r)
+
+	testReq := TestPolicyRequest{Query: "test query"}
+	body, _ := json.Marshal(testReq)
+
+	req := httptest.NewRequest("POST", "/api/v1/dynamic-policies/"+policyID+"/test", bytes.NewReader(body))
+	req.Header.Set("X-Tenant-ID", "test-tenant")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("Expected status 404, got %d", w.Code)
+	}
+}
+
+func TestDynamicPolicyAPI_Versions_NotFound(t *testing.T) {
+	policyID := uuid.New().String()
+	mockService := &mockDynamicPolicyService{
+		getFunc: func(ctx context.Context, tenantID, id string) (*PolicyResource, error) {
+			return nil, nil // Policy not found
+		},
+	}
+
+	handler := NewDynamicPolicyAPIHandler(mockService)
+	r := mux.NewRouter()
+	handler.RegisterRoutes(r)
+
+	req := httptest.NewRequest("GET", "/api/v1/dynamic-policies/"+policyID+"/versions", nil)
+	req.Header.Set("X-Tenant-ID", "test-tenant")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("Expected status 404, got %d", w.Code)
+	}
+}
+
+func TestDynamicPolicyAPI_Versions_NotDynamicPolicy(t *testing.T) {
+	policyID := uuid.New().String()
+	mockService := &mockDynamicPolicyService{
+		getFunc: func(ctx context.Context, tenantID, id string) (*PolicyResource, error) {
+			return &PolicyResource{ID: id, Name: "Test", Category: "static-security"}, nil
+		},
+	}
+
+	handler := NewDynamicPolicyAPIHandler(mockService)
+	r := mux.NewRouter()
+	handler.RegisterRoutes(r)
+
+	req := httptest.NewRequest("GET", "/api/v1/dynamic-policies/"+policyID+"/versions", nil)
+	req.Header.Set("X-Tenant-ID", "test-tenant")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("Expected status 404, got %d", w.Code)
+	}
+}
+
+func TestDynamicPolicyAPI_List_Pagination(t *testing.T) {
+	mockService := &mockDynamicPolicyService{
+		listFunc: func(ctx context.Context, tenantID string, params ListPoliciesParams) (*PoliciesListResponse, error) {
+			return &PoliciesListResponse{
+				Policies: []PolicyResource{
+					{ID: "1", Name: "Policy 1", Category: "dynamic-risk"},
+					{ID: "2", Name: "Policy 2", Category: "dynamic-risk"},
+				},
+				Pagination: PaginationMeta{TotalItems: 10, Page: 2, PageSize: 2},
+			}, nil
+		},
+	}
+
+	handler := NewDynamicPolicyAPIHandler(mockService)
+	r := mux.NewRouter()
+	handler.RegisterRoutes(r)
+
+	req := httptest.NewRequest("GET", "/api/v1/dynamic-policies?page=2&page_size=2&enabled=true&category=dynamic-risk", nil)
+	req.Header.Set("X-Tenant-ID", "test-tenant")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", w.Code)
+	}
+}
+
+func TestDynamicPolicyAPI_CORS_Preflight(t *testing.T) {
+	mockService := &mockDynamicPolicyService{}
+
+	handler := NewDynamicPolicyAPIHandler(mockService)
+	r := mux.NewRouter()
+	handler.RegisterRoutes(r)
+
+	req := httptest.NewRequest("OPTIONS", "/api/v1/dynamic-policies", nil)
+	req.Header.Set("X-Tenant-ID", "test-tenant")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Errorf("Expected status 204, got %d", w.Code)
+	}
+}
+
+func TestDynamicPolicyAPI_HandlePolicyByID_Options(t *testing.T) {
+	policyID := uuid.New().String()
+	mockService := &mockDynamicPolicyService{}
+
+	handler := NewDynamicPolicyAPIHandler(mockService)
+	r := mux.NewRouter()
+	handler.RegisterRoutes(r)
+
+	req := httptest.NewRequest("OPTIONS", "/api/v1/dynamic-policies/"+policyID, nil)
+	req.Header.Set("X-Tenant-ID", "test-tenant")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Errorf("Expected status 204, got %d", w.Code)
+	}
+}
+
+func TestDynamicPolicyAPI_Import_Options(t *testing.T) {
+	mockService := &mockDynamicPolicyService{}
+
+	handler := NewDynamicPolicyAPIHandler(mockService)
+	r := mux.NewRouter()
+	handler.RegisterRoutes(r)
+
+	req := httptest.NewRequest("OPTIONS", "/api/v1/dynamic-policies/import", nil)
+	req.Header.Set("X-Tenant-ID", "test-tenant")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Errorf("Expected status 204, got %d", w.Code)
+	}
+}
+
+func TestDynamicPolicyAPI_Export_Options(t *testing.T) {
+	mockService := &mockDynamicPolicyService{}
+
+	handler := NewDynamicPolicyAPIHandler(mockService)
+	r := mux.NewRouter()
+	handler.RegisterRoutes(r)
+
+	req := httptest.NewRequest("OPTIONS", "/api/v1/dynamic-policies/export", nil)
+	req.Header.Set("X-Tenant-ID", "test-tenant")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Errorf("Expected status 204, got %d", w.Code)
+	}
+}
+
+func TestDynamicPolicyAPI_Effective_Options(t *testing.T) {
+	mockService := &mockDynamicPolicyService{}
+
+	handler := NewDynamicPolicyAPIHandler(mockService)
+	r := mux.NewRouter()
+	handler.RegisterRoutes(r)
+
+	req := httptest.NewRequest("OPTIONS", "/api/v1/dynamic-policies/effective", nil)
+	req.Header.Set("X-Tenant-ID", "test-tenant")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Errorf("Expected status 204, got %d", w.Code)
+	}
+}

--- a/platform/orchestrator/llm/request_adapter.go
+++ b/platform/orchestrator/llm/request_adapter.go
@@ -59,6 +59,15 @@ type RequestContext struct {
 
 	// Metadata contains additional request-specific data
 	Metadata map[string]any
+
+	// Policy-based routing overrides (Issue #883 - strict provider enforcement)
+	// PolicyPreferredProvider is the preferred provider from dynamic policy evaluation
+	PolicyPreferredProvider string
+	// PolicyAllowedProviders is the strict list of allowed providers for compliance
+	// When set, failover can ONLY occur within this list (GDPR, PII, cost control)
+	PolicyAllowedProviders []string
+	// PolicyRoutingReason explains why routing was overridden by policy
+	PolicyRoutingReason string
 }
 
 // LegacyProviderInfo represents the legacy ProviderInfo format from run.go.

--- a/platform/orchestrator/llm/router.go
+++ b/platform/orchestrator/llm/router.go
@@ -197,7 +197,8 @@ func (r *Router) RouteRequest(ctx context.Context, req CompletionRequest, opts .
 
 		// Try failover if enabled
 		if !routeOpts.disableFailover {
-			fallback, fallbackErr := r.getFallbackProvider(ctx, provider.Name())
+			// Pass allowedProviders to enforce compliance during failover
+			fallback, fallbackErr := r.getFallbackProvider(ctx, provider.Name(), routeOpts.allowedProviders)
 			if fallbackErr == nil && fallback != nil {
 				r.logger.Printf("Failing over from %s to %s", provider.Name(), fallback.Name())
 				response, err = fallback.Complete(ctx, req)
@@ -207,6 +208,10 @@ func (r *Router) RouteRequest(ctx context.Context, req CompletionRequest, opts .
 				}
 				provider = fallback
 			} else {
+				// Include compliance context in error message
+				if len(routeOpts.allowedProviders) > 0 {
+					return nil, nil, fmt.Errorf("primary provider failed and no compliant fallback available (allowed: %v): %w", routeOpts.allowedProviders, err)
+				}
 				return nil, nil, fmt.Errorf("primary provider failed and no fallback: %w", err)
 			}
 		} else {
@@ -237,13 +242,34 @@ func (r *Router) RouteRequest(ctx context.Context, req CompletionRequest, opts .
 
 // selectProvider selects the best provider for a request.
 func (r *Router) selectProvider(ctx context.Context, req CompletionRequest, opts *routeOptions) (Provider, error) {
-	// If a specific provider was requested, use it
+	// If a specific provider was requested, use it (but verify it's allowed)
 	if opts.preferredProvider != "" {
-		provider, err := r.registry.Get(ctx, opts.preferredProvider)
-		if err == nil {
-			return provider, nil
+		// Check if preferred provider is in allowed list (if restrictions apply)
+		if len(opts.allowedProviders) > 0 {
+			allowed := false
+			for _, p := range opts.allowedProviders {
+				if p == opts.preferredProvider {
+					allowed = true
+					break
+				}
+			}
+			if !allowed {
+				r.logger.Printf("Preferred provider %q not in allowed list %v", opts.preferredProvider, opts.allowedProviders)
+				// Fall through to select from allowed providers
+			} else {
+				provider, err := r.registry.Get(ctx, opts.preferredProvider)
+				if err == nil {
+					return provider, nil
+				}
+				r.logger.Printf("Requested provider %q not available: %v", opts.preferredProvider, err)
+			}
+		} else {
+			provider, err := r.registry.Get(ctx, opts.preferredProvider)
+			if err == nil {
+				return provider, nil
+			}
+			r.logger.Printf("Requested provider %q not available: %v", opts.preferredProvider, err)
 		}
-		r.logger.Printf("Requested provider %q not available: %v", opts.preferredProvider, err)
 	}
 
 	// Get healthy providers
@@ -253,7 +279,24 @@ func (r *Router) selectProvider(ctx context.Context, req CompletionRequest, opts
 		healthyNames = r.registry.ListEnabled()
 	}
 
+	// Filter by allowed providers if compliance restrictions apply
+	if len(opts.allowedProviders) > 0 {
+		var filtered []string
+		for _, name := range healthyNames {
+			for _, allowed := range opts.allowedProviders {
+				if name == allowed {
+					filtered = append(filtered, name)
+					break
+				}
+			}
+		}
+		healthyNames = filtered
+	}
+
 	if len(healthyNames) == 0 {
+		if len(opts.allowedProviders) > 0 {
+			return nil, fmt.Errorf("no compliant providers available (allowed: %v)", opts.allowedProviders)
+		}
 		return nil, fmt.Errorf("no providers available")
 	}
 
@@ -316,16 +359,34 @@ func (r *Router) getWeights(providers []string, overrides map[string]float64) ma
 	return weights
 }
 
-// getFallbackProvider returns a fallback provider.
-func (r *Router) getFallbackProvider(ctx context.Context, failedProvider string) (Provider, error) {
+// getFallbackProvider returns a fallback provider, respecting allowed providers for compliance.
+// If allowedProviders is empty, any healthy provider can be used.
+// If allowedProviders is set, only providers in that list can be used for failover.
+func (r *Router) getFallbackProvider(ctx context.Context, failedProvider string, allowedProviders []string) (Provider, error) {
 	healthyNames := r.registry.GetHealthyProviders()
 
+	// Helper to check if provider is in allowed list
+	isAllowed := func(name string) bool {
+		if len(allowedProviders) == 0 {
+			return true // No restrictions
+		}
+		for _, allowed := range allowedProviders {
+			if name == allowed {
+				return true
+			}
+		}
+		return false
+	}
+
 	for _, name := range healthyNames {
-		if name != failedProvider {
+		if name != failedProvider && isAllowed(name) {
 			return r.registry.Get(ctx, name)
 		}
 	}
 
+	if len(allowedProviders) > 0 {
+		return nil, fmt.Errorf("no compliant fallback provider available (allowed: %v)", allowedProviders)
+	}
 	return nil, fmt.Errorf("no fallback provider available")
 }
 
@@ -459,6 +520,7 @@ type routeOptions struct {
 	preferredProvider string
 	weights           map[string]float64
 	disableFailover   bool
+	allowedProviders  []string // Strict provider list for compliance (empty = all providers allowed)
 }
 
 // WithPreferredProvider sets a preferred provider for the request.
@@ -479,6 +541,16 @@ func WithRouteWeights(weights map[string]float64) RouteOption {
 func WithDisableFailover() RouteOption {
 	return func(o *routeOptions) {
 		o.disableFailover = true
+	}
+}
+
+// WithAllowedProviders sets a strict list of providers for compliance.
+// When set, failover can ONLY occur within these providers.
+// Use this for GDPR, PII, or other compliance scenarios where certain
+// providers must not be used regardless of availability.
+func WithAllowedProviders(providers []string) RouteOption {
+	return func(o *routeOptions) {
+		o.allowedProviders = providers
 	}
 }
 

--- a/platform/orchestrator/llm/router_test.go
+++ b/platform/orchestrator/llm/router_test.go
@@ -374,4 +374,318 @@ func TestRouteOptions(t *testing.T) {
 			t.Error("disableFailover should be true")
 		}
 	})
+
+	t.Run("WithAllowedProviders", func(t *testing.T) {
+		opts := &routeOptions{}
+		WithAllowedProviders([]string{"ollama", "azure"})(opts)
+		if len(opts.allowedProviders) != 2 {
+			t.Errorf("allowedProviders length = %d, want 2", len(opts.allowedProviders))
+		}
+		if opts.allowedProviders[0] != "ollama" || opts.allowedProviders[1] != "azure" {
+			t.Error("allowedProviders should contain ollama and azure")
+		}
+	})
 }
+
+// =============================================================================
+// Issue #883: Tests for allowedProviders strict provider enforcement
+// =============================================================================
+
+func TestRouter_AllowedProviders_SelectProvider(t *testing.T) {
+	ctx := context.Background()
+	router := setupTestRouter(t)
+
+	// Register multiple providers
+	_ = router.registry.Register(ctx, &ProviderConfig{
+		Name:    "openai-test",
+		Type:    ProviderTypeOpenAI,
+		APIKey:  "test",
+		Enabled: true,
+	})
+	_ = router.registry.Register(ctx, &ProviderConfig{
+		Name:    "anthropic-test",
+		Type:    ProviderTypeAnthropic,
+		APIKey:  "test",
+		Enabled: true,
+	})
+	_ = router.registry.Register(ctx, &ProviderConfig{
+		Name:    "ollama-test",
+		Type:    ProviderTypeOllama,
+		Enabled: true,
+	})
+
+	// Trigger lazy instantiation and health check
+	_, _ = router.registry.Get(ctx, "openai-test")
+	_, _ = router.registry.Get(ctx, "anthropic-test")
+	_, _ = router.registry.Get(ctx, "ollama-test")
+	router.registry.HealthCheck(ctx)
+
+	t.Run("routes only to allowed providers", func(t *testing.T) {
+		req := CompletionRequest{
+			Prompt:    "Hello",
+			MaxTokens: 100,
+		}
+
+		// Route with only ollama-test allowed
+		counts := make(map[string]int)
+		for i := 0; i < 50; i++ {
+			_, info, err := router.RouteRequest(ctx, req, WithAllowedProviders([]string{"ollama-test"}))
+			if err != nil {
+				t.Fatalf("RouteRequest error: %v", err)
+			}
+			counts[info.ProviderName]++
+		}
+
+		// Should only have ollama-test
+		if counts["ollama-test"] != 50 {
+			t.Errorf("ollama-test count = %d, want 50", counts["ollama-test"])
+		}
+		if counts["openai-test"] != 0 || counts["anthropic-test"] != 0 {
+			t.Error("should not route to non-allowed providers")
+		}
+	})
+
+	t.Run("preferred provider must be in allowed list", func(t *testing.T) {
+		req := CompletionRequest{
+			Prompt:    "Hello",
+			MaxTokens: 100,
+		}
+
+		// Prefer openai-test but only allow ollama-test
+		_, info, err := router.RouteRequest(ctx, req,
+			WithPreferredProvider("openai-test"),
+			WithAllowedProviders([]string{"ollama-test"}),
+		)
+		if err != nil {
+			t.Fatalf("RouteRequest error: %v", err)
+		}
+
+		// Should ignore preferred and use allowed
+		if info.ProviderName != "ollama-test" {
+			t.Errorf("provider = %q, want ollama-test (preferred was not in allowed list)", info.ProviderName)
+		}
+	})
+
+	t.Run("preferred provider in allowed list is used", func(t *testing.T) {
+		req := CompletionRequest{
+			Prompt:    "Hello",
+			MaxTokens: 100,
+		}
+
+		// Prefer anthropic-test and it's in allowed list
+		_, info, err := router.RouteRequest(ctx, req,
+			WithPreferredProvider("anthropic-test"),
+			WithAllowedProviders([]string{"ollama-test", "anthropic-test"}),
+		)
+		if err != nil {
+			t.Fatalf("RouteRequest error: %v", err)
+		}
+
+		if info.ProviderName != "anthropic-test" {
+			t.Errorf("provider = %q, want anthropic-test", info.ProviderName)
+		}
+	})
+}
+
+func TestRouter_AllowedProviders_NoCompliantProviders(t *testing.T) {
+	ctx := context.Background()
+	router := setupTestRouter(t)
+
+	// Register only openai provider
+	_ = router.registry.Register(ctx, &ProviderConfig{
+		Name:    "openai-only",
+		Type:    ProviderTypeOpenAI,
+		APIKey:  "test",
+		Enabled: true,
+	})
+	_, _ = router.registry.Get(ctx, "openai-only")
+	router.registry.HealthCheck(ctx)
+
+	t.Run("fails when no compliant providers available", func(t *testing.T) {
+		req := CompletionRequest{
+			Prompt:    "Hello",
+			MaxTokens: 100,
+		}
+
+		// Request ollama-test but only openai is available
+		_, _, err := router.RouteRequest(ctx, req, WithAllowedProviders([]string{"ollama-test"}))
+		if err == nil {
+			t.Fatal("expected error when no compliant providers available")
+		}
+		// Should mention compliance in error
+		if !containsString(err.Error(), "compliant") && !containsString(err.Error(), "allowed") {
+			t.Errorf("error should mention compliance context: %v", err)
+		}
+	})
+}
+
+func TestRouter_AllowedProviders_Failover(t *testing.T) {
+	ctx := context.Background()
+
+	// Create registry with custom factory that can simulate failures
+	fm := NewFactoryManager()
+
+	// Create a failing provider by setting completeErr
+	fm.Register(ProviderTypeOpenAI, func(config ProviderConfig) (Provider, error) {
+		mock := NewMockProvider(config.Name, config.Type)
+		mock.healthStatus = HealthStatusHealthy
+		if config.Name == "failing-provider" {
+			mock.completeErr = NewProviderError("failing-provider", ErrCodeRateLimit, "simulated failure")
+		}
+		return mock, nil
+	})
+	fm.Register(ProviderTypeAnthropic, func(config ProviderConfig) (Provider, error) {
+		mock := NewMockProvider(config.Name, config.Type)
+		mock.healthStatus = HealthStatusHealthy
+		return mock, nil
+	})
+	fm.Register(ProviderTypeOllama, func(config ProviderConfig) (Provider, error) {
+		mock := NewMockProvider(config.Name, config.Type)
+		mock.healthStatus = HealthStatusHealthy
+		return mock, nil
+	})
+
+	registry := NewRegistry(WithFactoryManager(fm))
+	router := NewRouter(WithRouterRegistry(registry))
+
+	// Register providers
+	_ = router.registry.Register(ctx, &ProviderConfig{
+		Name:    "failing-provider",
+		Type:    ProviderTypeOpenAI,
+		APIKey:  "test",
+		Enabled: true,
+	})
+	_ = router.registry.Register(ctx, &ProviderConfig{
+		Name:    "anthropic-backup",
+		Type:    ProviderTypeAnthropic,
+		APIKey:  "test",
+		Enabled: true,
+	})
+	_ = router.registry.Register(ctx, &ProviderConfig{
+		Name:    "ollama-compliant",
+		Type:    ProviderTypeOllama,
+		Enabled: true,
+	})
+
+	_, _ = router.registry.Get(ctx, "failing-provider")
+	_, _ = router.registry.Get(ctx, "anthropic-backup")
+	_, _ = router.registry.Get(ctx, "ollama-compliant")
+	router.registry.HealthCheck(ctx)
+
+	t.Run("failover respects allowed providers", func(t *testing.T) {
+		req := CompletionRequest{
+			Prompt:    "Hello",
+			MaxTokens: 100,
+		}
+
+		// Prefer failing provider, allow only failing and ollama (not anthropic)
+		_, info, err := router.RouteRequest(ctx, req,
+			WithPreferredProvider("failing-provider"),
+			WithAllowedProviders([]string{"failing-provider", "ollama-compliant"}),
+		)
+
+		if err != nil {
+			t.Fatalf("RouteRequest error: %v", err)
+		}
+
+		// Should failover to ollama (not anthropic, which is healthier but not allowed)
+		if info.ProviderName != "ollama-compliant" {
+			t.Errorf("provider = %q, want ollama-compliant (failover should respect allowed list)", info.ProviderName)
+		}
+	})
+
+	t.Run("failover fails when no compliant fallback", func(t *testing.T) {
+		req := CompletionRequest{
+			Prompt:    "Hello",
+			MaxTokens: 100,
+		}
+
+		// Only allow the failing provider - no compliant fallback available
+		_, _, err := router.RouteRequest(ctx, req,
+			WithPreferredProvider("failing-provider"),
+			WithAllowedProviders([]string{"failing-provider"}),
+		)
+
+		if err == nil {
+			t.Fatal("expected error when no compliant fallback available")
+		}
+
+		// Should mention compliance in error
+		if !containsString(err.Error(), "compliant") && !containsString(err.Error(), "allowed") {
+			t.Errorf("error should mention compliance context: %v", err)
+		}
+	})
+}
+
+func TestRouter_GetFallbackProvider(t *testing.T) {
+	ctx := context.Background()
+	router := setupTestRouter(t)
+
+	// Register multiple providers
+	_ = router.registry.Register(ctx, &ProviderConfig{
+		Name:    "provider-a",
+		Type:    ProviderTypeOpenAI,
+		APIKey:  "test",
+		Enabled: true,
+	})
+	_ = router.registry.Register(ctx, &ProviderConfig{
+		Name:    "provider-b",
+		Type:    ProviderTypeAnthropic,
+		APIKey:  "test",
+		Enabled: true,
+	})
+	_ = router.registry.Register(ctx, &ProviderConfig{
+		Name:    "provider-c",
+		Type:    ProviderTypeOllama,
+		Enabled: true,
+	})
+
+	_, _ = router.registry.Get(ctx, "provider-a")
+	_, _ = router.registry.Get(ctx, "provider-b")
+	_, _ = router.registry.Get(ctx, "provider-c")
+	router.registry.HealthCheck(ctx)
+
+	t.Run("returns fallback excluding failed provider", func(t *testing.T) {
+		fallback, err := router.getFallbackProvider(ctx, "provider-a", nil)
+		if err != nil {
+			t.Fatalf("getFallbackProvider error: %v", err)
+		}
+		if fallback.Name() == "provider-a" {
+			t.Error("fallback should not be the failed provider")
+		}
+	})
+
+	t.Run("respects allowed providers", func(t *testing.T) {
+		fallback, err := router.getFallbackProvider(ctx, "provider-a", []string{"provider-c"})
+		if err != nil {
+			t.Fatalf("getFallbackProvider error: %v", err)
+		}
+		if fallback.Name() != "provider-c" {
+			t.Errorf("fallback = %q, want provider-c", fallback.Name())
+		}
+	})
+
+	t.Run("returns error when no compliant fallback", func(t *testing.T) {
+		// Allow only provider-a, but it's the failed one
+		_, err := router.getFallbackProvider(ctx, "provider-a", []string{"provider-a"})
+		if err == nil {
+			t.Fatal("expected error when no compliant fallback")
+		}
+		if !containsString(err.Error(), "compliant") && !containsString(err.Error(), "allowed") {
+			t.Errorf("error should mention compliance: %v", err)
+		}
+	})
+
+	t.Run("empty allowed list means all providers OK", func(t *testing.T) {
+		fallback, err := router.getFallbackProvider(ctx, "provider-a", []string{})
+		if err != nil {
+			t.Fatalf("getFallbackProvider error: %v", err)
+		}
+		// Should return any healthy provider except provider-a
+		if fallback.Name() == "provider-a" {
+			t.Error("fallback should not be the failed provider")
+		}
+	})
+}
+
+// Note: containsString helper is already defined in factory_test.go

--- a/platform/orchestrator/llm/unified_router.go
+++ b/platform/orchestrator/llm/unified_router.go
@@ -81,8 +81,23 @@ func (u *UnifiedRouter) RouteRequest(ctx context.Context, reqCtx RequestContext)
 
 	// Build route options
 	var opts []RouteOption
-	if reqCtx.Provider != "" {
+
+	// Policy-based routing takes precedence (Issue #883 - strict provider enforcement)
+	// This ensures dynamic policies can enforce compliance requirements (GDPR, PII, etc.)
+	if reqCtx.PolicyPreferredProvider != "" {
+		opts = append(opts, WithPreferredProvider(reqCtx.PolicyPreferredProvider))
+		u.logger.Printf("Policy routing: preferred provider=%s reason=%s",
+			reqCtx.PolicyPreferredProvider, reqCtx.PolicyRoutingReason)
+	} else if reqCtx.Provider != "" {
+		// Fall back to explicit provider request if no policy override
 		opts = append(opts, WithPreferredProvider(reqCtx.Provider))
+	}
+
+	// Strict provider enforcement: failover can ONLY occur within allowed providers
+	if len(reqCtx.PolicyAllowedProviders) > 0 {
+		opts = append(opts, WithAllowedProviders(reqCtx.PolicyAllowedProviders))
+		u.logger.Printf("Policy routing: allowed providers=%v (strict enforcement)",
+			reqCtx.PolicyAllowedProviders)
 	}
 
 	// Route using new router

--- a/platform/orchestrator/llm_request_adapter.go
+++ b/platform/orchestrator/llm_request_adapter.go
@@ -5,6 +5,7 @@ package orchestrator
 
 import (
 	"context"
+	"log"
 
 	"axonflow/platform/orchestrator/llm"
 )
@@ -86,6 +87,19 @@ func OrchestratorRequestToLLMContext(req OrchestratorRequest) llm.RequestContext
 	temperature := 0.0
 	systemPrompt := ""
 
+	// Policy routing hints (Issue #883 - strict provider enforcement)
+	policyPreferredProvider := ""
+	var policyAllowedProviders []string
+	policyRoutingReason := ""
+
+	// Debug: Log the context to trace policy routing
+	if req.Context != nil && (req.Context["policy_preferred_provider"] != nil || req.Context["policy_allowed_providers"] != nil) {
+		log.Printf("[LLM_ADAPTER] Policy routing context detected: preferred=%v, allowed=%v, reason=%v",
+			req.Context["policy_preferred_provider"],
+			req.Context["policy_allowed_providers"],
+			req.Context["policy_routing_reason"])
+	}
+
 	if req.Context != nil {
 		if p, ok := req.Context["provider"].(string); ok {
 			provider = p
@@ -105,23 +119,37 @@ func OrchestratorRequestToLLMContext(req OrchestratorRequest) llm.RequestContext
 		if sp, ok := req.Context["system_prompt"].(string); ok {
 			systemPrompt = sp
 		}
+
+		// Extract policy routing hints injected by dynamic policy evaluation
+		if pp, ok := req.Context["policy_preferred_provider"].(string); ok {
+			policyPreferredProvider = pp
+		}
+		if ap, ok := req.Context["policy_allowed_providers"].([]string); ok {
+			policyAllowedProviders = ap
+		}
+		if pr, ok := req.Context["policy_routing_reason"].(string); ok {
+			policyRoutingReason = pr
+		}
 	}
 
 	return llm.RequestContext{
-		Query:           req.Query,
-		RequestType:     req.RequestType,
-		UserRole:        req.User.Role,
-		UserPermissions: req.User.Permissions,
-		ClientID:        req.Client.ID,
-		OrgID:           req.Client.OrgID,
-		TenantID:        req.Client.TenantID,
-		Provider:        provider,
-		Model:           model,
-		MaxTokens:       maxTokens,
-		Temperature:     temperature,
-		SystemPrompt:    systemPrompt,
-		AllowLocal:      true, // Allow local/ollama by default
-		Metadata:        req.Context,
+		Query:                   req.Query,
+		RequestType:             req.RequestType,
+		UserRole:                req.User.Role,
+		UserPermissions:         req.User.Permissions,
+		ClientID:                req.Client.ID,
+		OrgID:                   req.Client.OrgID,
+		TenantID:                req.Client.TenantID,
+		Provider:                provider,
+		Model:                   model,
+		MaxTokens:               maxTokens,
+		Temperature:             temperature,
+		SystemPrompt:            systemPrompt,
+		AllowLocal:              true, // Allow local/ollama by default
+		Metadata:                req.Context,
+		PolicyPreferredProvider: policyPreferredProvider,
+		PolicyAllowedProviders:  policyAllowedProviders,
+		PolicyRoutingReason:     policyRoutingReason,
 	}
 }
 

--- a/platform/orchestrator/run.go
+++ b/platform/orchestrator/run.go
@@ -75,8 +75,9 @@ var (
 	usageDB            *sql.DB                            // Database for usage metering
 	heartbeatService   *node_enforcement.HeartbeatService // Node enforcement
 	nodeMonitor        *node_enforcement.NodeMonitor      // Node enforcement
-	policyAPIHandler      *PolicyAPIHandler                  // Policy CRUD API handler
-	templateAPIHandler    *TemplateAPIHandler                // Policy Templates API handler
+	policyAPIHandler         *PolicyAPIHandler         // Policy CRUD API handler
+	dynamicPolicyAPIHandler  *DynamicPolicyAPIHandler  // Dynamic Policy API handler (ADR-026)
+	templateAPIHandler       *TemplateAPIHandler       // Policy Templates API handler
 	llmProviderRouter     *llm.UnifiedRouter                 // Unified LLM provider router (ADR-007, ADR-022)
 	llmRouterWrapper      LLMRouterInterface                 // Interface for router compatibility (ADR-022 Phase 6)
 	llmProviderAPIHandler *LLMProviderAPIHandler             // LLM Provider REST API handler
@@ -207,6 +208,7 @@ type UserContext struct {
 	ID          int      `json:"id"`
 	Email       string   `json:"email"`
 	Role        string   `json:"role"`
+	Region      string   `json:"region"` // User's region for geo-based routing policies
 	Permissions []string `json:"permissions"`
 	TenantID    string   `json:"tenant_id"`
 }
@@ -237,6 +239,11 @@ type PolicyEvaluationResult struct {
 	RequiredActions  []string `json:"required_actions"`
 	ProcessingTimeMs int64    `json:"processing_time_ms"`
 	DatabaseAccessed bool     `json:"database_accessed,omitempty"`
+
+	// LLM Routing overrides from dynamic policies
+	PreferredProvider string   `json:"preferred_provider,omitempty"` // Preferred LLM provider
+	AllowedProviders  []string `json:"allowed_providers,omitempty"`  // Strict list for compliance (failover only within this list)
+	RoutingReason     string   `json:"routing_reason,omitempty"`     // Why routing was changed
 }
 
 type ProviderInfo struct {
@@ -415,6 +422,13 @@ func Run() {
 	r.HandleFunc("/api/v1/templates/stats", templateAPIStatsHandler).Methods("GET", "OPTIONS")
 	r.HandleFunc("/api/v1/templates/{id}", templateAPIGetHandler).Methods("GET", "OPTIONS")
 	r.HandleFunc("/api/v1/templates/{id}/apply", templateAPIApplyHandler).Methods("POST", "OPTIONS")
+
+	// Dynamic Policy API (ADR-026: Single Entry Point Architecture)
+	// New consistent path: /api/v1/dynamic-policies (matches /api/v1/static-policies pattern)
+	if dynamicPolicyAPIHandler != nil {
+		dynamicPolicyAPIHandler.RegisterRoutes(r)
+		log.Println("Dynamic Policy API routes registered (/api/v1/dynamic-policies)")
+	}
 
 	// LLM Provider Management API (ADR-007 - Pluggable LLM Providers)
 	// Register routes only if bootstrap was successful
@@ -834,6 +848,10 @@ func initializeComponents() {
 		policyAPIHandler = NewPolicyAPIHandler(policyService)
 		log.Println("Policy CRUD API initialized ✅")
 
+		// Initialize Dynamic Policy API (ADR-026: Single Entry Point)
+		dynamicPolicyAPIHandler = NewDynamicPolicyAPIHandler(policyService)
+		log.Println("Dynamic Policy API initialized ✅ (ADR-026)")
+
 		// Initialize Policy Templates API (Track D - Policy Templates)
 		log.Println("Initializing Policy Templates API...")
 		templateRepo := NewTemplateRepository(usageDB)
@@ -1003,6 +1021,25 @@ func processRequestHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		orchestratorMetrics.dynamicPolicyTimings = append(orchestratorMetrics.dynamicPolicyTimings, policyMs)
 		orchestratorMetrics.mu.Unlock()
+	}
+
+	// Inject policy routing hints into request context for LLM router (Issue #883)
+	// This ensures dynamic policies can enforce strict provider compliance
+	if policyResult.PreferredProvider != "" || len(policyResult.AllowedProviders) > 0 {
+		if req.Context == nil {
+			req.Context = make(map[string]interface{})
+		}
+		if policyResult.PreferredProvider != "" {
+			req.Context["policy_preferred_provider"] = policyResult.PreferredProvider
+		}
+		if len(policyResult.AllowedProviders) > 0 {
+			req.Context["policy_allowed_providers"] = policyResult.AllowedProviders
+		}
+		if policyResult.RoutingReason != "" {
+			req.Context["policy_routing_reason"] = policyResult.RoutingReason
+		}
+		log.Printf("[POLICY_ROUTING] Injected routing hints: preferred=%s, allowed=%v, reason=%s",
+			policyResult.PreferredProvider, policyResult.AllowedProviders, policyResult.RoutingReason)
 	}
 
 	if !policyResult.Allowed {


### PR DESCRIPTION
Changes synced from enterprise:

**Single Entry Point Architecture (ADR-026):**
- Agent (port 8080) proxies requests to Orchestrator and Portal internally
- New proxy infrastructure with path-based routing
- Eliminates need for clients to configure multiple endpoints

**Tiered Detection Defaults (Issue #891):**
- New detection action environment variables: SQLI_ACTION, PII_ACTION, SENSITIVE_DATA_ACTION, HIGH_RISK_ACTION, DANGEROUS_QUERY_ACTION
- Philosophy: "Block high-confidence threats, warn on heuristics, redact PII"
- PII default changed from block to redact

**Strict Provider Enforcement (Issue #883):**
- Dynamic policy allowed_providers enforced during failover
- Intersection logic for multiple policies (least privilege)
- Condition evaluation with 10 operators: equals, not_equals, contains, regex, in, etc.
- Fix: tenant extraction Client.ID → Client.TenantID

**README UX Improvements:**
- docker-compose → docker compose (deprecated V1 syntax)
- Added prerequisites, wait guidance, service ports table
- Fresh environment tested and verified

Additional Changes:
- feat(migrations): add circuit_breaker table for agent (#874)
- feat(examples): add portal-auth examples (#875)
- feat(examples): add EU AI Act HTTP examples (#870)
- feat(examples): add audit log read demonstrations
- refactor(support-demo): consolidate to single location (#879)
- docs(adr): add ADR-026 and ADR-027

Source commits:
- 89b736e0
- ae59d5ff
- ae050d92
- 5c37072b
- b8783790
- 374a47bf
- b86a0aaf
- ec97f287
- cc6b0848
- 332e6ce9
- 42b8f050
- fc431731
- 1684e160
- 4eb662ff
- 297c8874
- cc9f71b1
- 767b136f
- 80e64925

Enterprise PRs: #868, #870, #874, #875, #876, #879, #880, #882, #888, #892, #893, #894, #895, #896, #898, #901

Authored-by: Saurabh Jain <saurabhjain1592@gmail.com>

Co-authored-by: AxonFlow Team <bot@getaxonflow.com>