### PR TITLE
feat: circuit breaker Phase 2B, per-tool governance examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [5.3.0] - 2026-03-17
+
+### Community
+
+#### Added
+
+- **Circuit breaker error auto-trip** (#1176): Upstream LLM errors (orchestrator hard failures, orchestrator-level errors, proxy 502s) now automatically trip client-scoped circuits after threshold exceeded within a sliding window. Previously, `RecordError` was implemented but not wired into the request pipeline.
+- **Sliding window for circuit breaker thresholds** (#1176): Error and policy violation counting now uses a time-windowed approach (default 5 minutes) instead of lifetime counters. Errors outside the window are automatically discarded.
+- **Per-tool governance examples** (#1243): LangGraph adapter examples for TypeScript, Go, and Java demonstrating per-tool gate checks within tools nodes.
+- **WCP guide updated**: Workflow Control Plane documentation expanded with TypeScript, Go, and Java LangGraph adapter examples alongside Python.
+
+### Enterprise
+
+#### Added
+
+- **Per-tenant circuit breaker thresholds** (#1176): Tenants can override global circuit breaker defaults (error threshold, violation threshold, window duration, timeout, auto-recovery) via `GET/PUT /api/v1/circuit-breaker/config`. Null fields fall back to global defaults. In-memory cache with 1-minute TTL.
+- **Circuit breaker notification fan-out** (#1176): Auto-trip events trigger notifications via webhook (HMAC-SHA256 signed), Slack (Block Kit), or PagerDuty (Events API v2). CRUD endpoints at `/api/v1/circuit-breaker/notifications`. Includes SSRF protection (private IP rejection) and retry with exponential backoff.
+- **SDK circuit breaker observability** (#1176): New methods across all 4 SDKs: `GetCircuitBreakerStatus`, `GetCircuitBreakerHistory`, `GetCircuitBreakerConfig`, `UpdateCircuitBreakerConfig`.
+
+---
+
 ## [5.2.0] - 2026-03-14
 
 ### Community

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Use the Workflow Control Plane (WCP) to manage multi-step AI workflows with step
 
 This creates a WCP workflow, runs step-level gate checks, records a step ledger, demonstrates cancellation, and shows unified execution status.
 
-> **[Execution tracking guide](https://docs.getaxonflow.com/docs/orchestration/workflow-control-plane)** — WCP workflow creation, step gates, SSE streaming, and unified execution status.
+> **[Execution tracking guide](https://docs.getaxonflow.com/docs/orchestration/wcp/overview)** — WCP workflow creation, step gates, SSE streaming, and unified execution status.
 
 ---
 

--- a/docs/api/agent-api.yaml
+++ b/docs/api/agent-api.yaml
@@ -1410,21 +1410,220 @@ paths:
       tags:
         - Circuit Breaker
       summary: Get circuit breaker status
+      description: |
+        Returns all active (open) circuits for the organization.
+        Uses X-Org-ID header for org identification.
       operationId: getCircuitBreakerStatus
       parameters:
         - $ref: '#/components/parameters/LicenseKey'
-        - name: org_id
+      responses:
+        '200':
+          description: Active circuit breaker circuits
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      active_circuits:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/CircuitBreaker'
+                      count:
+                        type: integer
+                      emergency_stop_active:
+                        type: boolean
+        '400':
+          $ref: '#/components/responses/BadRequest'
+
+  /api/v1/circuit-breaker/history:
+    get:
+      tags:
+        - Circuit Breaker
+      summary: Get circuit breaker history
+      description: |
+        Returns circuit breaker trip/reset history for audit trail.
+        Ordered by creation time descending.
+      operationId: getCircuitBreakerHistory
+      parameters:
+        - $ref: '#/components/parameters/LicenseKey'
+        - name: limit
           in: query
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 50
+      responses:
+        '200':
+          description: Circuit breaker history
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      history:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/CircuitBreaker'
+                      count:
+                        type: integer
+        '400':
+          $ref: '#/components/responses/BadRequest'
+
+  /api/v1/circuit-breaker/config:
+    get:
+      tags:
+        - Circuit Breaker
+      summary: Get circuit breaker config
+      description: |
+        Returns effective circuit breaker configuration. If tenant_id is provided,
+        returns tenant-specific overrides merged with global defaults. Otherwise
+        returns global defaults.
+      operationId: getCircuitBreakerConfig
+      parameters:
+        - $ref: '#/components/parameters/LicenseKey'
+        - name: tenant_id
+          in: query
+          schema:
+            type: string
+          description: Optional tenant ID for tenant-specific config
+      responses:
+        '200':
+          description: Effective circuit breaker configuration
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    $ref: '#/components/schemas/CircuitBreakerConfigResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+    put:
+      tags:
+        - Circuit Breaker
+      summary: Update per-tenant circuit breaker config
+      description: |
+        Creates or updates per-tenant circuit breaker threshold overrides.
+        Null fields fall back to global defaults.
+      operationId: updateCircuitBreakerConfig
+      parameters:
+        - $ref: '#/components/parameters/LicenseKey'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CircuitBreakerConfigUpdate'
+      responses:
+        '200':
+          description: Config updated
+        '400':
+          $ref: '#/components/responses/BadRequest'
+
+  /api/v1/circuit-breaker/notifications:
+    get:
+      tags:
+        - Circuit Breaker
+      summary: List notification configs
+      description: Returns all circuit breaker notification configs for the organization.
+      operationId: listCircuitBreakerNotifications
+      parameters:
+        - $ref: '#/components/parameters/LicenseKey'
+      responses:
+        '200':
+          description: Notification configs
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      notifications:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/CircuitBreakerNotificationConfig'
+                      count:
+                        type: integer
+    post:
+      tags:
+        - Circuit Breaker
+      summary: Create notification config
+      description: |
+        Create a notification channel for circuit breaker auto-trip events.
+        Supports webhook (HMAC-signed), Slack (Block Kit), and PagerDuty (Events API v2).
+      operationId: createCircuitBreakerNotification
+      parameters:
+        - $ref: '#/components/parameters/LicenseKey'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CircuitBreakerNotificationCreate'
+      responses:
+        '201':
+          description: Notification config created
+        '400':
+          $ref: '#/components/responses/BadRequest'
+
+  /api/v1/circuit-breaker/notifications/{id}:
+    put:
+      tags:
+        - Circuit Breaker
+      summary: Update notification config
+      operationId: updateCircuitBreakerNotification
+      parameters:
+        - $ref: '#/components/parameters/LicenseKey'
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CircuitBreakerNotificationUpdate'
+      responses:
+        '200':
+          description: Notification config updated
+        '404':
+          description: Notification config not found
+    delete:
+      tags:
+        - Circuit Breaker
+      summary: Delete notification config
+      operationId: deleteCircuitBreakerNotification
+      parameters:
+        - $ref: '#/components/parameters/LicenseKey'
+        - name: id
+          in: path
           required: true
           schema:
             type: string
       responses:
         '200':
-          description: Circuit breaker status
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/CircuitBreaker'
+          description: Notification config deleted
+        '404':
+          description: Notification config not found
 
   # ==========================================================================
   # Accuracy & Bias Detection (EU AI Act Article 15)
@@ -4322,6 +4521,127 @@ components:
         requires_two_person:
           type: boolean
           description: Whether two-person authorization is required
+
+    CircuitBreakerConfigResponse:
+      type: object
+      properties:
+        source:
+          type: string
+          enum: [global, tenant]
+          description: Whether config is global defaults or tenant-specific
+        error_threshold:
+          type: integer
+          description: Number of errors in window to trigger auto-trip
+        violation_threshold:
+          type: integer
+          description: Number of policy violations in window to trigger auto-trip
+        window_seconds:
+          type: integer
+          description: Sliding window duration for counting events
+        default_timeout_seconds:
+          type: integer
+          description: How long a circuit stays open before auto-recovery
+        max_timeout_seconds:
+          type: integer
+          description: Maximum allowed circuit timeout
+        enable_auto_recovery:
+          type: boolean
+          description: Whether open circuits automatically close after timeout
+        tenant_id:
+          type: string
+          description: Tenant ID (present when source is tenant)
+        overrides:
+          type: object
+          description: Tenant-specific override values (present when source is tenant)
+
+    CircuitBreakerConfigUpdate:
+      type: object
+      required:
+        - tenant_id
+      properties:
+        tenant_id:
+          type: string
+        error_threshold:
+          type: integer
+          nullable: true
+        violation_threshold:
+          type: integer
+          nullable: true
+        window_seconds:
+          type: integer
+          nullable: true
+        default_timeout_seconds:
+          type: integer
+          nullable: true
+        max_timeout_seconds:
+          type: integer
+          nullable: true
+        enable_auto_recovery:
+          type: boolean
+          nullable: true
+
+    CircuitBreakerNotificationConfig:
+      type: object
+      properties:
+        id:
+          type: string
+        org_id:
+          type: string
+        tenant_id:
+          type: string
+        type:
+          type: string
+          enum: [webhook, slack, pagerduty]
+        url:
+          type: string
+        secret:
+          type: string
+          description: Masked in GET responses
+        active:
+          type: boolean
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
+    CircuitBreakerNotificationCreate:
+      type: object
+      required:
+        - type
+        - url
+      properties:
+        type:
+          type: string
+          enum: [webhook, slack, pagerduty]
+        url:
+          type: string
+          description: Webhook URL, Slack incoming webhook URL, or PagerDuty override URL
+        secret:
+          type: string
+          description: HMAC secret for webhooks, or PagerDuty routing key
+        tenant_id:
+          type: string
+          description: Optional tenant filter for notifications
+        active:
+          type: boolean
+          default: true
+
+    CircuitBreakerNotificationUpdate:
+      type: object
+      properties:
+        type:
+          type: string
+          enum: [webhook, slack, pagerduty]
+        url:
+          type: string
+        secret:
+          type: string
+        tenant_id:
+          type: string
+        active:
+          type: boolean
 
     # ==========================================================================
     # Accuracy & Bias Schemas (EU AI Act Article 15)

--- a/docs/enterprise/customer-portal-access.md
+++ b/docs/enterprise/customer-portal-access.md
@@ -1,0 +1,325 @@
+# Customer Portal Access Guide
+
+## Overview
+
+The Customer Portal provides organization management, execution timeline, approval dashboard, and policy management through a web interface. It consists of two main components:
+
+- **Customer Portal UI** (Next.js, port 3000) -- the frontend
+- **Customer Portal API** (Go, port 8090) -- the backend
+
+Two deployment modes are supported: SaaS (multi-tenant, AxonFlow-hosted) and In-VPC (customer-managed, typically single-tenant).
+
+## Architecture
+
+```
+                         +------------------+
+                         |   ALB (443)      |
+                         +--------+---------+
+                                  |
+              +-------------------+-------------------+
+              |                   |                   |
+     Port 8080 (Agent)   Port 8090 (Portal API)  Port 3000 (Portal UI)
+              |                   |                   |
+   +----------+----------+  +----+----+         +-----+-----+
+   | Agent Gateway        |  | Portal  |         | Next.js   |
+   | - /api/v1/auth/* ----|->| API     |         | Frontend  |
+   |   (proxied, no auth) |  | (Go)    |         |           |
+   | - /api/v1/* (authed) |  +---------+         +-----------+
+   +-----------+----------+
+```
+
+Key points:
+
+- The Agent Gateway on port 8080 proxies all `/api/v1/auth/*` requests to the Portal API. No Basic auth is required on this path, allowing unauthenticated login and SSO flows.
+- The ALB exposes listeners on ports 443 (Agent), 8090 (Portal API), and 3000 (Portal UI).
+- Vanity domains (e.g., `app.getaxonflow.com`) are configured via the `setup-vanity-domain.yml` workflow.
+- The Portal UI requires `API_BACKEND_URL` to be configured to point to the Portal API on port 8090.
+
+## Organization Provisioning
+
+### Method 1: Admin API (Recommended for Running Stacks)
+
+**Endpoint:** `POST https://{stack-domain}:8090/api/v1/admin/organizations`
+
+This is the recommended way to create organizations on an already-running stack. The endpoint is idempotent (uses `ON CONFLICT (org_id) DO UPDATE`).
+
+**Authentication:** See the Admin Auth Matrix below. No auth required for enterprise/in-vpc deployments.
+
+**Request body:**
+
+| Field | Type | Required | Default | Notes |
+|-------|------|----------|---------|-------|
+| `org_id` | string | Yes | -- | Unique organization identifier |
+| `name` | string | Yes | -- | Display name |
+| `license_key` | string | Yes | -- | Pre-generated license key |
+| `password` | string | No | -- | Portal login password (bcrypt hashed internally) |
+| `tier` | string | No | `DEVELOPER` | One of: `DEVELOPER`, `Professional`, `Enterprise`, `Plus` |
+| `status` | string | No | `ACTIVE` | One of: `ACTIVE`, `SUSPENDED`, `CANCELLED` |
+| `max_nodes` | int | No | Tier default | Override default node limit for tier |
+| `contact_email` | string | No | -- | Admin contact email |
+| `contact_phone` | string | No | -- | Admin contact phone |
+| `expires_at` | string | No | 1 year | Format: `YYYY-MM-DD` |
+
+**Example:**
+
+```bash
+curl -X POST https://{stack-domain}:8090/api/v1/admin/organizations \
+  -H "Content-Type: application/json" \
+  -d '{
+    "org_id": "acme-corp",
+    "name": "Acme Corporation",
+    "license_key": "axf_pro_acme_...",
+    "password": "secure-portal-password",
+    "tier": "Professional"
+  }'
+```
+
+For SaaS production, include the admin API key header:
+
+```bash
+curl -X POST https://{stack-domain}:8090/api/v1/admin/organizations \
+  -H "Content-Type: application/json" \
+  -H "X-Admin-API-Key: ${ADMIN_API_KEY}" \
+  -d '{ ... }'
+```
+
+### Method 2: Customer Onboarding API (Full Provisioning)
+
+**Endpoint:** `POST https://{stack-domain}:8090/api/v1/admin/onboard-customer`
+
+This endpoint generates a license key automatically, inserts the organization into the database, and stores the license key in AWS Secrets Manager at `axonflow/customers/{org-id}/license-key`.
+
+**Authentication:** None (legacy endpoint, registered outside the admin auth middleware).
+
+> **Security Warning:** This endpoint is unauthenticated in all deployment modes. In non-SaaS deployments, port 8090 must be network-restricted (security groups, NACLs, or VPN) to prevent unauthorized organization creation. Never expose port 8090 to the public internet without additional access controls.
+
+**Request body:**
+
+| Field | Type | Required | Default | Notes |
+|-------|------|----------|---------|-------|
+| `org_id` | string | Yes | -- | Unique organization identifier |
+| `name` | string | Yes | -- | Display name |
+| `tier` | string | No | `Professional` | One of: `Professional`, `Enterprise`, `Plus` |
+| `validity_days` | int | No | `365` | License validity in days |
+| `email` | string | No | -- | Contact email |
+| `phone` | string | No | -- | Contact phone |
+| `status` | string | No | `ACTIVE` | Organization status |
+| `password` | string | No | -- | Portal login password |
+
+**Example:**
+
+```bash
+curl -X POST https://{stack-domain}:8090/api/v1/admin/onboard-customer \
+  -H "Content-Type: application/json" \
+  -d '{
+    "org_id": "acme-corp",
+    "name": "Acme Corporation",
+    "tier": "Enterprise",
+    "validity_days": 365,
+    "email": "admin@acme.com",
+    "password": "secure-portal-password"
+  }'
+```
+
+The response includes the generated `license_key`, Secrets Manager ARN, and database record ID.
+
+### Method 3: Direct Database Seeding (Test Environments Only)
+
+> **Warning:** This method is for E2E testing only. Do not use direct SQL inserts for customer or production bootstrapping. Use Method 1 or Method 2 instead, which handle password hashing, validation, and audit logging correctly.
+
+For E2E test environments, organizations can be seeded directly via SQL. This approach is used by `scripts/setup-e2e-testing.sh` (approximately lines 730-790).
+
+```sql
+INSERT INTO organizations (org_id, name, license_key, tier, password_hash, status, max_nodes, expires_at)
+VALUES (
+  'test-org',
+  'Test Organization',
+  'axf_test_license_key_here',
+  'Professional',
+  '$2a$12$...', -- bcrypt hash, cost 12
+  'ACTIVE',
+  10,
+  NOW() + INTERVAL '365 days'
+)
+ON CONFLICT (org_id) DO UPDATE SET
+  license_key = EXCLUDED.license_key,
+  password_hash = EXCLUDED.password_hash;
+```
+
+The password must be bcrypt hashed at cost 12. A corresponding row in the `customers` table is also needed for tenant isolation.
+
+**Reference:** `scripts/setup-e2e-testing.sh`
+
+### Method 4: Seed Test Data Workflow (Staging Only)
+
+The `seed-test-data.yml` GitHub Actions workflow seeds organizations via the Admin API on staging environments. Production is blocked.
+
+```bash
+gh workflow run seed-test-data.yml -f environment=staging -f confirm=seed
+```
+
+**Reference:** `.github/workflows/seed-test-data.yml`
+
+## Portal Login
+
+### Password Authentication
+
+**Endpoint:** `POST /api/v1/auth/login`
+
+This endpoint is proxied through the Agent Gateway on port 8080 -- no Basic auth is needed on this path. The Agent forwards all `/api/v1/auth/*` requests to the Portal API without authentication checks.
+
+**Request:**
+
+```json
+{
+  "org_id": "acme-corp",
+  "password": "secure-portal-password"
+}
+```
+
+**Response:**
+
+```json
+{
+  "session_id": "abc123...",
+  "org_id": "acme-corp",
+  "email": "admin@acme.com",
+  "name": "Acme Corporation",
+  "expires_at": "2026-03-17T12:00:00Z"
+}
+```
+
+**Session management:**
+
+- Session cookie: `axonflow_session` (HttpOnly, Secure, SameSite=Lax)
+- Expiry: 24 hours (`MaxAge: 86400`)
+- Rate limit: 5 attempts per minute per IP
+
+**Related endpoints (also proxied through Agent, no Basic auth):**
+
+- `POST /api/v1/auth/logout` -- clears session
+- `GET /api/v1/auth/session` -- checks current session validity
+- `POST /api/v1/auth/forgot-password` -- initiates password reset
+- `POST /api/v1/auth/reset-password` -- completes password reset
+- `POST /api/v1/auth/change-password` -- changes password (authenticated)
+
+### SSO/SAML Authentication
+
+SSO requires `SSO_ENABLED=true` (multi-tenant SAML) or `SAML_ENABLED=true` (single-tenant SAML) environment variables on the Portal API.
+
+**Check availability:**
+
+```
+GET /api/v1/auth/sso/availability?org_id={org_id}
+```
+
+Returns `sso_enabled`, `sso_provider`, `enforce_sso`, and `sso_login_url` if configured.
+
+**SAML login flow:**
+
+1. `GET /auth/saml/{tenantID}/login` -- initiates SAML login redirect to IdP
+2. IdP redirects back to `POST /auth/saml/{tenantID}/callback` (ACS endpoint)
+3. Portal auto-provisions `portal_users` record on first SSO login
+4. Portal creates session and sets `axonflow_session` cookie
+5. User is redirected to `/portal/dashboard`
+
+**Supported IdPs:** Okta, Azure AD, Auth0 (configured per-tenant via SSO config API).
+
+**SAML metadata:** Available at `GET /auth/saml/{tenantID}/metadata` for IdP configuration.
+
+## Deployment Modes
+
+### SaaS Mode
+
+- Multi-tenant, AxonFlow-hosted
+- Admin API requires `X-Admin-API-Key` header in production (read from `ADMIN_API_KEY` env var)
+- Organizations created during customer onboarding by AxonFlow team
+- Portal accessible via vanity domain (e.g., `app.getaxonflow.com`)
+- Tenant isolation via RLS (row-level security)
+
+### In-VPC Mode
+
+- Customer-managed deployment on customer's AWS account
+- Admin API has no auth requirement (customer controls network access)
+- Customer creates their org via Admin API after CloudFormation stack deployment
+- Portal accessible via ALB domain on port 3000, or custom domain via `setup-vanity-domain.yml`
+- Typically single-tenant
+
+## CloudFormation Deployment Notes
+
+The CloudFormation template (`ee/platform/aws-marketplace/cloudformation-ecs-fargate.yaml`) includes a `LicenseKeyGenerator` Lambda that creates a license key and stores it in Secrets Manager. However, this Lambda does NOT create the organization in the database.
+
+After stack creation, the admin must call one of:
+
+- `POST /api/v1/admin/organizations` (Method 1, if you have a license key)
+- `POST /api/v1/admin/onboard-customer` (Method 2, generates its own license key)
+
+The Portal UI container needs `API_BACKEND_URL` configured to point to the Portal API (port 8090).
+
+## Admin Auth Matrix
+
+| DEPLOYMENT_MODE | ENVIRONMENT | Auth Required for Admin API? |
+|-----------------|-------------|------------------------------|
+| `saas` | `production` | Yes -- `X-Admin-API-Key` header required |
+| `saas` | `staging` | Optional -- respected if sent, anonymous allowed |
+| `enterprise` | any | No -- anonymous allowed |
+| `in-vpc-*` | any | No -- customer controls network access |
+| `community` | any | No (no admin portal in community edition) |
+
+When auth is optional and an invalid key is provided, the request is still rejected (constant-time comparison). Only missing keys are allowed through in optional mode.
+
+**Source:** `ee/platform/customer-portal/middleware/admin_auth.go`
+
+## Verification
+
+### Check Portal UI health
+
+```bash
+curl https://{domain}:3000/api/healthz
+```
+
+### Check Portal API health
+
+```bash
+curl https://{domain}:8090/health
+```
+
+### Check deployment configuration
+
+```bash
+curl https://{domain}:8090/api/v1/deployment/config
+```
+
+Returns deployment mode, feature flags, and environment info. This endpoint is unauthenticated (the frontend needs mode info before login).
+
+### Test password login
+
+```bash
+curl -X POST https://{domain}/api/v1/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"org_id": "test-org", "password": "test-password"}'
+```
+
+Note: This goes through the Agent Gateway on port 443/8080 (which proxies to Portal API). You can also hit the Portal API directly on port 8090.
+
+### Check SSO availability
+
+```bash
+curl "https://{domain}:8090/api/v1/auth/sso/availability?org_id=acme-corp"
+```
+
+## Related Resources
+
+| Resource | Path |
+|----------|------|
+| Vanity domain setup | `.github/workflows/setup-vanity-domain.yml` |
+| Seed test data | `.github/workflows/seed-test-data.yml` |
+| E2E setup script | `scripts/setup-e2e-testing.sh` |
+| Portal UI source | `ee/platform/customer-portal-ui/` |
+| Portal API source | `ee/platform/customer-portal/` |
+| Admin auth middleware | `ee/platform/customer-portal/middleware/admin_auth.go` |
+| Auth handler | `ee/platform/customer-portal/api/auth.go` |
+| Organizations handler | `ee/platform/customer-portal/api/organizations.go` |
+| Onboarding handler | `ee/platform/customer-portal/api/admin.go` |
+| Agent proxy (auth routing) | `platform/agent/proxy.go` |
+| CloudFormation template | `ee/platform/aws-marketplace/cloudformation-ecs-fargate.yaml` |

--- a/docs/guides/workflow-control-plane.md
+++ b/docs/guides/workflow-control-plane.md
@@ -213,7 +213,80 @@ tool_interceptors=[adapter.mcp_tool_interceptor(opts)]
 
 The interceptor enforces `mcp_check_input → handler → mcp_check_output`, raises `PolicyViolationError` on block, and automatically substitutes `redacted_data` when output redaction is applied.
 
-### Go
+### TypeScript LangGraph Adapter
+
+```typescript
+import { AxonFlow, AxonFlowLangGraphAdapter } from "@axonflow/sdk";
+
+const client = new AxonFlow({ endpoint: "http://localhost:8080" });
+const adapter = new AxonFlowLangGraphAdapter(client, "my-workflow");
+
+await adapter.startWorkflow();
+
+if (await adapter.checkGate("generate", "llm_call", { model: "gpt-4" })) {
+  const result = await generateCode(state);
+  await adapter.stepCompleted("generate");
+}
+
+// Per-tool governance
+if (await adapter.checkToolGate("web_search", "function")) {
+  const result = await webSearch(state);
+  await adapter.toolCompleted("web_search", { output: result });
+}
+
+await adapter.completeWorkflow();
+```
+
+### Go LangGraph Adapter
+
+```go
+adapter := axonflow.NewLangGraphAdapter(client, "my-workflow")
+
+ctx := context.Background()
+adapter.StartWorkflow(ctx, nil, "")
+
+allowed, _ := adapter.CheckGate(ctx, "generate", axonflow.StepTypeLLMCall,
+    &axonflow.CheckGateOptions{Model: "gpt-4"})
+if allowed {
+    result := generateCode(state)
+    adapter.StepCompleted(ctx, "generate", nil)
+}
+
+// Per-tool governance
+allowed, _ = adapter.CheckToolGate(ctx, "web_search", "function", nil)
+if allowed {
+    result := webSearch(state)
+    adapter.ToolCompleted(ctx, "web_search",
+        &axonflow.ToolCompletedOptions{Output: result})
+}
+
+adapter.CompleteWorkflow(ctx)
+```
+
+### Java LangGraph Adapter
+
+```java
+LangGraphAdapter adapter = LangGraphAdapter.builder(client, "my-workflow").build();
+
+adapter.startWorkflow();
+
+if (adapter.checkGate("generate", "llm_call",
+        CheckGateOptions.builder().model("gpt-4").build())) {
+    Object result = generateCode(state);
+    adapter.stepCompleted("generate");
+}
+
+// Per-tool governance
+if (adapter.checkToolGate("web_search", "function")) {
+    Object result = webSearch(state);
+    adapter.toolCompleted("web_search",
+        ToolCompletedOptions.builder().output(Map.of("results", result)).build());
+}
+
+adapter.completeWorkflow();
+```
+
+### Go (Low-Level Client)
 
 ```go
 client := axonflow.NewClient(axonflow.AxonFlowConfig{
@@ -495,10 +568,14 @@ See the complete examples in `examples/workflow-control/`:
 
 - `http/workflow-control.sh` - HTTP/curl example
 - `go/main.go` - Go SDK example
+- `go/langgraph_tools_example.go` - Go per-tool governance with LangGraph adapter
 - `python/main.py` - Python SDK example
 - `python/langgraph_example.py` - LangGraph adapter example
+- `python/langgraph_tools_example.py` - Python per-tool governance with LangGraph adapter
 - `typescript/index.ts` - TypeScript SDK example
+- `typescript/langgraph_tools_example.ts` - TypeScript per-tool governance with LangGraph adapter
 - `java/WorkflowControl.java` - Java SDK example
+- `java/LangGraphToolsExample.java` - Java per-tool governance with LangGraph adapter
 
 ## Related
 

--- a/examples/interceptors/typescript/src/index.ts
+++ b/examples/interceptors/typescript/src/index.ts
@@ -245,7 +245,7 @@ async function main() {
   console.log();
   console.log("Note: This example uses Gateway Mode (recommended).");
   console.log("The wrapOpenAIClient interceptor is deprecated in v2.0.0.");
-  console.log("See: https://docs.getaxonflow.com/sdk/gateway-mode");
+  console.log("See: https://docs.getaxonflow.com/docs/sdk/gateway-mode");
 
   process.exit(failures.length > 0 ? 1 : 0);
 }

--- a/examples/workflow-control/go/langgraph_tools_example.go
+++ b/examples/workflow-control/go/langgraph_tools_example.go
@@ -1,0 +1,296 @@
+//go:build ignore
+
+// LangGraph Per-Tool Governance Example - Go
+//
+// Requires: axonflow-sdk-go v4.2.0+
+//
+// VALIDATION: This example exits with code 1 if any assertion fails.
+//
+// "LangChain runs the workflow. AxonFlow decides when it's allowed to move forward."
+//
+// This example demonstrates per-tool governance using the LangGraphAdapter.
+// Instead of governing an entire tools node as one step, each individual tool
+// invocation gets its own gate check — enabling fine-grained tool-level policies.
+//
+// Run with: go run langgraph_tools_example.go
+// Prerequisites: docker compose up -d
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/getaxonflow/axonflow-sdk-go/v4"
+)
+
+var toolsFailures []string
+
+func toolsAssertCheck(condition bool, message string) {
+	if condition {
+		fmt.Printf("   \u2713 PASS: %s\n", message)
+	} else {
+		fmt.Printf("   FAIL: %s\n", message)
+		toolsFailures = append(toolsFailures, message)
+	}
+}
+
+func getToolsEnv(key, defaultValue string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return defaultValue
+}
+
+func main() {
+	os.Exit(runToolsExample())
+}
+
+func runToolsExample() int {
+	fmt.Println("LangGraph Per-Tool Governance Example - Go")
+	fmt.Println("==========================================")
+	fmt.Println()
+	fmt.Println("Demonstrates per-tool governance within a LangGraph tools node.")
+	fmt.Println("Each tool invocation gets its own gate check and completion tracking.")
+	fmt.Println()
+
+	client := axonflow.NewClient(axonflow.AxonFlowConfig{
+		Endpoint:     getToolsEnv("AXONFLOW_AGENT_URL", "http://localhost:8080"),
+		ClientID:     getToolsEnv("AXONFLOW_CLIENT_ID", "langgraph-tools-example-go"),
+		ClientSecret: getToolsEnv("AXONFLOW_CLIENT_SECRET", ""),
+	})
+
+	adapter := axonflow.NewLangGraphAdapter(client, "langgraph-research-agent")
+	ctx := context.Background()
+
+	// --- Start workflow with trace_id ---
+	fmt.Println("Step 1: Start Workflow (with trace_id)")
+	workflowID, err := adapter.StartWorkflow(ctx,
+		map[string]interface{}{"example": "per-tool-governance-go"},
+		"otel-trace-12345-research-go",
+	)
+	if err != nil {
+		fmt.Printf("   FATAL: Failed to start workflow: %v\n", err)
+		return 1
+	}
+
+	toolsAssertCheck(workflowID != "", "StartWorkflow returned workflowID")
+	fmt.Printf("   Workflow started: %s\n", workflowID)
+	fmt.Println()
+
+	// --- Step 2: LLM Node --- standard gate check ---
+	fmt.Println("Step 2: Node 'plan_research' (LLM call)")
+	fmt.Println("   Checking gate...")
+
+	gateResult, err := adapter.CheckGate(ctx, "plan_research", axonflow.StepTypeLLMCall,
+		&axonflow.CheckGateOptions{
+			Model:    "claude-sonnet-4-20250514",
+			Provider: "anthropic",
+			StepInput: map[string]interface{}{
+				"prompt": "Plan research on AI governance",
+			},
+		})
+	if err != nil {
+		fmt.Printf("   BLOCKED or ERROR: %v\n", err)
+		toolsAssertCheck(true, "CheckGate returned error (blocked or approval required)")
+		return printToolsSummary()
+	}
+
+	toolsAssertCheck(gateResult, "CheckGate returned true for plan_research")
+
+	if gateResult {
+		fmt.Println("   Gate: ALLOWED --- executing LLM node...")
+		tokensIn := 50
+		tokensOut := 150
+		costUsd := 0.003
+		err = adapter.StepCompleted(ctx, "plan_research", &axonflow.StepCompletedOptions{
+			Output: map[string]interface{}{
+				"plan":        []string{"web_search", "sql_query", "code_analysis"},
+				"tokens_used": 150,
+			},
+			TokensIn:  &tokensIn,
+			TokensOut: &tokensOut,
+			CostUSD:   &costUsd,
+		})
+		toolsAssertCheck(err == nil, "StepCompleted succeeded for plan_research")
+		fmt.Println("   Node completed!")
+	}
+	fmt.Println()
+
+	// --- Step 3: Tools Node --- per-tool governance ---
+	fmt.Println("Step 3: Tools Node (3 individual tools)")
+	fmt.Println("   Each tool gets its own gate check.")
+	fmt.Println()
+
+	{
+		// Tool 1: web_search (function type)
+		fmt.Println("   Tool 3a: web_search (function)")
+		toolAllowed, toolErr := adapter.CheckToolGate(ctx, "web_search", "function",
+			&axonflow.CheckToolGateOptions{
+				ToolInput: map[string]interface{}{"query": "AI governance frameworks 2026"},
+			})
+		if toolErr != nil {
+			fmt.Printf("   ERROR: %v\n", toolErr)
+		}
+		toolsAssertCheck(toolAllowed, "CheckToolGate returned true for web_search")
+
+		if toolAllowed {
+			fmt.Println("   Gate: ALLOWED --- executing web_search...")
+			costSearch := 0.001
+			err = adapter.ToolCompleted(ctx, "web_search", &axonflow.ToolCompletedOptions{
+				Output: map[string]interface{}{
+					"results": []map[string]interface{}{
+						{"title": "EU AI Act", "url": "https://example.com"},
+					},
+				},
+				CostUSD: &costSearch,
+			})
+			toolsAssertCheck(err == nil, "ToolCompleted succeeded for web_search")
+			fmt.Println("   Tool completed!")
+		}
+		fmt.Println()
+	}
+
+	{
+		// Tool 2: sql_query (MCP type)
+		fmt.Println("   Tool 3b: sql_query (mcp)")
+		toolAllowed, toolErr := adapter.CheckToolGate(ctx, "sql_query", "mcp",
+			&axonflow.CheckToolGateOptions{
+				ToolInput: map[string]interface{}{
+					"query": "SELECT COUNT(*) FROM regulations WHERE region='EU'",
+				},
+			})
+		if toolErr != nil {
+			fmt.Printf("   ERROR: %v\n", toolErr)
+		}
+		toolsAssertCheck(toolAllowed, "CheckToolGate returned true for sql_query")
+
+		if toolAllowed {
+			fmt.Println("   Gate: ALLOWED --- executing sql_query...")
+			err = adapter.ToolCompleted(ctx, "sql_query", &axonflow.ToolCompletedOptions{
+				Output: map[string]interface{}{
+					"rows": []map[string]interface{}{{"count": 42}},
+				},
+			})
+			toolsAssertCheck(err == nil, "ToolCompleted succeeded for sql_query")
+			fmt.Println("   Tool completed!")
+		}
+		fmt.Println()
+	}
+
+	{
+		// Tool 3: code_executor (function type)
+		fmt.Println("   Tool 3c: code_executor (function)")
+		toolAllowed, toolErr := adapter.CheckToolGate(ctx, "code_executor", "function",
+			&axonflow.CheckToolGateOptions{
+				ToolInput: map[string]interface{}{
+					"language": "python",
+					"code":     "print('analysis complete')",
+				},
+			})
+		if toolErr != nil {
+			fmt.Printf("   ERROR: %v\n", toolErr)
+		}
+		toolsAssertCheck(toolAllowed, "CheckToolGate returned true for code_executor")
+
+		if toolAllowed {
+			fmt.Println("   Gate: ALLOWED --- executing code_executor...")
+			err = adapter.ToolCompleted(ctx, "code_executor", &axonflow.ToolCompletedOptions{
+				Output: map[string]interface{}{
+					"stdout":    "analysis complete",
+					"exit_code": 0,
+				},
+			})
+			toolsAssertCheck(err == nil, "ToolCompleted succeeded for code_executor")
+			fmt.Println("   Tool completed!")
+		}
+		fmt.Println()
+	}
+
+	// --- Step 4: Final Synthesis (LLM call) ---
+	fmt.Println("Step 4: Node 'synthesize_report' (LLM call)")
+	fmt.Println("   Checking gate...")
+
+	{
+		gate2, gate2Err := adapter.CheckGate(ctx, "synthesize_report", axonflow.StepTypeLLMCall,
+			&axonflow.CheckGateOptions{
+				Model:    "claude-sonnet-4-20250514",
+				Provider: "anthropic",
+				StepInput: map[string]interface{}{
+					"prompt": "Synthesize research findings",
+				},
+			})
+		if gate2Err != nil {
+			fmt.Printf("   ERROR: %v\n", gate2Err)
+		}
+		toolsAssertCheck(gate2, "CheckGate returned true for synthesize_report")
+
+		if gate2 {
+			fmt.Println("   Gate: ALLOWED --- executing LLM node...")
+			tokensIn := 200
+			tokensOut := 500
+			costUsd := 0.01
+			err = adapter.StepCompleted(ctx, "synthesize_report", &axonflow.StepCompletedOptions{
+				Output: map[string]interface{}{
+					"report":     "AI governance analysis complete",
+					"word_count": 500,
+				},
+				TokensIn:  &tokensIn,
+				TokensOut: &tokensOut,
+				CostUSD:   &costUsd,
+			})
+			toolsAssertCheck(err == nil, "StepCompleted succeeded for synthesize_report")
+			fmt.Println("   Node completed!")
+		}
+		fmt.Println()
+	}
+
+	// --- Verify workflow status ---
+	fmt.Println("Step 5: Verify Workflow Status")
+	status, statusErr := client.GetWorkflow(workflowID)
+	if statusErr != nil {
+		fmt.Printf("   ERROR: GetWorkflow failed: %v\n", statusErr)
+	} else {
+		toolsAssertCheck(status != nil, "GetWorkflow returned status")
+		fmt.Printf("   Status: %s\n", status.Status)
+		fmt.Printf("   Steps recorded: %d\n", len(status.Steps))
+
+		// We should have 5 steps: plan_research + 3 tools + synthesize_report
+		toolsAssertCheck(len(status.Steps) >= 5, "at least 5 steps recorded (1 LLM + 3 tools + 1 LLM)")
+
+		// Verify trace_id persists
+		toolsAssertCheck(status.TraceID == "otel-trace-12345-research-go", "trace_id preserved in status")
+	}
+	fmt.Println()
+
+	fmt.Println("Step 6: Workflow Complete")
+	err = adapter.CompleteWorkflow(ctx)
+	toolsAssertCheck(err == nil, "CompleteWorkflow succeeded")
+
+	return printToolsSummary()
+}
+
+func printToolsSummary() int {
+	fmt.Println()
+	fmt.Println("==========================================")
+
+	if len(toolsFailures) == 0 {
+		fmt.Println("ALL TESTS PASSED")
+		fmt.Println()
+		fmt.Println("Per-Tool Governance validated:")
+		fmt.Println("  - StartWorkflow() with trace_id")
+		fmt.Println("  - CheckGate() for LLM nodes")
+		fmt.Println("  - CheckToolGate() for individual tools (function, mcp)")
+		fmt.Println("  - ToolCompleted() for tool-level completion tracking")
+		fmt.Println("  - StepCompleted() with post-execution metrics")
+		fmt.Println("  - Workflow status tracks all steps including tools")
+		fmt.Println("  - trace_id preserved across lifecycle")
+		return 0
+	}
+
+	fmt.Printf("%d TEST(S) FAILED:\n", len(toolsFailures))
+	for _, f := range toolsFailures {
+		fmt.Printf("   - %s\n", f)
+	}
+	return 1
+}

--- a/examples/workflow-control/java/src/main/java/com/getaxonflow/examples/LangGraphToolsExample.java
+++ b/examples/workflow-control/java/src/main/java/com/getaxonflow/examples/LangGraphToolsExample.java
@@ -1,0 +1,248 @@
+package com.getaxonflow.examples;
+
+import com.getaxonflow.sdk.AxonFlow;
+import com.getaxonflow.sdk.AxonFlowConfig;
+import com.getaxonflow.sdk.adapters.*;
+import com.getaxonflow.sdk.types.workflow.WorkflowTypes;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * LangGraph Per-Tool Governance Example - Java
+ *
+ * Requires: axonflow-sdk-java v4.2.0+
+ *
+ * VALIDATION: This example exits with code 1 if any assertion fails.
+ *
+ * "LangChain runs the workflow. AxonFlow decides when it's allowed to move forward."
+ *
+ * This example demonstrates per-tool governance using the LangGraphAdapter.
+ * Instead of governing an entire tools node as one step, each individual tool
+ * invocation gets its own gate check, enabling fine-grained tool-level policies.
+ *
+ * Run with: mvn exec:java -Dexec.mainClass="com.getaxonflow.examples.LangGraphToolsExample" -q
+ * Prerequisites: docker compose up -d
+ */
+public class LangGraphToolsExample {
+
+    private static final List<String> failures = new ArrayList<>();
+
+    private static void assertCheck(boolean condition, String message) {
+        if (condition) {
+            System.out.println("   \u2713 PASS: " + message);
+        } else {
+            System.out.println("   FAIL: " + message);
+            failures.add(message);
+        }
+    }
+
+    private static String getEnv(String key, String defaultValue) {
+        String value = System.getenv(key);
+        return (value != null && !value.isEmpty()) ? value : defaultValue;
+    }
+
+    public static void main(String[] args) {
+        System.out.println("LangGraph Per-Tool Governance Example - Java");
+        System.out.println("=============================================");
+        System.out.println();
+        System.out.println("Demonstrates per-tool governance within a LangGraph tools node.");
+        System.out.println("Each tool invocation gets its own gate check and completion tracking.");
+        System.out.println();
+
+        AxonFlow client = AxonFlow.create(AxonFlowConfig.builder()
+                .endpoint(getEnv("AXONFLOW_AGENT_URL", "http://localhost:8080"))
+                .clientId(getEnv("AXONFLOW_CLIENT_ID", "langgraph-tools-example-java"))
+                .clientSecret(getEnv("AXONFLOW_CLIENT_SECRET", ""))
+                .build());
+
+        LangGraphAdapter adapter = LangGraphAdapter.builder(client, "langgraph-research-agent")
+                .autoBlock(true)
+                .build();
+
+        try {
+            // --- Start workflow with trace_id ---
+            System.out.println("Step 1: Start Workflow (with trace_id)");
+            String workflowId = adapter.startWorkflow(
+                    Map.of("example", "per-tool-governance-java"),
+                    "otel-trace-12345-research-java");
+
+            assertCheck(workflowId != null, "startWorkflow returned workflowId");
+            assertCheck(!workflowId.isEmpty(), "workflowId is not empty");
+            System.out.println("   Workflow started: " + workflowId);
+            System.out.println();
+
+            // --- Step 2: LLM Node --- standard gate check ---
+            System.out.println("Step 2: Node 'plan_research' (LLM call)");
+            System.out.println("   Checking gate...");
+
+            boolean gateResult = adapter.checkGate("plan_research", "llm_call",
+                    CheckGateOptions.builder()
+                            .model("claude-sonnet-4-20250514")
+                            .provider("anthropic")
+                            .stepInput(Map.of("prompt", "Plan research on AI governance"))
+                            .build());
+
+            assertCheck(gateResult, "checkGate returned true for plan_research");
+
+            if (gateResult) {
+                System.out.println("   Gate: ALLOWED --- executing LLM node...");
+                adapter.stepCompleted("plan_research", StepCompletedOptions.builder()
+                        .output(Map.of(
+                                "plan", List.of("web_search", "sql_query", "code_analysis"),
+                                "tokens_used", 150))
+                        .tokensIn(50)
+                        .tokensOut(150)
+                        .costUsd(0.003)
+                        .build());
+                assertCheck(true, "stepCompleted succeeded for plan_research");
+                System.out.println("   Node completed!");
+            }
+            System.out.println();
+
+            // --- Step 3: Tools Node --- per-tool governance ---
+            System.out.println("Step 3: Tools Node (3 individual tools)");
+            System.out.println("   Each tool gets its own gate check.");
+            System.out.println();
+
+            // Tool 1: web_search (function type)
+            System.out.println("   Tool 3a: web_search (function)");
+            boolean toolAllowed = adapter.checkToolGate("web_search", "function",
+                    CheckToolGateOptions.builder()
+                            .toolInput(Map.of("query", "AI governance frameworks 2026"))
+                            .build());
+
+            assertCheck(toolAllowed, "checkToolGate returned true for web_search");
+
+            if (toolAllowed) {
+                System.out.println("   Gate: ALLOWED --- executing web_search...");
+                adapter.toolCompleted("web_search", ToolCompletedOptions.builder()
+                        .output(Map.of("results", List.of(Map.of("title", "EU AI Act", "url", "https://example.com"))))
+                        .costUsd(0.001)
+                        .build());
+                assertCheck(true, "toolCompleted succeeded for web_search");
+                System.out.println("   Tool completed!");
+            }
+            System.out.println();
+
+            // Tool 2: sql_query (MCP type)
+            System.out.println("   Tool 3b: sql_query (mcp)");
+            toolAllowed = adapter.checkToolGate("sql_query", "mcp",
+                    CheckToolGateOptions.builder()
+                            .toolInput(Map.of("query", "SELECT COUNT(*) FROM regulations WHERE region='EU'"))
+                            .build());
+
+            assertCheck(toolAllowed, "checkToolGate returned true for sql_query");
+
+            if (toolAllowed) {
+                System.out.println("   Gate: ALLOWED --- executing sql_query...");
+                adapter.toolCompleted("sql_query", ToolCompletedOptions.builder()
+                        .output(Map.of("rows", List.of(Map.of("count", 42))))
+                        .build());
+                assertCheck(true, "toolCompleted succeeded for sql_query");
+                System.out.println("   Tool completed!");
+            }
+            System.out.println();
+
+            // Tool 3: code_executor (function type)
+            System.out.println("   Tool 3c: code_executor (function)");
+            toolAllowed = adapter.checkToolGate("code_executor", "function",
+                    CheckToolGateOptions.builder()
+                            .toolInput(Map.of("language", "python", "code", "print('analysis complete')"))
+                            .build());
+
+            assertCheck(toolAllowed, "checkToolGate returned true for code_executor");
+
+            if (toolAllowed) {
+                System.out.println("   Gate: ALLOWED --- executing code_executor...");
+                adapter.toolCompleted("code_executor", ToolCompletedOptions.builder()
+                        .output(Map.of("stdout", "analysis complete", "exit_code", 0))
+                        .build());
+                assertCheck(true, "toolCompleted succeeded for code_executor");
+                System.out.println("   Tool completed!");
+            }
+            System.out.println();
+
+            // --- Step 4: Final Synthesis (LLM call) ---
+            System.out.println("Step 4: Node 'synthesize_report' (LLM call)");
+            System.out.println("   Checking gate...");
+
+            boolean gate2 = adapter.checkGate("synthesize_report", "llm_call",
+                    CheckGateOptions.builder()
+                            .model("claude-sonnet-4-20250514")
+                            .provider("anthropic")
+                            .stepInput(Map.of("prompt", "Synthesize research findings"))
+                            .build());
+
+            assertCheck(gate2, "checkGate returned true for synthesize_report");
+
+            if (gate2) {
+                System.out.println("   Gate: ALLOWED --- executing LLM node...");
+                adapter.stepCompleted("synthesize_report", StepCompletedOptions.builder()
+                        .output(Map.of("report", "AI governance analysis complete", "word_count", 500))
+                        .tokensIn(200)
+                        .tokensOut(500)
+                        .costUsd(0.01)
+                        .build());
+                assertCheck(true, "stepCompleted succeeded for synthesize_report");
+                System.out.println("   Node completed!");
+            }
+            System.out.println();
+
+            // --- Verify workflow status ---
+            System.out.println("Step 5: Verify Workflow Status");
+            WorkflowTypes.WorkflowStatusResponse status = client.getWorkflow(workflowId);
+
+            assertCheck(status != null, "getWorkflow returned status");
+            System.out.println("   Status: " + status.getStatus());
+            System.out.println("   Steps recorded: " + (status.getSteps() != null ? status.getSteps().size() : 0));
+
+            // We should have 5 steps: plan_research + 3 tools + synthesize_report
+            int stepCount = status.getSteps() != null ? status.getSteps().size() : 0;
+            assertCheck(stepCount >= 5, "at least 5 steps recorded (1 LLM + 3 tools + 1 LLM)");
+
+            // Verify trace_id persists
+            assertCheck("otel-trace-12345-research-java".equals(status.getTraceId()),
+                    "trace_id preserved in status");
+            System.out.println();
+
+            System.out.println("Step 6: Workflow Complete");
+            adapter.completeWorkflow();
+            assertCheck(true, "completeWorkflow succeeded");
+
+        } catch (WorkflowBlockedError e) {
+            System.out.println("   BLOCKED: " + e.getMessage());
+            System.out.println("   Step: " + e.getStepId());
+            System.out.println("   Reason: " + e.getReason());
+            assertCheck(true, "WorkflowBlockedError raised correctly");
+        } catch (Exception e) {
+            System.err.println("Fatal error: " + e.getMessage());
+            e.printStackTrace();
+            System.exit(1);
+        }
+
+        System.out.println();
+        System.out.println("=============================================");
+
+        if (failures.isEmpty()) {
+            System.out.println("ALL TESTS PASSED");
+            System.out.println();
+            System.out.println("Per-Tool Governance validated:");
+            System.out.println("  - startWorkflow() with trace_id");
+            System.out.println("  - checkGate() for LLM nodes");
+            System.out.println("  - checkToolGate() for individual tools (function, mcp)");
+            System.out.println("  - toolCompleted() for tool-level completion tracking");
+            System.out.println("  - stepCompleted() with post-execution metrics");
+            System.out.println("  - Workflow status tracks all steps including tools");
+            System.out.println("  - trace_id preserved across lifecycle");
+            System.exit(0);
+        } else {
+            System.out.println(failures.size() + " TEST(S) FAILED:");
+            for (String f : failures) {
+                System.out.println("   - " + f);
+            }
+            System.exit(1);
+        }
+    }
+}

--- a/examples/workflow-control/typescript/langgraph_tools_example.ts
+++ b/examples/workflow-control/typescript/langgraph_tools_example.ts
@@ -1,0 +1,258 @@
+/**
+ * LangGraph Per-Tool Governance Example - TypeScript
+ *
+ * Requires: @axonflow/sdk v4.2.0+
+ *
+ * VALIDATION: This example exits with code 1 if any assertion fails.
+ *
+ * "LangChain runs the workflow. AxonFlow decides when it's allowed to move forward."
+ *
+ * This example demonstrates per-tool governance using the AxonFlowLangGraphAdapter.
+ * Instead of governing an entire tools node as one step, each individual tool
+ * invocation gets its own gate check — enabling fine-grained tool-level policies.
+ *
+ * Run with: npx tsx langgraph_tools_example.ts
+ * Prerequisites: docker compose up -d
+ */
+
+import "dotenv/config";
+import {
+  AxonFlow,
+  AxonFlowLangGraphAdapter,
+  WorkflowBlockedError,
+} from "@axonflow/sdk";
+
+const failures: string[] = [];
+
+function assertCheck(condition: boolean, message: string): void {
+  if (condition) {
+    console.log(`   \u2713 PASS: ${message}`);
+  } else {
+    console.log(`   FAIL: ${message}`);
+    failures.push(message);
+  }
+}
+
+async function main(): Promise<number> {
+  console.log("LangGraph Per-Tool Governance Example - TypeScript");
+  console.log("=".repeat(50));
+  console.log();
+  console.log("Demonstrates per-tool governance within a LangGraph tools node.");
+  console.log("Each tool invocation gets its own gate check and completion tracking.");
+  console.log();
+
+  const client = new AxonFlow({
+    endpoint: process.env.AXONFLOW_AGENT_URL || "http://localhost:8080",
+    clientId: process.env.AXONFLOW_CLIENT_ID || "langgraph-tools-example-ts",
+    clientSecret: process.env.AXONFLOW_CLIENT_SECRET || "",
+  });
+
+  const adapter = new AxonFlowLangGraphAdapter(client, "langgraph-research-agent", {
+    source: "langgraph",
+    autoBlock: true,
+  });
+
+  try {
+    // --- Start workflow with trace_id ---
+    console.log("Step 1: Start Workflow (with trace_id)");
+    const workflowId = await adapter.startWorkflow(
+      { example: "per-tool-governance-ts" },
+      "otel-trace-12345-research-ts",
+    );
+
+    assertCheck(workflowId !== null && workflowId !== undefined, "startWorkflow returned workflowId");
+    assertCheck(workflowId.length > 0, "workflowId is not empty");
+    console.log(`   Workflow started: ${workflowId}`);
+    console.log();
+
+    // --- Step 2: LLM Node --- standard gate check ---
+    console.log("Step 2: Node 'plan_research' (LLM call)");
+    console.log("   Checking gate...");
+
+    const gateResult = await adapter.checkGate("plan_research", "llm_call", {
+      model: "claude-sonnet-4-20250514",
+      provider: "anthropic",
+      stepInput: { prompt: "Plan research on AI governance" },
+    });
+
+    assertCheck(gateResult === true, "checkGate returned true for plan_research");
+
+    if (gateResult) {
+      console.log("   Gate: ALLOWED --- executing LLM node...");
+      const planResult = {
+        plan: ["web_search", "sql_query", "code_analysis"],
+        tokens_used: 150,
+      };
+
+      await adapter.stepCompleted("plan_research", {
+        output: planResult,
+        tokensIn: 50,
+        tokensOut: 150,
+        costUsd: 0.003,
+      });
+      assertCheck(true, "stepCompleted succeeded for plan_research");
+      console.log("   Node completed!");
+    }
+    console.log();
+
+    // --- Step 3: Tools Node --- per-tool governance ---
+    console.log("Step 3: Tools Node (3 individual tools)");
+    console.log("   Each tool gets its own gate check.");
+    console.log();
+
+    // Tool 1: web_search (function type)
+    console.log("   Tool 3a: web_search (function)");
+    let toolAllowed = await adapter.checkToolGate("web_search", "function", {
+      toolInput: { query: "AI governance frameworks 2026" },
+    });
+
+    assertCheck(toolAllowed === true, "checkToolGate returned true for web_search");
+
+    if (toolAllowed) {
+      console.log("   Gate: ALLOWED --- executing web_search...");
+      const searchResult = { results: [{ title: "EU AI Act", url: "https://example.com" }] };
+
+      await adapter.toolCompleted("web_search", {
+        output: searchResult,
+        tokensIn: 0,
+        tokensOut: 0,
+        costUsd: 0.001,
+      });
+      assertCheck(true, "toolCompleted succeeded for web_search");
+      console.log("   Tool completed!");
+    }
+    console.log();
+
+    // Tool 2: sql_query (MCP type)
+    console.log("   Tool 3b: sql_query (mcp)");
+    toolAllowed = await adapter.checkToolGate("sql_query", "mcp", {
+      toolInput: { query: "SELECT COUNT(*) FROM regulations WHERE region='EU'" },
+    });
+
+    assertCheck(toolAllowed === true, "checkToolGate returned true for sql_query");
+
+    if (toolAllowed) {
+      console.log("   Gate: ALLOWED --- executing sql_query...");
+      const sqlResult = { rows: [{ count: 42 }] };
+
+      await adapter.toolCompleted("sql_query", {
+        output: sqlResult,
+      });
+      assertCheck(true, "toolCompleted succeeded for sql_query");
+      console.log("   Tool completed!");
+    }
+    console.log();
+
+    // Tool 3: code_executor (function type)
+    console.log("   Tool 3c: code_executor (function)");
+    toolAllowed = await adapter.checkToolGate("code_executor", "function", {
+      toolInput: { language: "python", code: "print('analysis complete')" },
+    });
+
+    assertCheck(toolAllowed === true, "checkToolGate returned true for code_executor");
+
+    if (toolAllowed) {
+      console.log("   Gate: ALLOWED --- executing code_executor...");
+      const execResult = { stdout: "analysis complete", exit_code: 0 };
+
+      await adapter.toolCompleted("code_executor", {
+        output: execResult,
+      });
+      assertCheck(true, "toolCompleted succeeded for code_executor");
+      console.log("   Tool completed!");
+    }
+    console.log();
+
+    // --- Step 4: Final Synthesis (LLM call) ---
+    console.log("Step 4: Node 'synthesize_report' (LLM call)");
+    console.log("   Checking gate...");
+
+    const gate2 = await adapter.checkGate("synthesize_report", "llm_call", {
+      model: "claude-sonnet-4-20250514",
+      provider: "anthropic",
+      stepInput: { prompt: "Synthesize research findings" },
+    });
+
+    assertCheck(gate2 === true, "checkGate returned true for synthesize_report");
+
+    if (gate2) {
+      console.log("   Gate: ALLOWED --- executing LLM node...");
+      const report = { report: "AI governance analysis complete", word_count: 500 };
+
+      await adapter.stepCompleted("synthesize_report", {
+        output: report,
+        tokensIn: 200,
+        tokensOut: 500,
+        costUsd: 0.01,
+      });
+      assertCheck(true, "stepCompleted succeeded for synthesize_report");
+      console.log("   Node completed!");
+    }
+    console.log();
+
+    // --- Verify workflow status ---
+    console.log("Step 5: Verify Workflow Status");
+    const status = await client.getWorkflow(workflowId);
+
+    assertCheck(status !== null && status !== undefined, "getWorkflow returned status");
+    console.log(`   Status: ${status.status}`);
+    console.log(`   Steps recorded: ${status.steps?.length || 0}`);
+
+    // We should have 5 steps: plan_research + 3 tools + synthesize_report
+    assertCheck(
+      (status.steps?.length || 0) >= 5,
+      "at least 5 steps recorded (1 LLM + 3 tools + 1 LLM)",
+    );
+
+    // Verify trace_id persists
+    assertCheck(
+      status.trace_id === "otel-trace-12345-research-ts",
+      "trace_id preserved in status",
+    );
+    console.log();
+
+    console.log("Step 6: Workflow Complete");
+    await adapter.completeWorkflow();
+    assertCheck(true, "completeWorkflow succeeded");
+
+  } catch (e) {
+    if (e instanceof WorkflowBlockedError) {
+      console.log(`   BLOCKED: ${e.message}`);
+      console.log(`   Step: ${e.details?.stepId}`);
+      console.log(`   Reason: ${e.details?.reason}`);
+      assertCheck(true, "WorkflowBlockedError raised correctly");
+    } else {
+      throw e;
+    }
+  }
+
+  console.log();
+  console.log("=".repeat(50));
+
+  if (failures.length === 0) {
+    console.log("ALL TESTS PASSED");
+    console.log();
+    console.log("Per-Tool Governance validated:");
+    console.log("  - startWorkflow() with trace_id");
+    console.log("  - checkGate() for LLM nodes");
+    console.log("  - checkToolGate() for individual tools (function, mcp)");
+    console.log("  - toolCompleted() for tool-level completion tracking");
+    console.log("  - stepCompleted() with post-execution metrics");
+    console.log("  - Workflow status tracks all steps including tools");
+    console.log("  - trace_id preserved across lifecycle");
+    return 0;
+  } else {
+    console.log(`${failures.length} TEST(S) FAILED:`);
+    for (const f of failures) {
+      console.log(`   - ${f}`);
+    }
+    return 1;
+  }
+}
+
+main()
+  .then((code) => process.exit(code))
+  .catch((err) => {
+    console.error("Fatal error:", err);
+    process.exit(1);
+  });

--- a/platform/agent/circuitbreaker/circuitbreaker_community.go
+++ b/platform/agent/circuitbreaker/circuitbreaker_community.go
@@ -32,6 +32,10 @@ func NewHandler(cb *CircuitBreaker) *Handler {
 	return &Handler{}
 }
 
+// SetNotificationService sets the notification service.
+// Community Edition: No-op.
+func (h *Handler) SetNotificationService(ns *NotificationService) {}
+
 // RegisterRoutes registers circuit breaker routes with a mux router.
 // Community Edition: Does not register any routes (feature not available).
 func (h *Handler) RegisterRoutes(r *mux.Router) {
@@ -117,6 +121,80 @@ func (cb *CircuitBreaker) LoadCircuits(ctx context.Context, orgID string) error 
 func (cb *CircuitBreaker) ExpireCircuits(ctx context.Context) error {
 	return nil
 }
+
+// SetTripCallback sets a callback function called when circuits trip.
+// Community Edition: No-op.
+func (cb *CircuitBreaker) SetTripCallback(fn func(trip *TripEvent)) {}
+
+// TripEvent is emitted when a circuit is tripped.
+// Community Edition: Defined for compilation compatibility.
+type TripEvent struct {
+	CircuitID string
+	OrgID     string
+	TenantID  string
+	Scope     string
+	ScopeID   string
+	Reason    string
+	TrippedBy string
+	Comment   string
+	Timestamp time.Time
+}
+
+// TenantConfig holds per-tenant circuit breaker threshold overrides.
+// Community Edition: Defined for compilation compatibility.
+type TenantConfig struct {
+	ID                    string
+	OrgID                 string
+	TenantID              string
+	ErrorThreshold        *int
+	ViolationThreshold    *int
+	WindowSeconds         *int
+	DefaultTimeoutSeconds *int
+	MaxTimeoutSeconds     *int
+	EnableAutoRecovery    *bool
+	CreatedAt             time.Time
+	UpdatedAt             time.Time
+}
+
+// GetConfig returns the global config.
+// Community Edition: Returns zero-value config.
+func (cb *CircuitBreaker) GetConfig() Config {
+	return Config{}
+}
+
+// GetTenantConfig returns nil (no tenant config in community).
+func (cb *CircuitBreaker) GetTenantConfig(ctx context.Context, orgID, tenantID string) (*TenantConfig, error) {
+	return nil, nil
+}
+
+// UpsertTenantConfig is a no-op in community edition.
+func (cb *CircuitBreaker) UpsertTenantConfig(ctx context.Context, config *TenantConfig) error {
+	return nil
+}
+
+// NotificationConfig holds notification channel configuration.
+// Community Edition: Defined for compilation compatibility.
+type NotificationConfig struct {
+	ID       string
+	OrgID    string
+	TenantID string
+	Type     string
+	URL      string
+	Secret   string
+	Active   bool
+}
+
+// NotificationService handles notification delivery.
+// Community Edition: No-op implementation.
+type NotificationService struct{}
+
+// NewNotificationService creates a no-op notification service.
+func NewNotificationService(repo *Repository) *NotificationService {
+	return &NotificationService{}
+}
+
+// HandleTripEvent is a no-op in community edition.
+func (ns *NotificationService) HandleTripEvent(event *TripEvent) {}
 
 // Repository provides data access for circuit breaker state.
 // Community Edition: No-op implementation.

--- a/platform/agent/code_detector_test.go
+++ b/platform/agent/code_detector_test.go
@@ -566,3 +566,59 @@ func TestCodeArtifactMetadata_Fields(t *testing.T) {
 		t.Errorf("UnsafePatterns = %d, want 2", metadata.UnsafePatterns)
 	}
 }
+
+func TestEvaluateCodePolicies_NonEmpty(t *testing.T) {
+	categories, err := EvaluateCodePolicies("def hello(): pass", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(categories) != 3 {
+		t.Fatalf("expected 3 categories, got %d", len(categories))
+	}
+	expected := []string{
+		string(CategoryCodeSecrets),
+		string(CategoryCodeUnsafe),
+		string(CategoryCodeCompliance),
+	}
+	for i, cat := range categories {
+		if cat != expected[i] {
+			t.Errorf("category[%d] = %q, want %q", i, cat, expected[i])
+		}
+	}
+}
+
+func TestEvaluateCodePolicies_Empty(t *testing.T) {
+	categories, err := EvaluateCodePolicies("", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if categories != nil {
+		t.Errorf("expected nil for empty code, got %v", categories)
+	}
+}
+
+func TestExtractResponseContent_NestedDataMap(t *testing.T) {
+	// Test nested map with "data" key containing a sub-map with "data" string
+	input := map[string]interface{}{
+		"data": map[string]interface{}{
+			"data": "nested-data-value",
+		},
+	}
+	result := extractResponseContent(input)
+	if result != "nested-data-value" {
+		t.Errorf("extractResponseContent() = %q, want %q", result, "nested-data-value")
+	}
+}
+
+func TestExtractResponseContent_NestedContentMap(t *testing.T) {
+	// Test nested map with "data" key containing a sub-map with "content" string
+	input := map[string]interface{}{
+		"data": map[string]interface{}{
+			"content": "nested-content-value",
+		},
+	}
+	result := extractResponseContent(input)
+	if result != "nested-content-value" {
+		t.Errorf("extractResponseContent() = %q, want %q", result, "nested-content-value")
+	}
+}

--- a/platform/agent/proxy.go
+++ b/platform/agent/proxy.go
@@ -101,6 +101,17 @@ func createReverseProxy(target *url.URL, serviceName string) *httputil.ReversePr
 	// Custom error handler for logging and 502 responses
 	proxy.ErrorHandler = func(w http.ResponseWriter, r *http.Request, err error) {
 		log.Printf("[Proxy] Error proxying to %s: %v (path: %s)", serviceName, err, r.URL.Path)
+		// Record proxy error for circuit breaker auto-trip (#1176 Phase 2B)
+		if circuitBreakerInstance != nil {
+			orgID := r.Header.Get("X-Org-ID")
+			tenantID := r.Header.Get("X-Tenant-ID")
+			clientID := r.Header.Get("X-Client-ID")
+			if orgID != "" && clientID != "" {
+				if cbErr := circuitBreakerInstance.RecordError(r.Context(), orgID, tenantID, clientID); cbErr != nil {
+					log.Printf("[CircuitBreaker] RecordError (proxy) failed: %v", cbErr)
+				}
+			}
+		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadGateway)
 		_, _ = w.Write([]byte(`{"error":"Backend service unavailable","service":"` + serviceName + `"}`))
@@ -199,8 +210,11 @@ func proxyAuthMiddleware(next http.HandlerFunc) http.HandlerFunc {
 			return
 		}
 
-		// Set tenant ID from authenticated client for downstream tenant isolation
+		// Set identity headers from authenticated client for downstream services
+		// and circuit breaker error tracking (RecordError in proxy ErrorHandler)
 		r.Header.Set("X-Tenant-ID", client.TenantID)
+		r.Header.Set("X-Org-ID", client.OrgID)
+		r.Header.Set("X-Client-ID", client.ID)
 
 		next(w, r)
 	}

--- a/platform/agent/proxy_test.go
+++ b/platform/agent/proxy_test.go
@@ -550,6 +550,20 @@ func TestProxyAuthMiddleware_ProductionInvalidCreds(t *testing.T) {
 	}
 }
 
+func TestGetProxyConfig_EnvOverrides(t *testing.T) {
+	t.Setenv("ORCHESTRATOR_URL", "http://custom-orchestrator:9090")
+	t.Setenv("PORTAL_URL", "http://custom-portal:9091")
+
+	config := GetProxyConfig()
+
+	if config.OrchestratorInternalURL != "http://custom-orchestrator:9090" {
+		t.Errorf("OrchestratorInternalURL = %s, want http://custom-orchestrator:9090", config.OrchestratorInternalURL)
+	}
+	if config.PortalInternalURL != "http://custom-portal:9091" {
+		t.Errorf("PortalInternalURL = %s, want http://custom-portal:9091", config.PortalInternalURL)
+	}
+}
+
 func TestIsRunningInDocker(t *testing.T) {
 	// In test environment, should detect correctly
 	// We can't fully test Docker detection in non-Docker environment,

--- a/platform/agent/run.go
+++ b/platform/agent/run.go
@@ -945,7 +945,10 @@ func Run() {
 		PolicyViolationWindow:    5 * time.Minute,
 		EnableAutoRecovery:       true,
 	})
+	notifService := circuitbreaker.NewNotificationService(cbRepo)
+	circuitBreakerInstance.SetTripCallback(notifService.HandleTripEvent)
 	cbHandler := circuitbreaker.NewHandler(circuitBreakerInstance)
+	cbHandler.SetNotificationService(notifService)
 	cbHandler.RegisterRoutes(globalRouter)
 	// Note: In community edition, RegisterRoutes is a no-op (Circuit Breaker is an enterprise feature)
 
@@ -1386,6 +1389,12 @@ func clientRequestHandler(w http.ResponseWriter, r *http.Request) {
 		if agentMetrics != nil {
 			atomic.AddInt64(&agentMetrics.failedRequests, 1)
 		}
+		// Record error for circuit breaker auto-trip (#1176 Phase 2B)
+		if circuitBreakerInstance != nil {
+			if cbErr := circuitBreakerInstance.RecordError(r.Context(), client.OrgID, client.TenantID, client.ID); cbErr != nil {
+				log.Printf("[CircuitBreaker] RecordError failed: %v", cbErr)
+			}
+		}
 		sendErrorResponse(w, "Orchestrator error: "+err.Error(), http.StatusInternalServerError, nil)
 		return
 	}
@@ -1429,6 +1438,12 @@ func clientRequestHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		promRequestsTotal.WithLabelValues("orchestrator_error").Inc()
 		log.Printf("[clientRequestHandler] Orchestrator returned error: %s", orchError)
+		// Record orchestrator-level error for circuit breaker auto-trip (#1176 Phase 2B)
+		if circuitBreakerInstance != nil {
+			if cbErr := circuitBreakerInstance.RecordError(r.Context(), client.OrgID, client.TenantID, client.ID); cbErr != nil {
+				log.Printf("[CircuitBreaker] RecordError failed: %v", cbErr)
+			}
+		}
 	}
 	promPolicyEvaluations.Inc()
 	promRequestDuration.WithLabelValues("dynamic").Observe(float64(latencyMs))

--- a/platform/connectors/amadeus/doc.go
+++ b/platform/connectors/amadeus/doc.go
@@ -38,6 +38,6 @@ The Enterprise edition supports:
 # Contact
 
 For Enterprise licensing: sales@getaxonflow.com
-For documentation: https://docs.getaxonflow.com/connectors/amadeus
+For documentation: https://docs.getaxonflow.com/docs/mcp/connectors/amadeus
 */
 package amadeus


### PR DESCRIPTION
## Sync from Enterprise Repository

### Added
- **Circuit breaker sliding window** (#1176): Error and violation counting uses time-windowed approach (default 5 min) instead of lifetime counters
- **RecordError wired into pipeline** (#1176): Upstream LLM errors (orchestrator + proxy 502s) now auto-trip client-scoped circuits
- **Circuit struct json tags**: API responses now use snake_case field names
- **Per-tool governance examples** (#1358): TypeScript, Go, Java LangGraph adapter examples
- **WCP guide updated**: Expanded with TS, Go, Java adapter examples

### Fixed
- Broken documentation URLs across platform and examples (#1354)
- Proxy auth sets X-Org-ID and X-Client-ID for circuit breaker tracking