### PR TITLE
fix: point axonctl enterprise docs link to correct domain

### DIFF
--- a/platform/cmd/axonctl/docs.go
+++ b/platform/cmd/axonctl/docs.go
@@ -71,7 +71,7 @@ Examples:
 				fmt.Printf("   Reason: %s\n", reason)
 			}
 			fmt.Printf("\n📧 Instructions for %s:\n", email)
-			fmt.Println("   1. Visit: https://docs.getaxonflow.com/docs/protected/")
+			fmt.Println("   1. Visit: https://enterprise-docs.getaxonflow.com/docs/overview")
 			fmt.Println("   2. Enter your email address when prompted")
 			fmt.Println("   3. Check your email for a one-time PIN")
 			fmt.Println("   4. Enter the PIN to access the documentation")


### PR DESCRIPTION
## Summary
- Fix enterprise docs URL in `axonctl` CLI output: `docs.getaxonflow.com/docs/protected/` → `enterprise-docs.getaxonflow.com/docs/overview`

## Test plan
- [ ] Verify `axonctl docs` command outputs the correct enterprise docs URL