### PR TITLE
fix: cross-tenant policy cache fix, step_input field resolution (v5.3.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [5.3.1] - 2026-03-23
+
+### Community
+
+#### Fixed
+
+- **Cross-tenant dynamic policy cache collision** (#1410): Dynamic policy cache was keyed by policy name, causing policies with the same name across different tenants to silently overwrite each other. In multi-tenant deployments, this could result in step gate evaluations using the wrong tenant's policy or skipping policies entirely due to tenant mismatch. Cache key changed from `name` to `policy_id` to ensure all policies coexist regardless of naming. Includes `GetPolicy()` fallback search by name field for backward compatibility.
+
+---
+
 ## [5.3.0] - 2026-03-17
 
 ### Community

--- a/platform/orchestrator/db_dynamic_policies.go
+++ b/platform/orchestrator/db_dynamic_policies.go
@@ -381,7 +381,16 @@ func (e *DatabaseDynamicPolicyEngine) refreshPolicies() error {
 			"loaded_at": time.Now().Unix(),
 		}
 
-		newPolicies[name] = policyData
+		// Use policy_id as cache key to avoid cross-tenant name collisions.
+		// Different tenants can have policies with the same name, and using name
+		// as the key caused the second policy to overwrite the first.
+		// Fall back to name for backward compatibility with legacy policies that
+		// might not have a policy_id set.
+		cacheKey := policyID
+		if cacheKey == "" {
+			cacheKey = name
+		}
+		newPolicies[cacheKey] = policyData
 	}
 
 	if err = rows.Err(); err != nil {
@@ -492,20 +501,25 @@ func (e *DatabaseDynamicPolicyEngine) GetPolicy(name string) (map[string]interfa
 	e.mu.RLock()
 	defer e.mu.RUnlock()
 
-	policy, exists := e.policies[name]
-	if !exists {
-		return nil, false
+	// Try direct cache key lookup first (policy_id or name)
+	if policy, exists := e.policies[name]; exists {
+		if policyMap, ok := policy.(map[string]interface{}); ok {
+			policyMap["database_accessed"] = true
+			return policyMap, true
+		}
 	}
 
-	policyMap, ok := policy.(map[string]interface{})
-	if !ok {
-		return nil, false
+	// Fall back to searching by name field (cache key may be policy_id)
+	for _, policy := range e.policies {
+		if policyMap, ok := policy.(map[string]interface{}); ok {
+			if policyMap["name"] == name {
+				policyMap["database_accessed"] = true
+				return policyMap, true
+			}
+		}
 	}
 
-	// Mark that database was accessed
-	policyMap["database_accessed"] = true
-
-	return policyMap, true
+	return nil, false
 }
 
 func (e *DatabaseDynamicPolicyEngine) GetAllPolicies() map[string]interface{} {
@@ -569,17 +583,24 @@ func (e *DatabaseDynamicPolicyEngine) EvaluateDynamicPolicies(ctx context.Contex
 	}
 
 	// Check for tenant-specific policies
-	for name, policy := range policies {
+	for cacheKey, policy := range policies {
 		policyMap, ok := policy.(map[string]interface{})
 		if !ok {
 			continue
+		}
+
+		// Use the policy name from the data (cache key may be policy_id)
+		name, _ := policyMap["name"].(string)
+		if name == "" {
+			name = cacheKey
 		}
 
 		// Check if policy applies to this tenant
 		metadata, ok := policyMap["_metadata"].(map[string]interface{})
 		if ok {
 			policyTenant, _ := metadata["tenant_id"].(string)
-			if policyTenant != "global" && policyTenant != tenantID {
+			// "global" and "default" (NULL tenant_id) apply to all tenants
+			if policyTenant != "global" && policyTenant != "default" && policyTenant != tenantID {
 				continue
 			}
 		}
@@ -610,7 +631,8 @@ func (e *DatabaseDynamicPolicyEngine) EvaluateDynamicPolicies(ctx context.Contex
 		if len(conditions) > 0 {
 			allMatch := true
 			for _, cond := range conditions {
-				if !e.evaluateCondition(cond, req) {
+				condResult := e.evaluateCondition(cond, req)
+				if !condResult {
 					allMatch = false
 					break
 				}

--- a/platform/orchestrator/dynamic_policy_engine.go
+++ b/platform/orchestrator/dynamic_policy_engine.go
@@ -384,6 +384,15 @@ func (e *DynamicPolicyEngine) getFieldValue(field string, req OrchestratorReques
 			return req.Context[key]
 		}
 		return req.Context
+	case "step_input", "tool_input":
+		// Step/tool input fields are stored in context as "step_input.fieldName" / "tool_input.fieldName"
+		// by WCPPolicyAdapter.convertToOrchestratorRequest. Allow policies to reference them
+		// directly (e.g. "step_input.recipient_count") without requiring the "context." prefix.
+		if len(parts) > 1 && req.Context != nil {
+			key := strings.Join(parts, ".")
+			return req.Context[key]
+		}
+		return nil
 	case "media":
 		// Media governance fields — resolved from context["media_analysis"]
 		// These are populated by the media analysis pipeline before policy evaluation.

--- a/platform/orchestrator/dynamic_policy_engine_test.go
+++ b/platform/orchestrator/dynamic_policy_engine_test.go
@@ -14,6 +14,7 @@ package orchestrator
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"testing"
 	"time"
@@ -341,6 +342,28 @@ func TestGetFieldValue(t *testing.T) {
 			},
 			result:   &PolicyEvaluationResult{},
 			expected: "healthcare",
+		},
+		{
+			name:  "Step input field without context prefix",
+			field: "step_input.recipient_count",
+			req: OrchestratorRequest{
+				Context: map[string]interface{}{
+					"step_input.recipient_count": float64(5000),
+				},
+			},
+			result:   &PolicyEvaluationResult{},
+			expected: float64(5000),
+		},
+		{
+			name:  "Tool input field without context prefix",
+			field: "tool_input.query",
+			req: OrchestratorRequest{
+				Context: map[string]interface{}{
+					"tool_input.query": "SELECT * FROM users",
+				},
+			},
+			result:   &PolicyEvaluationResult{},
+			expected: "SELECT * FROM users",
 		},
 	}
 
@@ -1571,4 +1594,279 @@ func TestEvaluateCondition_AdditionalOperators(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestDatabaseDynamicPolicyEngine_StepGateEvaluation reproduces the production step gate
+// policy matching scenario. The demo-block-bulk-email policy should block step_input.recipient_count > 1000.
+func TestDatabaseDynamicPolicyEngine_StepGateEvaluation(t *testing.T) {
+	db, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("Failed to create sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	metricsDB, metricsMock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("Failed to create metrics sqlmock: %v", err)
+	}
+	defer metricsDB.Close()
+
+	// Expect metrics insert (happens async, may or may not execute before test ends)
+	metricsMock.ExpectExec("INSERT INTO policy_metrics").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	engine := &DatabaseDynamicPolicyEngine{
+		db:           db,
+		metricsDB:    metricsDB,
+		policies:     make(map[string]interface{}),
+		cacheTimeout: 30 * time.Second,
+		lastRefresh:  time.Now(),
+		stopCh:       make(chan struct{}),
+	}
+
+	// Manually populate the cache exactly as refreshPolicies() would.
+	// This simulates a policy loaded from DB with:
+	//   name: "demo-block-bulk-email"
+	//   conditions: [{"field": "step_input.recipient_count", "operator": "greater_than", "value": 1000}]
+	//   actions: [{"type": "block", "config": {"reason": "Email blocked: recipient count exceeds 1000"}}]
+	//   tenant_id: "travel-us"
+	conditionsJSON := `[{"field": "step_input.recipient_count", "operator": "greater_than", "value": 1000}]`
+	actionsJSON := `[{"type": "block", "config": {"reason": "Email blocked: recipient count exceeds 1000"}}]`
+
+	policyData := map[string]interface{}{
+		"policy_id":  "148f22f0-test",
+		"name":       "demo-block-bulk-email",
+		"type":       "content",
+		"category":   "dynamic-risk",
+		"conditions": json.RawMessage(conditionsJSON),
+		"actions":    json.RawMessage(actionsJSON),
+		"tenant_id":  "travel-us",
+		"priority":   50,
+		"_metadata": map[string]interface{}{
+			"name":      "demo-block-bulk-email",
+			"tenant_id": "travel-us",
+			"priority":  50,
+			"loaded_at": time.Now().Unix(),
+		},
+	}
+
+	engine.policies = map[string]interface{}{
+		"demo-block-bulk-email": policyData,
+	}
+
+	// Build the OrchestratorRequest exactly as WCPPolicyAdapter.convertToOrchestratorRequest() would.
+	// StepInput: {"recipient_count": 5000, "tool": "email_sender", "action": "send_bulk"}
+	// These get merged as "step_input.recipient_count", "step_input.tool", etc.
+	contextData := map[string]interface{}{
+		"workflow_id":              "wf_test",
+		"workflow_name":            "support-automation",
+		"source":                   "api",
+		"step_id":                  "step-2",
+		"step_name":                "Send Email",
+		"step_type":                "tool_call",
+		"step_index":               2,
+		"model":                    "",
+		"provider":                 "",
+		"step_input.tool":          "email_sender",
+		"step_input.action":        "send_bulk",
+		"step_input.recipient_count": float64(5000),
+		"step_input.subject":       "Support case update",
+		"tool_name":                "email_sender",
+		"tool_type":                "function",
+	}
+
+	req := OrchestratorRequest{
+		RequestID:   "wf_test_step-2",
+		RequestType: "workflow_step_gate",
+		User: UserContext{
+			TenantID: "travel-us",
+		},
+		Client: ClientContext{
+			ID:       "travel-us",
+			TenantID: "travel-us",
+			OrgID:    "travel-us",
+		},
+		Context: contextData,
+	}
+
+	result := engine.EvaluateDynamicPolicies(context.Background(), req)
+
+	// The policy should match and block
+	if result.Allowed {
+		t.Errorf("Expected blocked (Allowed=false), got Allowed=true")
+		t.Logf("AppliedPolicies: %v", result.AppliedPolicies)
+		t.Logf("RequiredActions: %v", result.RequiredActions)
+
+		// Debug: manually trace the evaluation
+		t.Log("--- Manual trace ---")
+		for name, policy := range engine.policies {
+			policyMap, ok := policy.(map[string]interface{})
+			if !ok {
+				t.Logf("Policy %q: not a map", name)
+				continue
+			}
+			metadata, ok := policyMap["_metadata"].(map[string]interface{})
+			if ok {
+				policyTenant, _ := metadata["tenant_id"].(string)
+				t.Logf("Policy %q: tenant=%q (request tenant=%q)", name, policyTenant, "travel-us")
+			}
+			condRaw := policyMap["conditions"]
+			t.Logf("Policy %q: conditions type=%T, value=%v", name, condRaw, condRaw)
+
+			// Try to parse conditions
+			if raw, ok := condRaw.(json.RawMessage); ok {
+				var conditions []map[string]interface{}
+				if err := json.Unmarshal(raw, &conditions); err != nil {
+					t.Logf("Failed to parse: %v", err)
+				} else {
+					for _, cond := range conditions {
+						field, _ := cond["field"].(string)
+						operator, _ := cond["operator"].(string)
+						value := cond["value"]
+						fieldValue := engine.getFieldValue(field, req)
+						t.Logf("  Condition: field=%q op=%q value=%v(%T) -> fieldValue=%v(%T)",
+							field, operator, value, value, fieldValue, fieldValue)
+					}
+				}
+			}
+		}
+	}
+
+	if len(result.AppliedPolicies) != 1 || result.AppliedPolicies[0] != "demo-block-bulk-email" {
+		t.Errorf("Expected AppliedPolicies=[demo-block-bulk-email], got %v", result.AppliedPolicies)
+	}
+
+	// Wait briefly for async metrics goroutine
+	time.Sleep(50 * time.Millisecond)
+}
+
+// TestDatabaseDynamicPolicyEngine_CrossTenantCacheCollision verifies that policies with
+// the same name across different tenants don't overwrite each other in the cache.
+// This was the root cause of the step gate returning "allow" instead of "block" in production:
+// a stale vc-demo tenant policy overwrote the travel-us policy because both were named
+// "demo-block-bulk-email" and the cache was keyed by name.
+func TestDatabaseDynamicPolicyEngine_CrossTenantCacheCollision(t *testing.T) {
+	db, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("Failed to create sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	metricsDB, metricsMock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("Failed to create metrics sqlmock: %v", err)
+	}
+	defer metricsDB.Close()
+
+	metricsMock.ExpectExec("INSERT INTO policy_metrics").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	engine := &DatabaseDynamicPolicyEngine{
+		db:           db,
+		metricsDB:    metricsDB,
+		policies:     make(map[string]interface{}),
+		cacheTimeout: 30 * time.Second,
+		lastRefresh:  time.Now(),
+		stopCh:       make(chan struct{}),
+	}
+
+	conditionsJSON := `[{"field": "step_input.recipient_count", "operator": "greater_than", "value": 1000}]`
+	actionsJSON := `[{"type": "block", "config": {"reason": "Email blocked: recipient count exceeds 1000"}}]`
+
+	// Simulate two policies with the SAME name but different tenants and different policy_ids.
+	// With the old name-keyed cache, the second would overwrite the first.
+	// With the policy_id-keyed cache, both coexist.
+	travelPolicy := map[string]interface{}{
+		"policy_id":  "policy-travel-001",
+		"name":       "demo-block-bulk-email",
+		"type":       "content",
+		"category":   "dynamic-risk",
+		"conditions": json.RawMessage(conditionsJSON),
+		"actions":    json.RawMessage(actionsJSON),
+		"tenant_id":  "travel-us",
+		"priority":   50,
+		"_metadata": map[string]interface{}{
+			"name":      "demo-block-bulk-email",
+			"tenant_id": "travel-us",
+			"priority":  50,
+			"loaded_at": time.Now().Unix(),
+		},
+	}
+
+	// Stale policy from vc-demo tenant — same name, different tenant, different conditions
+	staleDemoPolicy := map[string]interface{}{
+		"policy_id":  "policy-vcdemo-999",
+		"name":       "demo-block-bulk-email",
+		"type":       "content",
+		"category":   "dynamic-risk",
+		"conditions": json.RawMessage(`[{"field": "step_input.recipient_count", "operator": "greater_than", "value": 10000}]`),
+		"actions":    json.RawMessage(actionsJSON),
+		"tenant_id":  "vc-demo",
+		"priority":   50,
+		"_metadata": map[string]interface{}{
+			"name":      "demo-block-bulk-email",
+			"tenant_id": "vc-demo",
+			"priority":  50,
+			"loaded_at": time.Now().Unix(),
+		},
+	}
+
+	// Cache keyed by policy_id — both policies coexist
+	engine.policies = map[string]interface{}{
+		"policy-travel-001": travelPolicy,
+		"policy-vcdemo-999": staleDemoPolicy,
+	}
+
+	// Request from travel-us tenant with 5000 recipients
+	req := OrchestratorRequest{
+		RequestID:   "wf_test_step-2",
+		RequestType: "workflow_step_gate",
+		User: UserContext{
+			TenantID: "travel-us",
+		},
+		Client: ClientContext{
+			ID:       "travel-us",
+			TenantID: "travel-us",
+			OrgID:    "travel-us",
+		},
+		Context: map[string]interface{}{
+			"step_input.recipient_count": float64(5000),
+			"step_input.tool":           "email_sender",
+			"tool_name":                 "email_sender",
+		},
+	}
+
+	result := engine.EvaluateDynamicPolicies(context.Background(), req)
+
+	// The travel-us policy (threshold 1000) should match and block
+	if result.Allowed {
+		t.Errorf("Expected blocked (Allowed=false), got Allowed=true — cross-tenant collision likely")
+	}
+
+	if len(result.AppliedPolicies) != 1 || result.AppliedPolicies[0] != "demo-block-bulk-email" {
+		t.Errorf("Expected AppliedPolicies=[demo-block-bulk-email], got %v", result.AppliedPolicies)
+	}
+
+	// Also verify GetPolicy finds the travel policy by name
+	policy, found := engine.GetPolicy("demo-block-bulk-email")
+	if !found {
+		t.Error("GetPolicy('demo-block-bulk-email') returned not found")
+	} else if policy["policy_id"] != "policy-travel-001" && policy["policy_id"] != "policy-vcdemo-999" {
+		t.Errorf("GetPolicy returned unexpected policy_id: %v", policy["policy_id"])
+	}
+
+	// Verify both policies exist in cache (not overwritten)
+	// GetAllPolicies adds a "database_accessed" key, so expect 3 entries (2 policies + marker)
+	allPolicies := engine.GetAllPolicies()
+	if len(allPolicies) != 3 {
+		t.Errorf("Expected 3 entries in GetAllPolicies (2 policies + database_accessed marker), got %d", len(allPolicies))
+	}
+	if _, ok := allPolicies["policy-travel-001"]; !ok {
+		t.Error("travel-us policy missing from cache — name collision likely overwrote it")
+	}
+	if _, ok := allPolicies["policy-vcdemo-999"]; !ok {
+		t.Error("vc-demo policy missing from cache — name collision likely overwrote it")
+	}
+
+	time.Sleep(50 * time.Millisecond)
 }

--- a/platform/orchestrator/policy_api_service.go
+++ b/platform/orchestrator/policy_api_service.go
@@ -606,7 +606,15 @@ func (s *PolicyService) evaluateCondition(cond PolicyCondition, req *TestPolicyR
 			fieldValue = req.Context[contextField]
 		}
 	default:
-		return false
+		// For fields like "step_input.recipient_count" or "tool_input.query",
+		// look them up directly in the context map (WCPPolicyAdapter stores them
+		// with dotted keys like "step_input.recipient_count" in OrchestratorRequest.Context).
+		if req.Context != nil {
+			fieldValue = req.Context[cond.Field]
+		}
+		if fieldValue == nil {
+			return false
+		}
 	}
 
 	// Evaluate the condition


### PR DESCRIPTION
## Summary
- Fix cross-tenant policy name collision in step gate evaluation cache
- Resolve step_input and tool_input fields in dynamic policy conditions
- Fix step gate policy matching for step_input fields
- Remove diagnostic logging left from debug session

## Changes
- 5 files modified, 0 added, 0 deleted
- platform/orchestrator/db_dynamic_policies.go
- platform/orchestrator/dynamic_policy_engine.go
- platform/orchestrator/dynamic_policy_engine_test.go
- platform/orchestrator/policy_api_service.go

## Source commits
ea6aefe0, a8121449, cdbe5d68, 076ab2a4, 8c5f167e