### PR TITLE
fix(examples): use orchestrator endpoint for dynamic policies

### DIFF
--- a/examples/dynamic-policies/compliance/http/compliance-policies.sh
+++ b/examples/dynamic-policies/compliance/http/compliance-policies.sh
@@ -15,11 +15,13 @@
 #   ./compliance-policies.sh
 #
 # Environment:
-#   AXONFLOW_ENDPOINT - Agent URL (default: http://localhost:8080)
+#   AXONFLOW_ORCHESTRATOR_ENDPOINT - Orchestrator URL (default: http://localhost:8081)
+#
+# Note: Dynamic policies are managed by the Orchestrator, not the Agent.
 
 set -e
 
-ENDPOINT="${AXONFLOW_ENDPOINT:-http://localhost:8080}"
+ENDPOINT="${AXONFLOW_ORCHESTRATOR_ENDPOINT:-http://localhost:8081}"
 ORG_ID="${ORG_ID:-demo-org}"
 TENANT_ID="${TENANT_ID:-demo-tenant}"
 


### PR DESCRIPTION
## Summary

Updates compliance-policies.sh to use the Orchestrator endpoint (port 8081) instead of Agent (port 8080).

## Problem

Dynamic policies are managed by the Orchestrator, not the Agent. The script was calling port 8080 which returned 404 for `/api/v1/policies/dynamic`.

## Solution

Changed default endpoint from `localhost:8080` to `localhost:8081` and updated environment variable name to `AXONFLOW_ORCHESTRATOR_ENDPOINT`.