### PR TITLE
fix: cross-tenant policy cache, audit summary, Python SDK 5.1.0 (v5.3.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [5.3.1] - 2026-03-24
+
+### Community
+
+#### Added
+
+- **Audit compliance summary endpoint**: `POST /api/v1/audit/summary` returns aggregated compliance stats for a date range including total events, breakdown by severity and action type, top triggered policies, and a compliance score. Used by the Customer Portal audit page.
+
+#### Fixed
+
+- **Cross-tenant dynamic policy cache collision** (#1410): Dynamic policy cache was keyed by policy name, causing policies with the same name across different tenants to silently overwrite each other. In multi-tenant deployments, this could result in step gate evaluations using the wrong tenant's policy or skipping policies entirely due to tenant mismatch. Cache key changed from `name` to `policy_id` to ensure all policies coexist regardless of naming. Includes `GetPolicy()` fallback search by name field for backward compatibility.
+
+### Enterprise
+
+#### Added
+
+- **SSO metadata URL fetcher**: `POST /api/v1/sso/fetch-metadata` in the Customer Portal fetches and parses SAML IDP metadata from a URL. Includes SSRF protection (HTTPS-only, private IP rejection, DNS validation), per-session rate limiting (5/min), 1MB response size limit, and automatic provider detection (Okta, Azure AD, Google, OneLogin, Auth0).
+
+#### Fixed
+
+- **Portal proxy missing headers**: Customer Portal orchestrator proxy now forwards `X-Org-ID` and `X-Client-ID` headers from session context, fixing 401 errors on SEBI compliance endpoints and other handlers that require these headers.
+- **SEBI audit export integer-only org IDs**: SEBI audit export service migrated from `int orgID` to `string tenantID` for consistency with the rest of the platform. Portal tenants with string IDs (e.g., `travel-us`) now work correctly with SEBI endpoints.
+- **SEBI org name lookup**: `getOrgName` now queries `org_id` column first (matching the varchar tenant ID from portal), with fallback to numeric `id` for backward compatibility.
+- **Compliance page crash on EU AI Act data**: Fixed `StatusBadge` component crash when `status` is undefined. Added null-safety guard. Also fixed `getEUAIActConformity()` API function to transform the backend list response (`{assessments: [...]}`) into the single-object shape (`{status, risk_level, last_assessment, requirements}`) expected by the compliance page UI.
+- **SCIM page smoke test false positive**: Playwright smoke test `afterEach` filter now catches browser-level "Failed to load resource: 403/404" console errors that lack endpoint URL context, preventing false failures on the SCIM settings page when SCIM provisioning is not configured.
+
+---
+
 ## [5.3.0] - 2026-03-17
 
 ### Community

--- a/docs/RBI_FREE_AI_COMPLIANCE.md
+++ b/docs/RBI_FREE_AI_COMPLIANCE.md
@@ -1,6 +1,6 @@
 # RBI FREE-AI Framework Compliance Guide
 
-*Last updated: March 2026 | AxonFlow Platform v5.3.0 | SDKs: Python v5.0.0, Go/TypeScript/Java v4.2.0*
+*Last updated: March 2026 | AxonFlow Platform v5.3.0 | SDKs: Python v5.1.0, Go/TypeScript/Java v4.2.0*
 
 This guide covers AxonFlow's compliance features for the Reserve Bank of India (RBI) Framework for Responsible and Ethical Enablement of AI (FREE-AI) published in August 2025.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # AxonFlow Documentation
 
-**Last Updated: March 2026** | **Platform: v5.3.0** | **SDKs: Python v5.0.0, Go/TypeScript/Java v4.2.0**
+**Last Updated: March 2026** | **Platform: v5.3.0** | **SDKs: Python v5.1.0, Go/TypeScript/Java v4.2.0**
 
 Public documentation for AxonFlow - synced to the Community Edition repository.
 
@@ -31,7 +31,7 @@ Configuration and how-to guides for common tasks.
 
 ## SDK Documentation
 
-AxonFlow provides official SDKs for Go, Python, Java, and TypeScript. SDK versions: Python v5.0.0, Go/TypeScript/Java v4.2.0.
+AxonFlow provides official SDKs for Go, Python, Java, and TypeScript. SDK versions: Python v5.1.0, Go/TypeScript/Java v4.2.0.
 
 | Document | Description |
 |----------|-------------|

--- a/docs/api/orchestrator-api.yaml
+++ b/docs/api/orchestrator-api.yaml
@@ -2392,6 +2392,113 @@ paths:
                 items:
                   $ref: '#/components/schemas/AuditLogEntry'
 
+  /api/v1/audit/summary:
+    post:
+      tags:
+        - Audit
+      summary: Get audit compliance summary
+      description: |
+        Returns aggregated compliance summary statistics for a given date range.
+        Includes total event counts, breakdowns by severity and action type,
+        top triggered policies, and an overall compliance score.
+      operationId: getAuditSummary
+      parameters:
+        - name: X-Tenant-ID
+          in: header
+          required: true
+          description: |
+            Tenant identifier for scoping results. Required to prevent cross-tenant
+            data aggregation. Falls back to X-Org-ID if X-Tenant-ID is not provided.
+          schema:
+            type: string
+          example: "travel-us"
+        - name: X-Org-ID
+          in: header
+          description: Organization identifier (fallback when X-Tenant-ID is absent)
+          schema:
+            type: string
+          example: "travel-us"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - start_time
+                - end_time
+              properties:
+                start_time:
+                  type: string
+                  format: date-time
+                  description: Start of date range (RFC3339)
+                end_time:
+                  type: string
+                  format: date-time
+                  description: End of date range (RFC3339, must be after start_time)
+            example:
+              start_time: "2026-01-01T00:00:00Z"
+              end_time: "2026-04-01T00:00:00Z"
+      responses:
+        '200':
+          description: Compliance summary
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  total_events:
+                    type: integer
+                    description: Total audit events in the date range
+                  by_severity:
+                    type: object
+                    additionalProperties:
+                      type: integer
+                    description: Event counts by severity (info, warning, critical)
+                  by_action:
+                    type: object
+                    additionalProperties:
+                      type: integer
+                    description: Event counts by action type (llm_call, tool_call, etc.)
+                  top_policies:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        policy_name:
+                          type: string
+                        trigger_count:
+                          type: integer
+                        block_count:
+                          type: integer
+                    description: Top 10 policies by trigger count
+                  compliance_score:
+                    type: number
+                    format: float
+                    description: "Compliance score 0-100 (100 = no blocked events)"
+              example:
+                total_events: 1523
+                by_severity:
+                  info: 1400
+                  warning: 100
+                  critical: 23
+                by_action:
+                  llm_call: 1200
+                  tool_call: 300
+                  policy_check: 23
+                top_policies:
+                  - policy_name: "demo-block-bulk-email"
+                    trigger_count: 15
+                    block_count: 15
+                  - policy_name: "pii-detection"
+                    trigger_count: 8
+                    block_count: 3
+                compliance_score: 98.5
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          description: Internal server error
+
   /api/v1/audit/tenant/{tenant_id}:
     get:
       tags:

--- a/docs/compliance/eu-ai-act.md
+++ b/docs/compliance/eu-ai-act.md
@@ -1,6 +1,6 @@
 # EU AI Act Compliance Guide
 
-*Last updated: March 2026 | AxonFlow Platform v5.3.0 | SDKs: Python v5.0.0, Go/TypeScript/Java v4.2.0*
+*Last updated: March 2026 | AxonFlow Platform v5.3.0 | SDKs: Python v5.1.0, Go/TypeScript/Java v4.2.0*
 
 AxonFlow provides comprehensive support for EU AI Act compliance. This guide covers the key features and APIs available for organizations operating AI systems in the European Union.
 

--- a/docs/compliance/rbi-free-ai.md
+++ b/docs/compliance/rbi-free-ai.md
@@ -1,6 +1,6 @@
 # RBI FREE-AI Framework Compliance
 
-*Last updated: March 2026 | AxonFlow Platform v5.3.0 | SDKs: Python v5.0.0, Go/TypeScript/Java v4.2.0*
+*Last updated: March 2026 | AxonFlow Platform v5.3.0 | SDKs: Python v5.1.0, Go/TypeScript/Java v4.2.0*
 
 AxonFlow provides comprehensive compliance support for the Reserve Bank of India's **Framework for Responsible and Ethical Enablement of AI (FREE-AI)** guidelines for Indian banking institutions.
 

--- a/docs/compliance/sebi-ai-ml.md
+++ b/docs/compliance/sebi-ai-ml.md
@@ -1,6 +1,6 @@
 # SEBI AI/ML Guidelines Compliance
 
-*Last updated: March 2026 | AxonFlow Platform v5.3.0 | SDKs: Python v5.0.0, Go/TypeScript/Java v4.2.0*
+*Last updated: March 2026 | AxonFlow Platform v5.3.0 | SDKs: Python v5.1.0, Go/TypeScript/Java v4.2.0*
 
 AxonFlow provides compliance support for the Securities and Exchange Board of India's **Framework for AI/ML in Securities Markets** for regulated entities in India's capital markets.
 

--- a/docs/compliance/sebi-compliance.md
+++ b/docs/compliance/sebi-compliance.md
@@ -2,7 +2,7 @@
 
 > **Comprehensive reference:** For the full SEBI AI/ML framework mapping including API endpoints, policy templates, and audit export workflows, see [sebi-ai-ml.md](./sebi-ai-ml.md). This document focuses on Indian PII detection details and hands-on implementation examples.
 
-*Last updated: March 2026 | AxonFlow Platform v5.3.0 | SDKs: Python v5.0.0, Go/TypeScript/Java v4.2.0*
+*Last updated: March 2026 | AxonFlow Platform v5.3.0 | SDKs: Python v5.1.0, Go/TypeScript/Java v4.2.0*
 
 This guide covers AxonFlow's compliance features for the Securities and Exchange Board of India (SEBI) AI/ML Guidelines (June 2025 Consultation Paper) and the Digital Personal Data Protection Act (DPDP) 2023.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started with AxonFlow
 
-**Last Updated: March 2026** | **Platform: v5.3.0** | **SDKs: Python v5.0.0, Go/TypeScript/Java v4.2.0**
+**Last Updated: March 2026** | **Platform: v5.3.0** | **SDKs: Python v5.1.0, Go/TypeScript/Java v4.2.0**
 
 **Build your first AI agent in 10 minutes** - No ML experience required.
 

--- a/docs/tutorials/01-first-agent-10-minutes.md
+++ b/docs/tutorials/01-first-agent-10-minutes.md
@@ -51,7 +51,7 @@ go get github.com/getaxonflow/axonflow-sdk-go/v4
 
 ```bash
 mkdir my-first-agent && cd my-first-agent
-pip3 install axonflow==5.0.0
+pip3 install axonflow==5.1.0
 ```
 
 ### TypeScript

--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -17,7 +17,7 @@ Step-by-step tutorials for getting started with AxonFlow.
 
 ## SDKs
 
-SDK versions: Python v5.0.0, Go/TypeScript/Java v4.2.0.
+SDK versions: Python v5.1.0, Go/TypeScript/Java v4.2.0.
 
 | Language | Package | Repository |
 |----------|---------|------------|
@@ -33,7 +33,7 @@ SDK versions: Python v5.0.0, Go/TypeScript/Java v4.2.0.
 go get github.com/getaxonflow/axonflow-sdk-go/v4
 
 # Python
-pip3 install axonflow==5.0.0
+pip3 install axonflow==5.1.0
 
 # Java (Maven)
 # Add to pom.xml:

--- a/examples/audit-logging/python/requirements.txt
+++ b/examples/audit-logging/python/requirements.txt
@@ -1,3 +1,3 @@
-axonflow>=5.0.0
+axonflow>=5.1.0
 python-dotenv>=1.0.0
 openai>=1.0.0

--- a/examples/code-governance/python/requirements.txt
+++ b/examples/code-governance/python/requirements.txt
@@ -1,2 +1,2 @@
-axonflow>=5.0.0
+axonflow>=5.1.0
 python-dotenv>=1.0.0

--- a/examples/cost-controls/enforcement/python/requirements.txt
+++ b/examples/cost-controls/enforcement/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=5.0.0
+axonflow>=5.1.0

--- a/examples/cost-controls/python/requirements.txt
+++ b/examples/cost-controls/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=5.0.0
+axonflow>=5.1.0

--- a/examples/cost-estimation/python/requirements.txt
+++ b/examples/cost-estimation/python/requirements.txt
@@ -1,3 +1,3 @@
-axonflow>=5.0.0
+axonflow>=5.1.0
 python-dotenv>=1.0.0
 requests>=2.31.0

--- a/examples/demo/requirements.txt
+++ b/examples/demo/requirements.txt
@@ -1,5 +1,5 @@
 # Core SDK
-axonflow>=5.0.0
+axonflow>=5.1.0
 
 # HTTP client
 httpx>=0.24.0

--- a/examples/evaluation-tier/python/requirements.txt
+++ b/examples/evaluation-tier/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=5.0.0
+axonflow>=5.1.0

--- a/examples/execution-replay/python/requirements.txt
+++ b/examples/execution-replay/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=5.0.0
+axonflow>=5.1.0

--- a/examples/execution-tracking/python/requirements.txt
+++ b/examples/execution-tracking/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=5.0.0
+axonflow>=5.1.0

--- a/examples/gateway-policy-config/python/requirements.txt
+++ b/examples/gateway-policy-config/python/requirements.txt
@@ -1,2 +1,2 @@
-axonflow>=5.0.0
+axonflow>=5.1.0
 python-dotenv>=1.0.0

--- a/examples/health-check/python/requirements.txt
+++ b/examples/health-check/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=5.0.0
+axonflow>=5.1.0

--- a/examples/hello-world/python/requirements.txt
+++ b/examples/hello-world/python/requirements.txt
@@ -1,5 +1,5 @@
 # AxonFlow SDK
-axonflow>=5.0.0
+axonflow>=5.1.0
 
 # Environment management
 python-dotenv>=1.0.0

--- a/examples/hitl-queue/python/requirements.txt
+++ b/examples/hitl-queue/python/requirements.txt
@@ -1,2 +1,2 @@
-axonflow>=5.0.0
+axonflow>=5.1.0
 python-dotenv>=1.0.0

--- a/examples/hitl/python/requirements.txt
+++ b/examples/hitl/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=5.0.0
+axonflow>=5.1.0

--- a/examples/integrations/autogen/requirements.txt
+++ b/examples/integrations/autogen/requirements.txt
@@ -1,3 +1,3 @@
 pyautogen>=0.2.0
-axonflow>=5.0.0
+axonflow>=5.1.0
 python-dotenv>=1.0.0

--- a/examples/integrations/crewai/requirements.txt
+++ b/examples/integrations/crewai/requirements.txt
@@ -1,5 +1,5 @@
 # AxonFlow SDK
-axonflow>=5.0.0
+axonflow>=5.1.0
 
 # CrewAI
 crewai>=0.5.0

--- a/examples/integrations/dspy/python/requirements.txt
+++ b/examples/integrations/dspy/python/requirements.txt
@@ -1,2 +1,2 @@
-axonflow>=5.0.0
+axonflow>=5.1.0
 python-dotenv>=1.0.0

--- a/examples/integrations/gateway-mode/python/requirements.txt
+++ b/examples/integrations/gateway-mode/python/requirements.txt
@@ -1,5 +1,5 @@
 # AxonFlow SDK
-axonflow>=5.0.0
+axonflow>=5.1.0
 
 # LLM Providers
 openai>=1.6.0

--- a/examples/integrations/langchain/requirements.txt
+++ b/examples/integrations/langchain/requirements.txt
@@ -1,5 +1,5 @@
 # AxonFlow SDK
-axonflow>=5.0.0
+axonflow>=5.1.0
 
 # LangChain
 langchain>=0.1.0

--- a/examples/integrations/langgraph/python/requirements.txt
+++ b/examples/integrations/langgraph/python/requirements.txt
@@ -1,2 +1,2 @@
-axonflow>=5.0.0
+axonflow>=5.1.0
 python-dotenv>=1.0.0

--- a/examples/integrations/proxy-mode/python/requirements.txt
+++ b/examples/integrations/proxy-mode/python/requirements.txt
@@ -1,5 +1,5 @@
 # AxonFlow SDK
-axonflow>=5.0.0
+axonflow>=5.1.0
 
 # Environment management
 python-dotenv>=1.0.0

--- a/examples/interceptors/python/requirements.txt
+++ b/examples/interceptors/python/requirements.txt
@@ -1,2 +1,2 @@
-axonflow>=5.0.0
+axonflow>=5.1.0
 openai>=1.0.0

--- a/examples/llm-providers/azure-openai/pii-detection/python/requirements.txt
+++ b/examples/llm-providers/azure-openai/pii-detection/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=5.0.0
+axonflow>=5.1.0

--- a/examples/llm-routing/e2e-tests/python/requirements.txt
+++ b/examples/llm-routing/e2e-tests/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=5.0.0
+axonflow>=5.1.0

--- a/examples/llm-routing/python/requirements.txt
+++ b/examples/llm-routing/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=5.0.0
+axonflow>=5.1.0

--- a/examples/map-confirm-mode/python/requirements.txt
+++ b/examples/map-confirm-mode/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=5.0.0
+axonflow>=5.1.0

--- a/examples/map-lifecycle/python/requirements.txt
+++ b/examples/map-lifecycle/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=5.0.0
+axonflow>=5.1.0

--- a/examples/map/python/requirements.txt
+++ b/examples/map/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=5.0.0
+axonflow>=5.1.0

--- a/examples/mcp-audit/python/requirements.txt
+++ b/examples/mcp-audit/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=5.0.0
+axonflow>=5.1.0

--- a/examples/mcp-connectors/python/requirements.txt
+++ b/examples/mcp-connectors/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=5.0.0
+axonflow>=5.1.0

--- a/examples/mcp-policies/check-endpoints/python/requirements.txt
+++ b/examples/mcp-policies/check-endpoints/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=5.0.0
+axonflow>=5.1.0

--- a/examples/mcp-policies/pii-redaction/python/requirements.txt
+++ b/examples/mcp-policies/pii-redaction/python/requirements.txt
@@ -1,2 +1,2 @@
-axonflow>=5.0.0
+axonflow>=5.1.0
 python-dotenv>=1.0.0

--- a/examples/mcp-policies/python/requirements.txt
+++ b/examples/mcp-policies/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=5.0.0
+axonflow>=5.1.0

--- a/examples/media-governance-policies/python/requirements.txt
+++ b/examples/media-governance-policies/python/requirements.txt
@@ -1,2 +1,2 @@
-axonflow>=5.0.0
+axonflow>=5.1.0
 python-dotenv>=1.0.0

--- a/examples/media-governance/python/requirements.txt
+++ b/examples/media-governance/python/requirements.txt
@@ -1,2 +1,2 @@
-axonflow>=5.0.0
+axonflow>=5.1.0
 python-dotenv>=1.0.0

--- a/examples/pii-detection/python/requirements.txt
+++ b/examples/pii-detection/python/requirements.txt
@@ -1,2 +1,2 @@
-axonflow>=5.0.0
+axonflow>=5.1.0
 python-dotenv>=1.0.0

--- a/examples/policies/crud/requirements.txt
+++ b/examples/policies/crud/requirements.txt
@@ -1,5 +1,5 @@
 # AxonFlow SDK
-axonflow>=5.0.0
+axonflow>=5.1.0
 
 # HTTP client for direct API calls
 httpx>=0.25.0

--- a/examples/policies/python/requirements.txt
+++ b/examples/policies/python/requirements.txt
@@ -1,5 +1,5 @@
 # AxonFlow SDK (from feature branch)
-axonflow>=5.0.0
+axonflow>=5.1.0
 
 # For loading environment variables
 python-dotenv>=1.0.0

--- a/examples/policy-configuration/python/requirements.txt
+++ b/examples/policy-configuration/python/requirements.txt
@@ -1,2 +1,2 @@
-axonflow>=5.0.0
+axonflow>=5.1.0
 python-dotenv>=1.0.0

--- a/examples/sdk-audit/python/requirements.txt
+++ b/examples/sdk-audit/python/requirements.txt
@@ -1,2 +1,2 @@
-axonflow>=5.0.0
+axonflow>=5.1.0
 python-dotenv>=1.0.0

--- a/examples/singapore-pii/python/requirements.txt
+++ b/examples/singapore-pii/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=5.0.0
+axonflow>=5.1.0

--- a/examples/sqli-detection/python/requirements.txt
+++ b/examples/sqli-detection/python/requirements.txt
@@ -1,2 +1,2 @@
-axonflow>=5.0.0
+axonflow>=5.1.0
 python-dotenv>=1.0.0

--- a/examples/static-policies/python/requirements.txt
+++ b/examples/static-policies/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=5.0.0
+axonflow>=5.1.0

--- a/examples/version-check/python/requirements.txt
+++ b/examples/version-check/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=5.0.0
+axonflow>=5.1.0

--- a/examples/webhooks/python/requirements.txt
+++ b/examples/webhooks/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=5.0.0
+axonflow>=5.1.0

--- a/examples/workflow-control/python/requirements.txt
+++ b/examples/workflow-control/python/requirements.txt
@@ -1,2 +1,2 @@
-axonflow>=5.0.0
+axonflow>=5.1.0
 python-dotenv>=1.0.0

--- a/examples/workflow-fail/python/requirements.txt
+++ b/examples/workflow-fail/python/requirements.txt
@@ -1,2 +1,2 @@
-axonflow>=5.0.0
+axonflow>=5.1.0
 python-dotenv>=1.0.0

--- a/examples/workflow-policy/python/requirements.txt
+++ b/examples/workflow-policy/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=5.0.0
+axonflow>=5.1.0

--- a/examples/workflows/01-simple-sequential/requirements.txt
+++ b/examples/workflows/01-simple-sequential/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=5.0.0
+axonflow>=5.1.0

--- a/examples/workflows/02-parallel-execution/requirements.txt
+++ b/examples/workflows/02-parallel-execution/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=5.0.0
+axonflow>=5.1.0

--- a/examples/workflows/03-conditional-logic/requirements.txt
+++ b/examples/workflows/03-conditional-logic/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=5.0.0
+axonflow>=5.1.0

--- a/examples/workflows/04-travel-booking-fallbacks/requirements.txt
+++ b/examples/workflows/04-travel-booking-fallbacks/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=5.0.0
+axonflow>=5.1.0

--- a/examples/workflows/05-data-pipeline/requirements.txt
+++ b/examples/workflows/05-data-pipeline/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=5.0.0
+axonflow>=5.1.0

--- a/examples/workflows/06-multi-step-approval/requirements.txt
+++ b/examples/workflows/06-multi-step-approval/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=5.0.0
+axonflow>=5.1.0

--- a/platform/agent/capabilities.go
+++ b/platform/agent/capabilities.go
@@ -45,7 +45,7 @@ func getSDKCompatibility() SDKCompatInfo {
 			"java":       "3.0.0",
 		},
 		RecommendedSDKVersion: map[string]string{
-			"python":     "5.0.0",
+			"python":     "5.1.0",
 			"typescript": "4.2.0",
 			"go":         "4.2.0",
 			"java":       "4.2.0",

--- a/platform/orchestrator/audit_summary_handler.go
+++ b/platform/orchestrator/audit_summary_handler.go
@@ -1,0 +1,226 @@
+// Copyright 2025 AxonFlow
+// SPDX-License-Identifier: BUSL-1.1
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package orchestrator
+
+import (
+	"database/sql"
+	"encoding/json"
+	"log"
+	"net/http"
+	"time"
+)
+
+// AuditSummaryRequest is the request body for POST /api/v1/audit/summary
+type AuditSummaryRequest struct {
+	StartTime string `json:"start_time"` // RFC3339
+	EndTime   string `json:"end_time"`   // RFC3339
+}
+
+// ComplianceSummary is the response for POST /api/v1/audit/summary
+type ComplianceSummary struct {
+	TotalEvents     int                `json:"total_events"`
+	BySeverity      map[string]int     `json:"by_severity"`
+	ByAction        map[string]int     `json:"by_action"`
+	TopPolicies     []PolicyHitSummary `json:"top_policies"`
+	ComplianceScore float64            `json:"compliance_score"`
+}
+
+// PolicyHitSummary represents a policy's trigger/block counts in the summary
+type PolicyHitSummary struct {
+	PolicyName   string `json:"policy_name"`
+	TriggerCount int    `json:"trigger_count"`
+	BlockCount   int    `json:"block_count"`
+}
+
+// AuditSummaryHandler handles the audit summary endpoint
+type AuditSummaryHandler struct {
+	db *sql.DB
+}
+
+// NewAuditSummaryHandler creates a new AuditSummaryHandler
+func NewAuditSummaryHandler(db *sql.DB) *AuditSummaryHandler {
+	return &AuditSummaryHandler{db: db}
+}
+
+// HandleSummary handles POST /api/v1/audit/summary
+func (h *AuditSummaryHandler) HandleSummary(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodOptions {
+		w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Tenant-ID, X-Org-ID")
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	var req AuditSummaryRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		sendErrorResponse(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	startTime, err := time.Parse(time.RFC3339, req.StartTime)
+	if err != nil {
+		sendErrorResponse(w, "Invalid start_time: must be RFC3339 format", http.StatusBadRequest)
+		return
+	}
+
+	endTime, err := time.Parse(time.RFC3339, req.EndTime)
+	if err != nil {
+		sendErrorResponse(w, "Invalid end_time: must be RFC3339 format", http.StatusBadRequest)
+		return
+	}
+
+	if !endTime.After(startTime) {
+		sendErrorResponse(w, "end_time must be after start_time", http.StatusBadRequest)
+		return
+	}
+
+	maxRange := 365 * 24 * time.Hour
+	if endTime.Sub(startTime) > maxRange {
+		sendErrorResponse(w, "Date range must not exceed 1 year", http.StatusBadRequest)
+		return
+	}
+
+	// Get tenant ID from request headers — reject if missing to prevent cross-tenant data leak
+	tenantID := r.Header.Get("X-Tenant-ID")
+	if tenantID == "" {
+		tenantID = r.Header.Get("X-Org-ID")
+	}
+	if tenantID == "" {
+		sendErrorResponse(w, "Missing tenant scope: X-Tenant-ID or X-Org-ID header required", http.StatusBadRequest)
+		return
+	}
+
+	summary, err := h.queryAuditSummary(tenantID, startTime, endTime)
+	if err != nil {
+		log.Printf("[AuditSummary] query failed for tenant %s: %v", tenantID, err)
+		sendErrorResponse(w, "Failed to generate audit summary", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(summary); err != nil {
+		log.Printf("[AuditSummary] error encoding response: %v", err)
+	}
+}
+
+// queryAuditSummary runs aggregation queries against audit_logs
+func (h *AuditSummaryHandler) queryAuditSummary(tenantID string, startTime, endTime time.Time) (*ComplianceSummary, error) {
+	if h.db == nil {
+		return &ComplianceSummary{
+			BySeverity:      map[string]int{},
+			ByAction:        map[string]int{},
+			TopPolicies:     []PolicyHitSummary{},
+			ComplianceScore: 100, // No events = fully compliant
+		}, nil
+	}
+
+	summary := &ComplianceSummary{
+		BySeverity:  map[string]int{},
+		ByAction:    map[string]int{},
+		TopPolicies: []PolicyHitSummary{},
+	}
+
+	// Query 1: Total events + by action (request_type) + blocked count
+	actionQuery := `
+		SELECT request_type, policy_decision, COUNT(*) as cnt
+		FROM audit_logs
+		WHERE tenant_id = $1
+		  AND timestamp >= $2
+		  AND timestamp <= $3
+		GROUP BY request_type, policy_decision
+	`
+
+	rows, err := h.db.Query(actionQuery, tenantID, startTime, endTime)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	totalEvents := 0
+	blockedCount := 0
+	for rows.Next() {
+		var requestType, policyDecision string
+		var cnt int
+		if err := rows.Scan(&requestType, &policyDecision, &cnt); err != nil {
+			return nil, err
+		}
+		totalEvents += cnt
+		if requestType != "" {
+			summary.ByAction[requestType] += cnt
+		}
+		if policyDecision == "blocked" {
+			blockedCount += cnt
+		}
+		// Map policy_decision to severity buckets
+		switch policyDecision {
+		case "blocked":
+			summary.BySeverity["critical"] += cnt
+		case "redacted":
+			summary.BySeverity["warning"] += cnt
+		case "allowed":
+			summary.BySeverity["info"] += cnt
+		default:
+			summary.BySeverity["info"] += cnt
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	summary.TotalEvents = totalEvents
+
+	// Compliance score: ratio of non-blocked events
+	if totalEvents > 0 {
+		summary.ComplianceScore = float64(totalEvents-blockedCount) / float64(totalEvents) * 100
+	} else {
+		summary.ComplianceScore = 100 // No events = fully compliant
+	}
+
+	// Query 2: Top policies by trigger count
+	policyQuery := `
+		SELECT
+			COALESCE(policy_details->>'policy_name', 'unknown') as policy_name,
+			COUNT(*) as trigger_count,
+			COUNT(*) FILTER (WHERE policy_decision = 'blocked') as block_count
+		FROM audit_logs
+		WHERE tenant_id = $1
+		  AND timestamp >= $2
+		  AND timestamp <= $3
+		  AND policy_details IS NOT NULL
+		  AND policy_details->>'policy_name' IS NOT NULL
+		GROUP BY policy_details->>'policy_name'
+		ORDER BY trigger_count DESC
+		LIMIT 10
+	`
+
+	policyRows, err := h.db.Query(policyQuery, tenantID, startTime, endTime)
+	if err != nil {
+		// Non-fatal: log and return partial results
+		log.Printf("[AuditSummary] policy query failed: %v", err)
+		return summary, nil
+	}
+	defer policyRows.Close()
+
+	for policyRows.Next() {
+		var entry PolicyHitSummary
+		if err := policyRows.Scan(&entry.PolicyName, &entry.TriggerCount, &entry.BlockCount); err != nil {
+			log.Printf("[AuditSummary] error scanning policy row: %v", err)
+			continue
+		}
+		summary.TopPolicies = append(summary.TopPolicies, entry)
+	}
+	if err := policyRows.Err(); err != nil {
+		log.Printf("[AuditSummary] policy rows iteration error: %v", err)
+	}
+
+	return summary, nil
+}

--- a/platform/orchestrator/audit_summary_handler_test.go
+++ b/platform/orchestrator/audit_summary_handler_test.go
@@ -1,0 +1,356 @@
+// Copyright 2025 AxonFlow
+// SPDX-License-Identifier: BUSL-1.1
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package orchestrator
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestAuditSummaryHandler_HandleSummary_ValidRequest(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	handler := NewAuditSummaryHandler(db)
+
+	// Mock action query
+	actionRows := sqlmock.NewRows([]string{"request_type", "policy_decision", "cnt"}).
+		AddRow("llm_call", "allowed", 80).
+		AddRow("llm_call", "blocked", 10).
+		AddRow("tool_call", "allowed", 5).
+		AddRow("tool_call", "redacted", 5)
+	mock.ExpectQuery("SELECT request_type, policy_decision, COUNT").
+		WithArgs("travel-us", sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnRows(actionRows)
+
+	// Mock policy query
+	policyRows := sqlmock.NewRows([]string{"policy_name", "trigger_count", "block_count"}).
+		AddRow("demo-block-bulk-email", 8, 8).
+		AddRow("pii-detection", 5, 2)
+	mock.ExpectQuery("SELECT").
+		WithArgs("travel-us", sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnRows(policyRows)
+
+	body := `{"start_time":"2026-01-01T00:00:00Z","end_time":"2026-04-01T00:00:00Z"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/audit/summary", strings.NewReader(body))
+	req.Header.Set("X-Tenant-ID", "travel-us")
+	rr := httptest.NewRecorder()
+
+	handler.HandleSummary(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var summary ComplianceSummary
+	if err := json.NewDecoder(rr.Body).Decode(&summary); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if summary.TotalEvents != 100 {
+		t.Errorf("expected 100 total events, got %d", summary.TotalEvents)
+	}
+	if summary.ByAction["llm_call"] != 90 {
+		t.Errorf("expected 90 llm_call events, got %d", summary.ByAction["llm_call"])
+	}
+	if summary.ByAction["tool_call"] != 10 {
+		t.Errorf("expected 10 tool_call events, got %d", summary.ByAction["tool_call"])
+	}
+	if summary.ComplianceScore != 90.0 {
+		t.Errorf("expected compliance score 90.0, got %f", summary.ComplianceScore)
+	}
+	if len(summary.TopPolicies) != 2 {
+		t.Errorf("expected 2 top policies, got %d", len(summary.TopPolicies))
+	}
+	if summary.TopPolicies[0].PolicyName != "demo-block-bulk-email" {
+		t.Errorf("expected first policy 'demo-block-bulk-email', got '%s'", summary.TopPolicies[0].PolicyName)
+	}
+	if summary.BySeverity["critical"] != 10 {
+		t.Errorf("expected 10 critical (blocked) events, got %d", summary.BySeverity["critical"])
+	}
+	if summary.BySeverity["warning"] != 5 {
+		t.Errorf("expected 5 warning (redacted) events, got %d", summary.BySeverity["warning"])
+	}
+}
+
+func TestAuditSummaryHandler_HandleSummary_InvalidBody(t *testing.T) {
+	handler := NewAuditSummaryHandler(nil)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/audit/summary", strings.NewReader("not json"))
+	rr := httptest.NewRecorder()
+
+	handler.HandleSummary(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", rr.Code)
+	}
+}
+
+func TestAuditSummaryHandler_HandleSummary_InvalidStartTime(t *testing.T) {
+	handler := NewAuditSummaryHandler(nil)
+
+	body := `{"start_time":"not-a-date","end_time":"2026-04-01T00:00:00Z"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/audit/summary", strings.NewReader(body))
+	rr := httptest.NewRecorder()
+
+	handler.HandleSummary(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", rr.Code)
+	}
+}
+
+func TestAuditSummaryHandler_HandleSummary_InvalidEndTime(t *testing.T) {
+	handler := NewAuditSummaryHandler(nil)
+
+	body := `{"start_time":"2026-01-01T00:00:00Z","end_time":"not-a-date"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/audit/summary", strings.NewReader(body))
+	rr := httptest.NewRecorder()
+
+	handler.HandleSummary(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", rr.Code)
+	}
+}
+
+func TestAuditSummaryHandler_HandleSummary_EndBeforeStart(t *testing.T) {
+	handler := NewAuditSummaryHandler(nil)
+
+	body := `{"start_time":"2026-04-01T00:00:00Z","end_time":"2026-01-01T00:00:00Z"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/audit/summary", strings.NewReader(body))
+	rr := httptest.NewRecorder()
+
+	handler.HandleSummary(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", rr.Code)
+	}
+}
+
+func TestAuditSummaryHandler_HandleSummary_RangeExceedsOneYear(t *testing.T) {
+	handler := NewAuditSummaryHandler(nil)
+
+	body := `{"start_time":"2024-01-01T00:00:00Z","end_time":"2026-04-01T00:00:00Z"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/audit/summary", strings.NewReader(body))
+	rr := httptest.NewRecorder()
+
+	handler.HandleSummary(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", rr.Code)
+	}
+}
+
+func TestAuditSummaryHandler_HandleSummary_MissingTenantID(t *testing.T) {
+	handler := NewAuditSummaryHandler(nil)
+
+	body := `{"start_time":"2026-01-01T00:00:00Z","end_time":"2026-04-01T00:00:00Z"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/audit/summary", strings.NewReader(body))
+	// No X-Tenant-ID or X-Org-ID headers
+	rr := httptest.NewRecorder()
+
+	handler.HandleSummary(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for missing tenant ID, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestAuditSummaryHandler_HandleSummary_NilDB(t *testing.T) {
+	handler := NewAuditSummaryHandler(nil)
+
+	body := `{"start_time":"2026-01-01T00:00:00Z","end_time":"2026-04-01T00:00:00Z"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/audit/summary", strings.NewReader(body))
+	req.Header.Set("X-Tenant-ID", "travel-us")
+	rr := httptest.NewRecorder()
+
+	handler.HandleSummary(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 for nil db, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var summary ComplianceSummary
+	if err := json.NewDecoder(rr.Body).Decode(&summary); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if summary.TotalEvents != 0 {
+		t.Errorf("expected 0 events for nil db, got %d", summary.TotalEvents)
+	}
+	if summary.ComplianceScore != 100 {
+		t.Errorf("expected 100 compliance score for empty, got %f", summary.ComplianceScore)
+	}
+}
+
+func TestAuditSummaryHandler_HandleSummary_DBError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	handler := NewAuditSummaryHandler(db)
+
+	mock.ExpectQuery("SELECT request_type").
+		WillReturnError(sqlmock.ErrCancelled)
+
+	body := `{"start_time":"2026-01-01T00:00:00Z","end_time":"2026-04-01T00:00:00Z"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/audit/summary", strings.NewReader(body))
+	req.Header.Set("X-Tenant-ID", "travel-us")
+	rr := httptest.NewRecorder()
+
+	handler.HandleSummary(rr, req)
+
+	if rr.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", rr.Code)
+	}
+}
+
+func TestAuditSummaryHandler_HandleSummary_CORS(t *testing.T) {
+	handler := NewAuditSummaryHandler(nil)
+
+	req := httptest.NewRequest(http.MethodOptions, "/api/v1/audit/summary", nil)
+	rr := httptest.NewRecorder()
+
+	handler.HandleSummary(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("expected 200 for OPTIONS, got %d", rr.Code)
+	}
+}
+
+func TestAuditSummaryHandler_HandleSummary_FallbackToOrgID(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	handler := NewAuditSummaryHandler(db)
+
+	actionRows := sqlmock.NewRows([]string{"request_type", "policy_decision", "cnt"}).
+		AddRow("llm_call", "allowed", 5)
+	mock.ExpectQuery("SELECT request_type").
+		WithArgs("banking-india", sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnRows(actionRows)
+
+	policyRows := sqlmock.NewRows([]string{"policy_name", "trigger_count", "block_count"})
+	mock.ExpectQuery("SELECT").
+		WithArgs("banking-india", sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnRows(policyRows)
+
+	body := `{"start_time":"2026-01-01T00:00:00Z","end_time":"2026-04-01T00:00:00Z"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/audit/summary", strings.NewReader(body))
+	// No X-Tenant-ID, but X-Org-ID set
+	req.Header.Set("X-Org-ID", "banking-india")
+	rr := httptest.NewRecorder()
+
+	handler.HandleSummary(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestAuditSummaryHandler_HandleSummary_ZeroBlockedEvents(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	handler := NewAuditSummaryHandler(db)
+
+	actionRows := sqlmock.NewRows([]string{"request_type", "policy_decision", "cnt"}).
+		AddRow("llm_call", "allowed", 50)
+	mock.ExpectQuery("SELECT request_type").
+		WillReturnRows(actionRows)
+
+	policyRows := sqlmock.NewRows([]string{"policy_name", "trigger_count", "block_count"})
+	mock.ExpectQuery("SELECT").
+		WillReturnRows(policyRows)
+
+	body := `{"start_time":"2026-01-01T00:00:00Z","end_time":"2026-04-01T00:00:00Z"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/audit/summary", strings.NewReader(body))
+	req.Header.Set("X-Tenant-ID", "travel-us")
+	rr := httptest.NewRecorder()
+
+	handler.HandleSummary(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+
+	var summary ComplianceSummary
+	json.NewDecoder(rr.Body).Decode(&summary)
+
+	if summary.ComplianceScore != 100 {
+		t.Errorf("expected 100%% compliance with no blocks, got %f", summary.ComplianceScore)
+	}
+}
+
+func TestAuditSummaryHandler_HandleSummary_AllBlocked(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	handler := NewAuditSummaryHandler(db)
+
+	actionRows := sqlmock.NewRows([]string{"request_type", "policy_decision", "cnt"}).
+		AddRow("llm_call", "blocked", 10)
+	mock.ExpectQuery("SELECT request_type").
+		WillReturnRows(actionRows)
+
+	policyRows := sqlmock.NewRows([]string{"policy_name", "trigger_count", "block_count"})
+	mock.ExpectQuery("SELECT").
+		WillReturnRows(policyRows)
+
+	body := `{"start_time":"2026-01-01T00:00:00Z","end_time":"2026-04-01T00:00:00Z"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/audit/summary", strings.NewReader(body))
+	req.Header.Set("X-Tenant-ID", "travel-us")
+	rr := httptest.NewRecorder()
+
+	handler.HandleSummary(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+
+	var summary ComplianceSummary
+	json.NewDecoder(rr.Body).Decode(&summary)
+
+	if summary.ComplianceScore != 0 {
+		t.Errorf("expected 0%% compliance with all blocked, got %f", summary.ComplianceScore)
+	}
+}
+
+func TestNewAuditSummaryHandler(t *testing.T) {
+	handler := NewAuditSummaryHandler(nil)
+	if handler == nil {
+		t.Error("expected non-nil handler")
+	}
+	if handler.db != nil {
+		t.Error("expected nil db")
+	}
+}

--- a/platform/orchestrator/capabilities.go
+++ b/platform/orchestrator/capabilities.go
@@ -61,7 +61,7 @@ func getSDKCompatibility() SDKCompatInfo {
 			"java":       "3.0.0",
 		},
 		RecommendedSDKVersion: map[string]string{
-			"python":     "5.0.0",
+			"python":     "5.1.0",
 			"typescript": "4.2.0",
 			"go":         "4.2.0",
 			"java":       "4.2.0",

--- a/platform/orchestrator/db_dynamic_policies.go
+++ b/platform/orchestrator/db_dynamic_policies.go
@@ -381,7 +381,16 @@ func (e *DatabaseDynamicPolicyEngine) refreshPolicies() error {
 			"loaded_at": time.Now().Unix(),
 		}
 
-		newPolicies[name] = policyData
+		// Use policy_id as cache key to avoid cross-tenant name collisions.
+		// Different tenants can have policies with the same name, and using name
+		// as the key caused the second policy to overwrite the first.
+		// Fall back to name for backward compatibility with legacy policies that
+		// might not have a policy_id set.
+		cacheKey := policyID
+		if cacheKey == "" {
+			cacheKey = name
+		}
+		newPolicies[cacheKey] = policyData
 	}
 
 	if err = rows.Err(); err != nil {
@@ -492,20 +501,25 @@ func (e *DatabaseDynamicPolicyEngine) GetPolicy(name string) (map[string]interfa
 	e.mu.RLock()
 	defer e.mu.RUnlock()
 
-	policy, exists := e.policies[name]
-	if !exists {
-		return nil, false
+	// Try direct cache key lookup first (policy_id or name)
+	if policy, exists := e.policies[name]; exists {
+		if policyMap, ok := policy.(map[string]interface{}); ok {
+			policyMap["database_accessed"] = true
+			return policyMap, true
+		}
 	}
 
-	policyMap, ok := policy.(map[string]interface{})
-	if !ok {
-		return nil, false
+	// Fall back to searching by name field (cache key may be policy_id)
+	for _, policy := range e.policies {
+		if policyMap, ok := policy.(map[string]interface{}); ok {
+			if policyMap["name"] == name {
+				policyMap["database_accessed"] = true
+				return policyMap, true
+			}
+		}
 	}
 
-	// Mark that database was accessed
-	policyMap["database_accessed"] = true
-
-	return policyMap, true
+	return nil, false
 }
 
 func (e *DatabaseDynamicPolicyEngine) GetAllPolicies() map[string]interface{} {
@@ -569,17 +583,24 @@ func (e *DatabaseDynamicPolicyEngine) EvaluateDynamicPolicies(ctx context.Contex
 	}
 
 	// Check for tenant-specific policies
-	for name, policy := range policies {
+	for cacheKey, policy := range policies {
 		policyMap, ok := policy.(map[string]interface{})
 		if !ok {
 			continue
+		}
+
+		// Use the policy name from the data (cache key may be policy_id)
+		name, _ := policyMap["name"].(string)
+		if name == "" {
+			name = cacheKey
 		}
 
 		// Check if policy applies to this tenant
 		metadata, ok := policyMap["_metadata"].(map[string]interface{})
 		if ok {
 			policyTenant, _ := metadata["tenant_id"].(string)
-			if policyTenant != "global" && policyTenant != tenantID {
+			// "global" and "default" (NULL tenant_id) apply to all tenants
+			if policyTenant != "global" && policyTenant != "default" && policyTenant != tenantID {
 				continue
 			}
 		}
@@ -610,7 +631,8 @@ func (e *DatabaseDynamicPolicyEngine) EvaluateDynamicPolicies(ctx context.Contex
 		if len(conditions) > 0 {
 			allMatch := true
 			for _, cond := range conditions {
-				if !e.evaluateCondition(cond, req) {
+				condResult := e.evaluateCondition(cond, req)
+				if !condResult {
 					allMatch = false
 					break
 				}

--- a/platform/orchestrator/dynamic_policy_engine.go
+++ b/platform/orchestrator/dynamic_policy_engine.go
@@ -384,6 +384,15 @@ func (e *DynamicPolicyEngine) getFieldValue(field string, req OrchestratorReques
 			return req.Context[key]
 		}
 		return req.Context
+	case "step_input", "tool_input":
+		// Step/tool input fields are stored in context as "step_input.fieldName" / "tool_input.fieldName"
+		// by WCPPolicyAdapter.convertToOrchestratorRequest. Allow policies to reference them
+		// directly (e.g. "step_input.recipient_count") without requiring the "context." prefix.
+		if len(parts) > 1 && req.Context != nil {
+			key := strings.Join(parts, ".")
+			return req.Context[key]
+		}
+		return nil
 	case "media":
 		// Media governance fields — resolved from context["media_analysis"]
 		// These are populated by the media analysis pipeline before policy evaluation.

--- a/platform/orchestrator/dynamic_policy_engine_test.go
+++ b/platform/orchestrator/dynamic_policy_engine_test.go
@@ -14,6 +14,7 @@ package orchestrator
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"testing"
 	"time"
@@ -341,6 +342,28 @@ func TestGetFieldValue(t *testing.T) {
 			},
 			result:   &PolicyEvaluationResult{},
 			expected: "healthcare",
+		},
+		{
+			name:  "Step input field without context prefix",
+			field: "step_input.recipient_count",
+			req: OrchestratorRequest{
+				Context: map[string]interface{}{
+					"step_input.recipient_count": float64(5000),
+				},
+			},
+			result:   &PolicyEvaluationResult{},
+			expected: float64(5000),
+		},
+		{
+			name:  "Tool input field without context prefix",
+			field: "tool_input.query",
+			req: OrchestratorRequest{
+				Context: map[string]interface{}{
+					"tool_input.query": "SELECT * FROM users",
+				},
+			},
+			result:   &PolicyEvaluationResult{},
+			expected: "SELECT * FROM users",
 		},
 	}
 
@@ -1571,4 +1594,279 @@ func TestEvaluateCondition_AdditionalOperators(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestDatabaseDynamicPolicyEngine_StepGateEvaluation reproduces the production step gate
+// policy matching scenario. The demo-block-bulk-email policy should block step_input.recipient_count > 1000.
+func TestDatabaseDynamicPolicyEngine_StepGateEvaluation(t *testing.T) {
+	db, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("Failed to create sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	metricsDB, metricsMock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("Failed to create metrics sqlmock: %v", err)
+	}
+	defer metricsDB.Close()
+
+	// Expect metrics insert (happens async, may or may not execute before test ends)
+	metricsMock.ExpectExec("INSERT INTO policy_metrics").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	engine := &DatabaseDynamicPolicyEngine{
+		db:           db,
+		metricsDB:    metricsDB,
+		policies:     make(map[string]interface{}),
+		cacheTimeout: 30 * time.Second,
+		lastRefresh:  time.Now(),
+		stopCh:       make(chan struct{}),
+	}
+
+	// Manually populate the cache exactly as refreshPolicies() would.
+	// This simulates a policy loaded from DB with:
+	//   name: "demo-block-bulk-email"
+	//   conditions: [{"field": "step_input.recipient_count", "operator": "greater_than", "value": 1000}]
+	//   actions: [{"type": "block", "config": {"reason": "Email blocked: recipient count exceeds 1000"}}]
+	//   tenant_id: "travel-us"
+	conditionsJSON := `[{"field": "step_input.recipient_count", "operator": "greater_than", "value": 1000}]`
+	actionsJSON := `[{"type": "block", "config": {"reason": "Email blocked: recipient count exceeds 1000"}}]`
+
+	policyData := map[string]interface{}{
+		"policy_id":  "148f22f0-test",
+		"name":       "demo-block-bulk-email",
+		"type":       "content",
+		"category":   "dynamic-risk",
+		"conditions": json.RawMessage(conditionsJSON),
+		"actions":    json.RawMessage(actionsJSON),
+		"tenant_id":  "travel-us",
+		"priority":   50,
+		"_metadata": map[string]interface{}{
+			"name":      "demo-block-bulk-email",
+			"tenant_id": "travel-us",
+			"priority":  50,
+			"loaded_at": time.Now().Unix(),
+		},
+	}
+
+	engine.policies = map[string]interface{}{
+		"demo-block-bulk-email": policyData,
+	}
+
+	// Build the OrchestratorRequest exactly as WCPPolicyAdapter.convertToOrchestratorRequest() would.
+	// StepInput: {"recipient_count": 5000, "tool": "email_sender", "action": "send_bulk"}
+	// These get merged as "step_input.recipient_count", "step_input.tool", etc.
+	contextData := map[string]interface{}{
+		"workflow_id":              "wf_test",
+		"workflow_name":            "support-automation",
+		"source":                   "api",
+		"step_id":                  "step-2",
+		"step_name":                "Send Email",
+		"step_type":                "tool_call",
+		"step_index":               2,
+		"model":                    "",
+		"provider":                 "",
+		"step_input.tool":          "email_sender",
+		"step_input.action":        "send_bulk",
+		"step_input.recipient_count": float64(5000),
+		"step_input.subject":       "Support case update",
+		"tool_name":                "email_sender",
+		"tool_type":                "function",
+	}
+
+	req := OrchestratorRequest{
+		RequestID:   "wf_test_step-2",
+		RequestType: "workflow_step_gate",
+		User: UserContext{
+			TenantID: "travel-us",
+		},
+		Client: ClientContext{
+			ID:       "travel-us",
+			TenantID: "travel-us",
+			OrgID:    "travel-us",
+		},
+		Context: contextData,
+	}
+
+	result := engine.EvaluateDynamicPolicies(context.Background(), req)
+
+	// The policy should match and block
+	if result.Allowed {
+		t.Errorf("Expected blocked (Allowed=false), got Allowed=true")
+		t.Logf("AppliedPolicies: %v", result.AppliedPolicies)
+		t.Logf("RequiredActions: %v", result.RequiredActions)
+
+		// Debug: manually trace the evaluation
+		t.Log("--- Manual trace ---")
+		for name, policy := range engine.policies {
+			policyMap, ok := policy.(map[string]interface{})
+			if !ok {
+				t.Logf("Policy %q: not a map", name)
+				continue
+			}
+			metadata, ok := policyMap["_metadata"].(map[string]interface{})
+			if ok {
+				policyTenant, _ := metadata["tenant_id"].(string)
+				t.Logf("Policy %q: tenant=%q (request tenant=%q)", name, policyTenant, "travel-us")
+			}
+			condRaw := policyMap["conditions"]
+			t.Logf("Policy %q: conditions type=%T, value=%v", name, condRaw, condRaw)
+
+			// Try to parse conditions
+			if raw, ok := condRaw.(json.RawMessage); ok {
+				var conditions []map[string]interface{}
+				if err := json.Unmarshal(raw, &conditions); err != nil {
+					t.Logf("Failed to parse: %v", err)
+				} else {
+					for _, cond := range conditions {
+						field, _ := cond["field"].(string)
+						operator, _ := cond["operator"].(string)
+						value := cond["value"]
+						fieldValue := engine.getFieldValue(field, req)
+						t.Logf("  Condition: field=%q op=%q value=%v(%T) -> fieldValue=%v(%T)",
+							field, operator, value, value, fieldValue, fieldValue)
+					}
+				}
+			}
+		}
+	}
+
+	if len(result.AppliedPolicies) != 1 || result.AppliedPolicies[0] != "demo-block-bulk-email" {
+		t.Errorf("Expected AppliedPolicies=[demo-block-bulk-email], got %v", result.AppliedPolicies)
+	}
+
+	// Wait briefly for async metrics goroutine
+	time.Sleep(50 * time.Millisecond)
+}
+
+// TestDatabaseDynamicPolicyEngine_CrossTenantCacheCollision verifies that policies with
+// the same name across different tenants don't overwrite each other in the cache.
+// This was the root cause of the step gate returning "allow" instead of "block" in production:
+// a stale vc-demo tenant policy overwrote the travel-us policy because both were named
+// "demo-block-bulk-email" and the cache was keyed by name.
+func TestDatabaseDynamicPolicyEngine_CrossTenantCacheCollision(t *testing.T) {
+	db, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("Failed to create sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	metricsDB, metricsMock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("Failed to create metrics sqlmock: %v", err)
+	}
+	defer metricsDB.Close()
+
+	metricsMock.ExpectExec("INSERT INTO policy_metrics").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	engine := &DatabaseDynamicPolicyEngine{
+		db:           db,
+		metricsDB:    metricsDB,
+		policies:     make(map[string]interface{}),
+		cacheTimeout: 30 * time.Second,
+		lastRefresh:  time.Now(),
+		stopCh:       make(chan struct{}),
+	}
+
+	conditionsJSON := `[{"field": "step_input.recipient_count", "operator": "greater_than", "value": 1000}]`
+	actionsJSON := `[{"type": "block", "config": {"reason": "Email blocked: recipient count exceeds 1000"}}]`
+
+	// Simulate two policies with the SAME name but different tenants and different policy_ids.
+	// With the old name-keyed cache, the second would overwrite the first.
+	// With the policy_id-keyed cache, both coexist.
+	travelPolicy := map[string]interface{}{
+		"policy_id":  "policy-travel-001",
+		"name":       "demo-block-bulk-email",
+		"type":       "content",
+		"category":   "dynamic-risk",
+		"conditions": json.RawMessage(conditionsJSON),
+		"actions":    json.RawMessage(actionsJSON),
+		"tenant_id":  "travel-us",
+		"priority":   50,
+		"_metadata": map[string]interface{}{
+			"name":      "demo-block-bulk-email",
+			"tenant_id": "travel-us",
+			"priority":  50,
+			"loaded_at": time.Now().Unix(),
+		},
+	}
+
+	// Stale policy from vc-demo tenant — same name, different tenant, different conditions
+	staleDemoPolicy := map[string]interface{}{
+		"policy_id":  "policy-vcdemo-999",
+		"name":       "demo-block-bulk-email",
+		"type":       "content",
+		"category":   "dynamic-risk",
+		"conditions": json.RawMessage(`[{"field": "step_input.recipient_count", "operator": "greater_than", "value": 10000}]`),
+		"actions":    json.RawMessage(actionsJSON),
+		"tenant_id":  "vc-demo",
+		"priority":   50,
+		"_metadata": map[string]interface{}{
+			"name":      "demo-block-bulk-email",
+			"tenant_id": "vc-demo",
+			"priority":  50,
+			"loaded_at": time.Now().Unix(),
+		},
+	}
+
+	// Cache keyed by policy_id — both policies coexist
+	engine.policies = map[string]interface{}{
+		"policy-travel-001": travelPolicy,
+		"policy-vcdemo-999": staleDemoPolicy,
+	}
+
+	// Request from travel-us tenant with 5000 recipients
+	req := OrchestratorRequest{
+		RequestID:   "wf_test_step-2",
+		RequestType: "workflow_step_gate",
+		User: UserContext{
+			TenantID: "travel-us",
+		},
+		Client: ClientContext{
+			ID:       "travel-us",
+			TenantID: "travel-us",
+			OrgID:    "travel-us",
+		},
+		Context: map[string]interface{}{
+			"step_input.recipient_count": float64(5000),
+			"step_input.tool":           "email_sender",
+			"tool_name":                 "email_sender",
+		},
+	}
+
+	result := engine.EvaluateDynamicPolicies(context.Background(), req)
+
+	// The travel-us policy (threshold 1000) should match and block
+	if result.Allowed {
+		t.Errorf("Expected blocked (Allowed=false), got Allowed=true — cross-tenant collision likely")
+	}
+
+	if len(result.AppliedPolicies) != 1 || result.AppliedPolicies[0] != "demo-block-bulk-email" {
+		t.Errorf("Expected AppliedPolicies=[demo-block-bulk-email], got %v", result.AppliedPolicies)
+	}
+
+	// Also verify GetPolicy finds the travel policy by name
+	policy, found := engine.GetPolicy("demo-block-bulk-email")
+	if !found {
+		t.Error("GetPolicy('demo-block-bulk-email') returned not found")
+	} else if policy["policy_id"] != "policy-travel-001" && policy["policy_id"] != "policy-vcdemo-999" {
+		t.Errorf("GetPolicy returned unexpected policy_id: %v", policy["policy_id"])
+	}
+
+	// Verify both policies exist in cache (not overwritten)
+	// GetAllPolicies adds a "database_accessed" key, so expect 3 entries (2 policies + marker)
+	allPolicies := engine.GetAllPolicies()
+	if len(allPolicies) != 3 {
+		t.Errorf("Expected 3 entries in GetAllPolicies (2 policies + database_accessed marker), got %d", len(allPolicies))
+	}
+	if _, ok := allPolicies["policy-travel-001"]; !ok {
+		t.Error("travel-us policy missing from cache — name collision likely overwrote it")
+	}
+	if _, ok := allPolicies["policy-vcdemo-999"]; !ok {
+		t.Error("vc-demo policy missing from cache — name collision likely overwrote it")
+	}
+
+	time.Sleep(50 * time.Millisecond)
 }

--- a/platform/orchestrator/policy_api_service.go
+++ b/platform/orchestrator/policy_api_service.go
@@ -606,7 +606,15 @@ func (s *PolicyService) evaluateCondition(cond PolicyCondition, req *TestPolicyR
 			fieldValue = req.Context[contextField]
 		}
 	default:
-		return false
+		// For fields like "step_input.recipient_count" or "tool_input.query",
+		// look them up directly in the context map (WCPPolicyAdapter stores them
+		// with dotted keys like "step_input.recipient_count" in OrchestratorRequest.Context).
+		if req.Context != nil {
+			fieldValue = req.Context[cond.Field]
+		}
+		if fieldValue == nil {
+			return false
+		}
 	}
 
 	// Evaluate the condition

--- a/platform/orchestrator/run.go
+++ b/platform/orchestrator/run.go
@@ -499,6 +499,7 @@ func Run() {
 	r.HandleFunc("/api/v1/audit/search", auditSearchHandler).Methods("POST")
 	r.HandleFunc("/api/v1/audit/tool-call", auditToolCallHandler).Methods("POST")
 	r.HandleFunc("/api/v1/audit/tenant/{tenant_id}", tenantAuditLogsHandler).Methods("GET")
+	r.HandleFunc("/api/v1/audit/summary", auditSummaryRequestHandler).Methods("POST", "OPTIONS")
 
 	// Workflow endpoints
 	r.HandleFunc("/api/v1/workflows/executions/tenant/{tenant_id}", tenantWorkflowExecutionsHandler).Methods("GET")
@@ -2264,6 +2265,19 @@ func auditSearchHandler(w http.ResponseWriter, r *http.Request) {
 	if err := json.NewEncoder(w).Encode(response); err != nil {
 		log.Printf("Error encoding response: %v", err)
 	}
+}
+
+var auditSummaryHandler *AuditSummaryHandler
+
+func auditSummaryRequestHandler(w http.ResponseWriter, r *http.Request) {
+	if auditSummaryHandler == nil {
+		var db *sql.DB
+		if auditLogger != nil {
+			db = auditLogger.db
+		}
+		auditSummaryHandler = NewAuditSummaryHandler(db)
+	}
+	auditSummaryHandler.HandleSummary(w, r)
 }
 
 func tenantAuditLogsHandler(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Platform v5.3.1 Release

### Community

#### Added
- **Audit compliance summary endpoint**: `POST /api/v1/audit/summary` returns aggregated compliance stats for a date range including total events, breakdown by severity and action type, top triggered policies, and a compliance score.

#### Fixed
- **Cross-tenant dynamic policy cache collision** (#1410): Cache key changed from policy name to policy_id to prevent policies with the same name across different tenants from silently overwriting each other.
- **step_input/tool_input field resolution**: Dynamic policy conditions referencing `step_input.*` and `tool_input.*` fields now resolve correctly in step gate evaluations.
- **Step gate policy matching**: Fixed policy matching for step_input fields in the dynamic policy engine.

#### Changed
- Python SDK 5.1.0 version sweep across all examples and docs
- Dependency bumps (next, npm_and_yarn group)

## Source commits
3a002261, 7bd99a42, fc75f235, 5ac4a08b, 956468a3, 516a247b, db069ebd, 5e439179, ea6aefe0, a8121449, cdbe5d68, 076ab2a4, 8c5f167e