### PR TITLE
v6.0.0: identity model tests, setup script rebuild fix

### DIFF
--- a/platform/agent/identity_model_integration_test.go
+++ b/platform/agent/identity_model_integration_test.go
@@ -1,0 +1,129 @@
+package agent
+
+import (
+	"database/sql"
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sync"
+	"testing"
+
+	_ "github.com/lib/pq"
+)
+
+// TestIdentityModel_CommunityMode_InjectsHeaders verifies that community mode
+// injects X-Tenant-ID and X-Org-ID headers from Basic auth and deployment ORG_ID.
+func TestIdentityModel_CommunityMode_InjectsHeaders(t *testing.T) {
+	t.Setenv("DEPLOYMENT_MODE", "community")
+
+	var capturedTenantID, capturedOrgID string
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedTenantID = r.Header.Get("X-Tenant-ID")
+		capturedOrgID = r.Header.Get("X-Org-ID")
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := proxyAuthMiddleware(inner)
+
+	// Test 1: No auth → defaults to "community" tenant, deployment org
+	req := httptest.NewRequest("GET", "/api/v1/dynamic-policies", nil)
+	w := httptest.NewRecorder()
+	handler(w, req)
+
+	if capturedTenantID != "community" {
+		t.Errorf("expected tenant_id 'community', got %q", capturedTenantID)
+	}
+	expectedOrg := getDeploymentOrgID()
+	if capturedOrgID != expectedOrg {
+		t.Errorf("expected org_id %q, got %q", expectedOrg, capturedOrgID)
+	}
+
+	// Test 2: Basic auth with custom clientId → uses that as tenant
+	capturedTenantID = ""
+	capturedOrgID = ""
+	req2 := httptest.NewRequest("GET", "/api/v1/dynamic-policies", nil)
+	creds := base64.StdEncoding.EncodeToString([]byte("my-tenant:"))
+	req2.Header.Set("Authorization", "Basic "+creds)
+	w2 := httptest.NewRecorder()
+	handler(w2, req2)
+
+	if capturedTenantID != "my-tenant" {
+		t.Errorf("expected tenant_id 'my-tenant', got %q", capturedTenantID)
+	}
+	if capturedOrgID != expectedOrg {
+		t.Errorf("expected org_id %q, got %q", expectedOrg, capturedOrgID)
+	}
+}
+
+// TestIdentityModel_CommunityMode_OverridesClientSuppliedHeaders verifies that
+// community mode does NOT trust client-supplied X-Tenant-ID headers.
+func TestIdentityModel_CommunityMode_OverridesClientSuppliedHeaders(t *testing.T) {
+	t.Setenv("DEPLOYMENT_MODE", "community")
+
+	var capturedTenantID string
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedTenantID = r.Header.Get("X-Tenant-ID")
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := proxyAuthMiddleware(inner)
+
+	req := httptest.NewRequest("GET", "/api/v1/dynamic-policies", nil)
+	req.Header.Set("X-Tenant-ID", "spoofed-tenant")
+	w := httptest.NewRecorder()
+	handler(w, req)
+
+	// Server-derived "community" should override client-supplied "spoofed-tenant"
+	if capturedTenantID != "community" {
+		t.Errorf("expected server-derived 'community', got client-supplied %q", capturedTenantID)
+	}
+}
+
+// TestIdentityModel_RegisterTenantAndOrg_CachesAfterFirstCall verifies that
+// auto-registration only hits DB once per tenant+org pair.
+func TestIdentityModel_RegisterTenantAndOrg_CachesAfterFirstCall(t *testing.T) {
+	// Reset the cache
+	registeredTenants = sync.Map{}
+
+	// Without a DB, registerTenantAndOrg should return immediately
+	registerTenantAndOrg(nil, "test-tenant", "test-org", "Community", 2)
+
+	// Verify cache was NOT populated (nil DB = early return)
+	if _, loaded := registeredTenants.Load("test-tenant|test-org"); loaded {
+		t.Error("cache should not be populated when DB is nil")
+	}
+}
+
+// TestIdentityModel_DB_RegisterTenantAndOrg verifies DB-backed auto-registration
+// when DATABASE_URL is available (integration test — skipped without DB).
+func TestIdentityModel_DB_RegisterTenantAndOrg(t *testing.T) {
+	dbURL := os.Getenv("DATABASE_URL")
+	if dbURL == "" {
+		t.Skip("DATABASE_URL not set — skipping DB integration test")
+	}
+
+	db, err := sql.Open("postgres", dbURL)
+	if err != nil {
+		t.Fatalf("failed to open DB: %v", err)
+	}
+	defer db.Close()
+
+	if err := db.Ping(); err != nil {
+		t.Skipf("DB not reachable: %v", err)
+	}
+
+	// Reset cache
+	registeredTenants = sync.Map{}
+
+	// First call should attempt DB write (may fail if tables don't exist — that's ok)
+	registerTenantAndOrg(db, "integration-tenant", "integration-org", "Community", 2)
+
+	// Second call should be cached (no DB hit)
+	registerTenantAndOrg(db, "integration-tenant", "integration-org", "Community", 2)
+
+	// Verify it was cached
+	if _, loaded := registeredTenants.Load("integration-tenant|integration-org"); !loaded {
+		t.Error("tenant+org pair should be cached after registration")
+	}
+}

--- a/platform/agent/mcp_server_handler_test.go
+++ b/platform/agent/mcp_server_handler_test.go
@@ -1661,3 +1661,119 @@ func TestTrimAuditSearchResponse(t *testing.T) {
 		t.Error("tenant_id should be preserved")
 	}
 }
+
+func TestMCPSearchAuditEvents_ResponseTrimming(t *testing.T) {
+	// Verify large fields are stripped and long queries truncated
+	resp := map[string]interface{}{
+		"entries": []interface{}{
+			map[string]interface{}{
+				"id":            "audit-1",
+				"request_body":  "large request body that should be removed",
+				"response_body": "large response body that should be removed",
+				"raw_request":   "raw request data",
+				"raw_response":  "raw response data",
+				"query":         string(make([]byte, 300)),
+				"tenant_id":     "community",
+			},
+			map[string]interface{}{
+				"id":         "audit-2",
+				"query":      "short query",
+				"tenant_id":  "community",
+				"raw_request": "should be removed",
+			},
+		},
+	}
+
+	if entries, ok := resp["entries"].([]interface{}); ok {
+		for i, entry := range entries {
+			if e, ok := entry.(map[string]interface{}); ok {
+				delete(e, "request_body")
+				delete(e, "response_body")
+				delete(e, "raw_request")
+				delete(e, "raw_response")
+				if q, ok := e["query"].(string); ok && len(q) > 200 {
+					e["query"] = q[:200] + "...(truncated)"
+				}
+				entries[i] = e
+			}
+		}
+	}
+
+	entries := resp["entries"].([]interface{})
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(entries))
+	}
+
+	e1 := entries[0].(map[string]interface{})
+	if _, ok := e1["request_body"]; ok {
+		t.Error("request_body should be removed")
+	}
+	if _, ok := e1["raw_response"]; ok {
+		t.Error("raw_response should be removed")
+	}
+	if q := e1["query"].(string); len(q) > 215 {
+		t.Errorf("query should be truncated, got %d chars", len(q))
+	}
+
+	e2 := entries[1].(map[string]interface{})
+	if e2["query"] != "short query" {
+		t.Error("short query should be preserved")
+	}
+	if _, ok := e2["raw_request"]; ok {
+		t.Error("raw_request should be removed from entry 2")
+	}
+}
+
+func TestMCPSearchAuditEvents_EmptyResponseTrimming(t *testing.T) {
+	// Edge case: empty entries, nil entries, non-map entries
+	testCases := []struct {
+		name string
+		resp map[string]interface{}
+	}{
+		{"nil entries", map[string]interface{}{"entries": nil}},
+		{"empty entries", map[string]interface{}{"entries": []interface{}{}}},
+		{"no entries key", map[string]interface{}{"total": 0}},
+		{"non-slice entries", map[string]interface{}{"entries": "not a slice"}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Should not panic
+			if entries, ok := tc.resp["entries"].([]interface{}); ok {
+				for i, entry := range entries {
+					if e, ok := entry.(map[string]interface{}); ok {
+						delete(e, "request_body")
+						if q, ok := e["query"].(string); ok && len(q) > 200 {
+							e["query"] = q[:200] + "...(truncated)"
+						}
+						entries[i] = e
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestGetDeploymentOrgID_Default(t *testing.T) {
+	// When ORG_ID is not set, should return "local-dev-org"
+	original := os.Getenv("ORG_ID")
+	os.Unsetenv("ORG_ID")
+	defer func() {
+		if original != "" {
+			os.Setenv("ORG_ID", original)
+		}
+	}()
+
+	result := getDeploymentOrgID()
+	if result != "local-dev-org" {
+		t.Errorf("expected 'local-dev-org', got %q", result)
+	}
+}
+
+func TestGetDeploymentOrgID_Custom(t *testing.T) {
+	t.Setenv("ORG_ID", "my-custom-org")
+	result := getDeploymentOrgID()
+	if result != "my-custom-org" {
+		t.Errorf("expected 'my-custom-org', got %q", result)
+	}
+}


### PR DESCRIPTION
## Community Sync

### Added
- Identity model integration tests (community mode header injection, client-supplied header override, tenant/org registration cache, DB-backed registration)
- `getDeploymentOrgID` unit tests (default and custom values)
- Audit response trimming edge case tests (nil, empty, non-slice entries)

### Fixed
- Setup script always rebuilds Docker images with `--no-cache` to prevent stale binaries when switching branches

### Enterprise PRs included
- #1510 (community contributions + coverage tests)
- #1507 (setup script rebuild fix)