### PR TITLE
chore: bump Go SDK to v5.3.1 in examples

### DIFF
--- a/examples/audit-logging/go/go.mod
+++ b/examples/audit-logging/go/go.mod
@@ -3,6 +3,6 @@ module github.com/getaxonflow/axonflow/examples/audit-logging/go
 go 1.21
 
 require (
-	github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.0
+	github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.1
 	github.com/sashabaranov/go-openai v1.17.9
 )

--- a/examples/code-governance/go/go.mod
+++ b/examples/code-governance/go/go.mod
@@ -2,4 +2,4 @@ module github.com/axonflow/examples/code-governance
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.1

--- a/examples/cost-controls/enforcement/go/go.mod
+++ b/examples/cost-controls/enforcement/go/go.mod
@@ -2,4 +2,4 @@ module cost-controls-enforcement
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.1

--- a/examples/cost-controls/go/go.mod
+++ b/examples/cost-controls/go/go.mod
@@ -2,4 +2,4 @@ module github.com/getaxonflow/axonflow/examples/cost-controls/go
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.1

--- a/examples/cost-estimation/go/go.mod
+++ b/examples/cost-estimation/go/go.mod
@@ -2,4 +2,4 @@ module cost-estimation
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.1

--- a/examples/dynamic-policies/compliance/go/go.mod
+++ b/examples/dynamic-policies/compliance/go/go.mod
@@ -2,6 +2,4 @@ module compliance-example
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.0
-
-
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.1

--- a/examples/dynamic-policies/go/go.mod
+++ b/examples/dynamic-policies/go/go.mod
@@ -2,6 +2,4 @@ module github.com/getaxonflow/axonflow/examples/dynamic-policies/go
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.0
-
-
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.1

--- a/examples/evaluation-tier/go/go.mod
+++ b/examples/evaluation-tier/go/go.mod
@@ -2,4 +2,4 @@ module github.com/getaxonflow/axonflow/examples/evaluation-tier/go
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.1

--- a/examples/execution-replay/go/go.mod
+++ b/examples/execution-replay/go/go.mod
@@ -2,6 +2,4 @@ module github.com/getaxonflow/axonflow/examples/execution-replay/go
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.0
-
-
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.1

--- a/examples/execution-tracking/go/go.mod
+++ b/examples/execution-tracking/go/go.mod
@@ -2,4 +2,4 @@ module github.com/getaxonflow/axonflow-enterprise/examples/execution-tracking
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.1

--- a/examples/gateway-policy-config/go/go.mod
+++ b/examples/gateway-policy-config/go/go.mod
@@ -2,4 +2,4 @@ module examples/gateway-policy-config/go
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.1

--- a/examples/health-check/go/go.mod
+++ b/examples/health-check/go/go.mod
@@ -2,4 +2,4 @@ module health-check
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.1

--- a/examples/hello-world/go/go.mod
+++ b/examples/hello-world/go/go.mod
@@ -2,4 +2,4 @@ module github.com/axonflow/examples/hello-world
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.1

--- a/examples/hitl-queue/go/go.mod
+++ b/examples/hitl-queue/go/go.mod
@@ -2,4 +2,4 @@ module github.com/axonflow/examples/hitl-queue
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.1

--- a/examples/hitl/go/go.mod
+++ b/examples/hitl/go/go.mod
@@ -2,6 +2,4 @@ module axonflow-hitl-example
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.0
-
-
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.1

--- a/examples/integrations/dspy/go/go.mod
+++ b/examples/integrations/dspy/go/go.mod
@@ -2,6 +2,4 @@ module dspy-axonflow-example
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.0
-
-
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.1

--- a/examples/integrations/gateway-mode/go/go.mod
+++ b/examples/integrations/gateway-mode/go/go.mod
@@ -3,6 +3,6 @@ module github.com/getaxonflow/axonflow/examples/integrations/gateway-mode/go
 go 1.21
 
 require (
-	github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.0
+	github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.1
 	github.com/sashabaranov/go-openai v1.17.9
 )

--- a/examples/integrations/governed-tools/go/go.mod
+++ b/examples/integrations/governed-tools/go/go.mod
@@ -2,4 +2,4 @@ module github.com/axonflow/examples/governed-tools
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.1

--- a/examples/integrations/langgraph/go/go.mod
+++ b/examples/integrations/langgraph/go/go.mod
@@ -2,6 +2,4 @@ module langgraph-axonflow-example
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.0
-
-
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.1

--- a/examples/integrations/proxy-mode/go/go.mod
+++ b/examples/integrations/proxy-mode/go/go.mod
@@ -2,4 +2,4 @@ module github.com/getaxonflow/axonflow/examples/integrations/proxy-mode/go
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.1

--- a/examples/interceptors/go/go.mod
+++ b/examples/interceptors/go/go.mod
@@ -2,4 +2,4 @@ module github.com/getaxonflow/axonflow/examples/interceptors/go
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.1

--- a/examples/llm-providers/azure-openai/proxy-mode/go/go.mod
+++ b/examples/llm-providers/azure-openai/proxy-mode/go/go.mod
@@ -2,4 +2,4 @@ module github.com/getaxonflow/axonflow/examples/llm-providers/azure-openai/proxy
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.1

--- a/examples/llm-providers/mistral/hello-world/go/go.mod
+++ b/examples/llm-providers/mistral/hello-world/go/go.mod
@@ -2,4 +2,4 @@ module mistral-hello-world
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.1

--- a/examples/llm-routing/e2e-tests/go/go.mod
+++ b/examples/llm-routing/e2e-tests/go/go.mod
@@ -2,6 +2,4 @@ module llm-provider-tests
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.0
-
-
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.1

--- a/examples/llm-routing/go/go.mod
+++ b/examples/llm-routing/go/go.mod
@@ -2,6 +2,4 @@ module github.com/getaxonflow/axonflow/examples/llm-routing/go
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.0
-
-
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.1

--- a/examples/map-confirm-mode/go/go.mod
+++ b/examples/map-confirm-mode/go/go.mod
@@ -2,4 +2,4 @@ module github.com/getaxonflow/axonflow/examples/map-confirm-mode/go
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.1

--- a/examples/map-lifecycle/go/go.mod
+++ b/examples/map-lifecycle/go/go.mod
@@ -2,4 +2,4 @@ module github.com/getaxonflow/axonflow/examples/map-lifecycle/go
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.1

--- a/examples/map/go/go.mod
+++ b/examples/map/go/go.mod
@@ -2,4 +2,4 @@ module github.com/getaxonflow/axonflow/examples/map/go
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.1

--- a/examples/mcp-audit/go/go.mod
+++ b/examples/mcp-audit/go/go.mod
@@ -2,4 +2,4 @@ module mcp-audit-example
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.1

--- a/examples/mcp-connectors/cloud-storage/go/go.mod
+++ b/examples/mcp-connectors/cloud-storage/go/go.mod
@@ -2,4 +2,4 @@ module github.com/getaxonflow/axonflow/examples/mcp-connectors/cloud-storage/go
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.1

--- a/examples/mcp-connectors/http/go/go.mod
+++ b/examples/mcp-connectors/http/go/go.mod
@@ -2,4 +2,4 @@ module github.com/getaxonflow/axonflow-enterprise/examples/mcp-connectors/http/g
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.1

--- a/examples/mcp-connectors/http/go/go.sum
+++ b/examples/mcp-connectors/http/go/go.sum
@@ -1,0 +1,2 @@
+github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.1 h1:G1HL1e1jcrSDhFS9vPiQeLModRsicBq/WrXVyWpZQVk=
+github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.1/go.mod h1:V3UDfEkKe48HHW8L1GNv39plObmSn3P0NgXNsNQ83SY=

--- a/examples/mcp-policies/check-endpoints/go/go.mod
+++ b/examples/mcp-policies/check-endpoints/go/go.mod
@@ -2,4 +2,4 @@ module mcp-check-endpoints-example
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.1

--- a/examples/mcp-policies/go/go.mod
+++ b/examples/mcp-policies/go/go.mod
@@ -2,4 +2,4 @@ module mcp-policies-example
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.1

--- a/examples/mcp-policies/pii-redaction/go/go.mod
+++ b/examples/mcp-policies/pii-redaction/go/go.mod
@@ -2,6 +2,4 @@ module mcp-pii-redaction-example
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.0
-
-
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.1

--- a/examples/media-governance-policies/go/go.mod
+++ b/examples/media-governance-policies/go/go.mod
@@ -2,4 +2,4 @@ module github.com/axonflow/examples/media-governance-policies
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.1

--- a/examples/media-governance/go/go.mod
+++ b/examples/media-governance/go/go.mod
@@ -2,4 +2,4 @@ module github.com/axonflow/examples/media-governance
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.1

--- a/examples/pii-detection/go/go.mod
+++ b/examples/pii-detection/go/go.mod
@@ -2,4 +2,4 @@ module github.com/getaxonflow/axonflow/examples/pii-detection/go
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.1

--- a/examples/policies/go/create-custom-policy/go.mod
+++ b/examples/policies/go/create-custom-policy/go.mod
@@ -2,4 +2,4 @@ module github.com/getaxonflow/axonflow-enterprise/examples/policies/go
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.1

--- a/examples/policies/go/list-and-filter/go.mod
+++ b/examples/policies/go/list-and-filter/go.mod
@@ -2,6 +2,4 @@ module github.com/getaxonflow/axonflow-enterprise/examples/policies/go
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.0
-
-
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.1

--- a/examples/policies/go/test-pattern/go.mod
+++ b/examples/policies/go/test-pattern/go.mod
@@ -2,6 +2,4 @@ module github.com/getaxonflow/axonflow-enterprise/examples/policies/go
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.0
-
-
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.1

--- a/examples/policy-configuration/go/go.mod
+++ b/examples/policy-configuration/go/go.mod
@@ -2,4 +2,4 @@ module examples/policy-configuration/go
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.1

--- a/examples/sdk-audit/go/go.mod
+++ b/examples/sdk-audit/go/go.mod
@@ -2,6 +2,4 @@ module github.com/axonflow/examples/sdk-audit
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.0
-
-
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.1

--- a/examples/singapore-pii/go/go.mod
+++ b/examples/singapore-pii/go/go.mod
@@ -2,6 +2,4 @@ module singapore-pii-example
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.0
-
-
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.1

--- a/examples/sqli-detection/go/go.mod
+++ b/examples/sqli-detection/go/go.mod
@@ -2,4 +2,4 @@ module github.com/getaxonflow/axonflow/examples/sqli-detection/go
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.1

--- a/examples/static-policies/go/go.mod
+++ b/examples/static-policies/go/go.mod
@@ -2,6 +2,4 @@ module static-policies-example
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.0
-
-
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.1

--- a/examples/support-demo/backend/go.mod
+++ b/examples/support-demo/backend/go.mod
@@ -3,11 +3,9 @@ module axonflow-support-demo
 go 1.21
 
 require (
-	github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.0
+	github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.1
 	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/gorilla/mux v1.8.1
 	github.com/lib/pq v1.10.9
 	github.com/rs/cors v1.11.1
 )
-
-

--- a/examples/version-check/go/go.mod
+++ b/examples/version-check/go/go.mod
@@ -2,4 +2,4 @@ module version-check-example
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.1

--- a/examples/webhooks/go/go.mod
+++ b/examples/webhooks/go/go.mod
@@ -2,4 +2,4 @@ module webhooks
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.1

--- a/examples/workflow-control/go/go.mod
+++ b/examples/workflow-control/go/go.mod
@@ -2,4 +2,4 @@ module workflow-control
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.1

--- a/examples/workflow-fail/go/go.mod
+++ b/examples/workflow-fail/go/go.mod
@@ -2,4 +2,4 @@ module workflow-fail
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.1

--- a/examples/workflow-policy/go/go.mod
+++ b/examples/workflow-policy/go/go.mod
@@ -2,6 +2,4 @@ module workflow-policy-example
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.0
-
-
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.1

--- a/examples/workflows/01-simple-sequential/go.mod
+++ b/examples/workflows/01-simple-sequential/go.mod
@@ -2,6 +2,4 @@ module github.com/getaxonflow/axonflow/examples/workflows/01-simple-sequential
 
 go 1.23
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.0
-
-
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.1

--- a/examples/workflows/02-parallel-execution/go.mod
+++ b/examples/workflows/02-parallel-execution/go.mod
@@ -2,6 +2,4 @@ module github.com/getaxonflow/axonflow/examples/workflows/02-parallel-execution
 
 go 1.23
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.0
-
-
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.1

--- a/examples/workflows/03-conditional-logic/go.mod
+++ b/examples/workflows/03-conditional-logic/go.mod
@@ -2,6 +2,4 @@ module github.com/getaxonflow/axonflow/examples/workflows/03-conditional-logic
 
 go 1.23
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.0
-
-
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.1

--- a/examples/workflows/04-travel-booking-fallbacks/go.mod
+++ b/examples/workflows/04-travel-booking-fallbacks/go.mod
@@ -2,6 +2,4 @@ module github.com/getaxonflow/axonflow/examples/workflows/04-travel-booking-fall
 
 go 1.23
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.0
-
-
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.1

--- a/examples/workflows/05-data-pipeline/go.mod
+++ b/examples/workflows/05-data-pipeline/go.mod
@@ -2,6 +2,4 @@ module github.com/getaxonflow/axonflow/examples/workflows/05-data-pipeline
 
 go 1.23
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.0
-
-
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.1

--- a/examples/workflows/06-multi-step-approval/go.mod
+++ b/examples/workflows/06-multi-step-approval/go.mod
@@ -2,6 +2,4 @@ module github.com/getaxonflow/axonflow/examples/workflows/06-multi-step-approval
 
 go 1.23
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.0
-
-
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.1


### PR DESCRIPTION
## Summary

Bumps Go SDK from v5.3.0 → v5.3.1 across all community Go examples.

[v5.3.1](https://github.com/getaxonflow/axonflow-sdk-go/releases/tag/v5.3.1) fixes missing auth headers on:
- `ListConnectors`, `GetConnector`, `GetConnectorHealth`
- `GetPlanStatus`
- All execution replay methods (`ListExecutions`, `GetExecution`, `GetExecutionSteps`, `GetExecutionTimeline`, `ExportExecution`, `DeleteExecution`)

Previously those methods returned 401 against authenticated servers like try.getaxonflow.com.

### Review Checklist
- [ ] No enterprise-only content included
- [ ] CI checks pass