### PR TITLE
chore: bump SDK and plugin versions in examples

### DIFF
--- a/docs/tutorials/01-first-agent-10-minutes.md
+++ b/docs/tutorials/01-first-agent-10-minutes.md
@@ -51,7 +51,7 @@ go get github.com/getaxonflow/axonflow-sdk-go/v5
 
 ```bash
 mkdir my-first-agent && cd my-first-agent
-pip3 install axonflow==5.3.0
+pip3 install axonflow==6.4.0
 ```
 
 ### TypeScript

--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -33,7 +33,7 @@ SDK versions: Python v6.1.0, Go/TypeScript/Java v5.1.0.
 go get github.com/getaxonflow/axonflow-sdk-go/v5
 
 # Python
-pip3 install axonflow==5.3.0
+pip3 install axonflow==6.4.0
 
 # Java (Maven)
 # Add to pom.xml:

--- a/examples/audit-logging/java/pom.xml
+++ b/examples/audit-logging/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.3.0</version>
+            <version>5.4.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/audit-logging/python/requirements.txt
+++ b/examples/audit-logging/python/requirements.txt
@@ -1,3 +1,3 @@
-axonflow>=6.3.0
+axonflow>=6.4.0
 python-dotenv>=1.0.0
 openai>=1.0.0

--- a/examples/audit-logging/typescript/package.json
+++ b/examples/audit-logging/typescript/package.json
@@ -7,7 +7,7 @@
     "start": "ts-node index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.3.0",
+    "@axonflow/sdk": "^5.4.0",
     "dotenv": "^16.6.1",
     "openai": "^4.104.0"
   },

--- a/examples/code-governance/java/pom.xml
+++ b/examples/code-governance/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.3.0</version>
+            <version>5.4.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/code-governance/python/requirements.txt
+++ b/examples/code-governance/python/requirements.txt
@@ -1,2 +1,2 @@
-axonflow>=6.3.0
+axonflow>=6.4.0
 python-dotenv>=1.0.0

--- a/examples/code-governance/typescript/package.json
+++ b/examples/code-governance/typescript/package.json
@@ -9,7 +9,7 @@
     "start:built": "node dist/index.js"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.3.0",
+    "@axonflow/sdk": "^5.4.0",
     "dotenv": "^16.3.1"
   },
   "devDependencies": {

--- a/examples/cost-controls/enforcement/java/pom.xml
+++ b/examples/cost-controls/enforcement/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.3.0</version>
+            <version>5.4.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/cost-controls/enforcement/python/requirements.txt
+++ b/examples/cost-controls/enforcement/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=6.3.0
+axonflow>=6.4.0

--- a/examples/cost-controls/enforcement/typescript/package.json
+++ b/examples/cost-controls/enforcement/typescript/package.json
@@ -9,7 +9,7 @@
     "test": "npm run start"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.3.0"
+    "@axonflow/sdk": "^5.4.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/examples/cost-controls/java/pom.xml
+++ b/examples/cost-controls/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.3.0</version>
+            <version>5.4.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/cost-controls/python/requirements.txt
+++ b/examples/cost-controls/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=6.3.0
+axonflow>=6.4.0

--- a/examples/cost-controls/typescript/package.json
+++ b/examples/cost-controls/typescript/package.json
@@ -8,7 +8,7 @@
     "start": "npx tsx src/index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.3.0"
+    "@axonflow/sdk": "^5.4.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/examples/cost-estimation/java/pom.xml
+++ b/examples/cost-estimation/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.3.0</version>
+            <version>5.4.0</version>
         </dependency>
         <!-- Override transitive jackson for GHSA-72hv-8253-57qq -->
         <dependency>

--- a/examples/cost-estimation/python/requirements.txt
+++ b/examples/cost-estimation/python/requirements.txt
@@ -1,3 +1,3 @@
-axonflow>=6.3.0
+axonflow>=6.4.0
 python-dotenv>=1.0.0
 requests>=2.31.0

--- a/examples/cost-estimation/typescript/package.json
+++ b/examples/cost-estimation/typescript/package.json
@@ -8,7 +8,7 @@
     "start": "npx tsx index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.3.0",
+    "@axonflow/sdk": "^5.4.0",
     "dotenv": "^16.3.1"
   },
   "devDependencies": {

--- a/examples/demo/requirements.txt
+++ b/examples/demo/requirements.txt
@@ -1,5 +1,5 @@
 # Core SDK
-axonflow>=6.3.0
+axonflow>=6.4.0
 
 # HTTP client
 httpx>=0.24.0

--- a/examples/dynamic-policies/compliance/java/pom.xml
+++ b/examples/dynamic-policies/compliance/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.3.0</version>
+            <version>5.4.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/dynamic-policies/compliance/typescript/package.json
+++ b/examples/dynamic-policies/compliance/typescript/package.json
@@ -6,7 +6,7 @@
     "start": "npx ts-node --esm index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.3.0"
+    "@axonflow/sdk": "^5.4.0"
   },
   "devDependencies": {
     "ts-node": "^10.9.2",

--- a/examples/dynamic-policies/java/pom.xml
+++ b/examples/dynamic-policies/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.3.0</version>
+            <version>5.4.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/dynamic-policies/typescript/package.json
+++ b/examples/dynamic-policies/typescript/package.json
@@ -6,6 +6,6 @@
     "start": "npx tsx index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.3.0"
+    "@axonflow/sdk": "^5.4.0"
   }
 }

--- a/examples/evaluation-tier/java/pom.xml
+++ b/examples/evaluation-tier/java/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <axonflow.version>5.3.0</axonflow.version>
+        <axonflow.version>5.4.0</axonflow.version>
     </properties>
 
     <dependencyManagement>

--- a/examples/evaluation-tier/python/requirements.txt
+++ b/examples/evaluation-tier/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=6.3.0
+axonflow>=6.4.0

--- a/examples/evaluation-tier/typescript/package.json
+++ b/examples/evaluation-tier/typescript/package.json
@@ -7,7 +7,7 @@
     "test": "npx ts-node test_tier_limits.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.3.0"
+    "@axonflow/sdk": "^5.4.0"
   },
   "devDependencies": {
     "ts-node": "^10.9.2",

--- a/examples/execution-replay/java/pom.xml
+++ b/examples/execution-replay/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.3.0</version>
+            <version>5.4.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/execution-replay/python/requirements.txt
+++ b/examples/execution-replay/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=6.3.0
+axonflow>=6.4.0

--- a/examples/execution-replay/typescript/package.json
+++ b/examples/execution-replay/typescript/package.json
@@ -9,7 +9,7 @@
     "dev": "ts-node src/index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.3.0"
+    "@axonflow/sdk": "^5.4.0"
   },
   "devDependencies": {
     "@types/node": "^20.10.0",

--- a/examples/execution-tracking/java/pom.xml
+++ b/examples/execution-tracking/java/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <axonflow.sdk.version>5.3.0</axonflow.sdk.version>
+        <axonflow.sdk.version>5.4.0</axonflow.sdk.version>
     </properties>
 
     <dependencyManagement>

--- a/examples/execution-tracking/python/requirements.txt
+++ b/examples/execution-tracking/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=6.3.0
+axonflow>=6.4.0

--- a/examples/execution-tracking/typescript/package.json
+++ b/examples/execution-tracking/typescript/package.json
@@ -8,7 +8,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.3.0"
+    "@axonflow/sdk": "^5.4.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/examples/gateway-policy-config/java/pom.xml
+++ b/examples/gateway-policy-config/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.3.0</version>
+            <version>5.4.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/gateway-policy-config/python/requirements.txt
+++ b/examples/gateway-policy-config/python/requirements.txt
@@ -1,2 +1,2 @@
-axonflow>=6.3.0
+axonflow>=6.4.0
 python-dotenv>=1.0.0

--- a/examples/gateway-policy-config/typescript/package.json
+++ b/examples/gateway-policy-config/typescript/package.json
@@ -7,7 +7,7 @@
     "start": "ts-node index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.3.0",
+    "@axonflow/sdk": "^5.4.0",
     "dotenv": "^16.3.1"
   },
   "devDependencies": {

--- a/examples/health-check/java/pom.xml
+++ b/examples/health-check/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.3.0</version>
+            <version>5.4.0</version>
         </dependency>
         <!-- Override transitive jackson for GHSA-72hv-8253-57qq -->
         <dependency>

--- a/examples/health-check/python/requirements.txt
+++ b/examples/health-check/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=6.3.0
+axonflow>=6.4.0

--- a/examples/health-check/typescript/package.json
+++ b/examples/health-check/typescript/package.json
@@ -6,6 +6,6 @@
     "start": "npx tsx index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.3.0"
+    "@axonflow/sdk": "^5.4.0"
   }
 }

--- a/examples/hello-world/java/pom.xml
+++ b/examples/hello-world/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.3.0</version>
+            <version>5.4.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/hello-world/python/requirements.txt
+++ b/examples/hello-world/python/requirements.txt
@@ -1,5 +1,5 @@
 # AxonFlow SDK
-axonflow>=6.3.0
+axonflow>=6.4.0
 
 # Environment management
 python-dotenv>=1.0.0

--- a/examples/hello-world/typescript/package.json
+++ b/examples/hello-world/typescript/package.json
@@ -13,7 +13,7 @@
   "author": "AxonFlow",
   "license": "MIT",
   "dependencies": {
-    "@axonflow/sdk": "^5.3.0",
+    "@axonflow/sdk": "^5.4.0",
     "dotenv": "^16.3.0",
     "openai": "^4.0.0"
   },

--- a/examples/hitl-queue/java/pom.xml
+++ b/examples/hitl-queue/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.3.0</version>
+            <version>5.4.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/hitl-queue/python/requirements.txt
+++ b/examples/hitl-queue/python/requirements.txt
@@ -1,2 +1,2 @@
-axonflow>=6.3.0
+axonflow>=6.4.0
 python-dotenv>=1.0.0

--- a/examples/hitl-queue/typescript/package.json
+++ b/examples/hitl-queue/typescript/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.3.0",
+    "@axonflow/sdk": "^5.4.0",
     "dotenv": "^16.3.1"
   },
   "devDependencies": {

--- a/examples/hitl/java/pom.xml
+++ b/examples/hitl/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.3.0</version>
+            <version>5.4.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/hitl/python/requirements.txt
+++ b/examples/hitl/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=6.3.0
+axonflow>=6.4.0

--- a/examples/hitl/typescript/package.json
+++ b/examples/hitl/typescript/package.json
@@ -7,7 +7,7 @@
     "example": "npx ts-node --esm require-approval-policy.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.3.0"
+    "@axonflow/sdk": "^5.4.0"
   },
   "devDependencies": {
     "ts-node": "^10.9.2",

--- a/examples/integrations/autogen/java/pom.xml
+++ b/examples/integrations/autogen/java/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.3.0</version>
+            <version>5.4.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/integrations/autogen/requirements.txt
+++ b/examples/integrations/autogen/requirements.txt
@@ -1,3 +1,3 @@
 pyautogen>=0.2.0
-axonflow>=6.3.0
+axonflow>=6.4.0
 python-dotenv>=1.0.0

--- a/examples/integrations/computer-use/python/requirements.txt
+++ b/examples/integrations/computer-use/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=6.3.0
+axonflow>=6.4.0

--- a/examples/integrations/crewai/requirements.txt
+++ b/examples/integrations/crewai/requirements.txt
@@ -1,5 +1,5 @@
 # AxonFlow SDK
-axonflow>=6.3.0
+axonflow>=6.4.0
 
 # CrewAI
 crewai>=0.5.0

--- a/examples/integrations/dspy/python/requirements.txt
+++ b/examples/integrations/dspy/python/requirements.txt
@@ -1,2 +1,2 @@
-axonflow>=6.3.0
+axonflow>=6.4.0
 python-dotenv>=1.0.0

--- a/examples/integrations/gateway-mode/java/pom.xml
+++ b/examples/integrations/gateway-mode/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.3.0</version>
+            <version>5.4.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/integrations/gateway-mode/python/requirements.txt
+++ b/examples/integrations/gateway-mode/python/requirements.txt
@@ -1,5 +1,5 @@
 # AxonFlow SDK
-axonflow>=6.3.0
+axonflow>=6.4.0
 
 # LLM Providers
 openai>=1.6.0

--- a/examples/integrations/gateway-mode/typescript/package.json
+++ b/examples/integrations/gateway-mode/typescript/package.json
@@ -14,7 +14,7 @@
   "author": "AxonFlow",
   "license": "MIT",
   "dependencies": {
-    "@axonflow/sdk": "^5.3.0",
+    "@axonflow/sdk": "^5.4.0",
     "dotenv": "^16.3.0",
     "openai": "^4.20.0",
     "@anthropic-ai/sdk": "^0.32.0"

--- a/examples/integrations/governed-tools/java/pom.xml
+++ b/examples/integrations/governed-tools/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.3.0</version>
+            <version>5.4.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/integrations/governed-tools/python/requirements.txt
+++ b/examples/integrations/governed-tools/python/requirements.txt
@@ -1,2 +1,2 @@
-axonflow>=6.3.0
+axonflow>=6.4.0
 langchain-core>=0.3.0

--- a/examples/integrations/governed-tools/typescript/package.json
+++ b/examples/integrations/governed-tools/typescript/package.json
@@ -13,7 +13,7 @@
   "author": "AxonFlow",
   "license": "MIT",
   "dependencies": {
-    "@axonflow/sdk": "^5.3.0"
+    "@axonflow/sdk": "^5.4.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/examples/integrations/langchain/requirements.txt
+++ b/examples/integrations/langchain/requirements.txt
@@ -1,5 +1,5 @@
 # AxonFlow SDK
-axonflow>=6.3.0
+axonflow>=6.4.0
 
 # LangChain
 langchain>=0.1.0

--- a/examples/integrations/langgraph/python/requirements.txt
+++ b/examples/integrations/langgraph/python/requirements.txt
@@ -1,2 +1,2 @@
-axonflow>=6.3.0
+axonflow>=6.4.0
 python-dotenv>=1.0.0

--- a/examples/integrations/langgraph/typescript/package.json
+++ b/examples/integrations/langgraph/typescript/package.json
@@ -9,7 +9,7 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.3.0"
+    "@axonflow/sdk": "^5.4.0"
   },
   "devDependencies": {
     "@types/node": "^20.10.0",

--- a/examples/integrations/proxy-mode/java/pom.xml
+++ b/examples/integrations/proxy-mode/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.3.0</version>
+            <version>5.4.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/integrations/proxy-mode/python/requirements.txt
+++ b/examples/integrations/proxy-mode/python/requirements.txt
@@ -1,5 +1,5 @@
 # AxonFlow SDK
-axonflow>=6.3.0
+axonflow>=6.4.0
 
 # Environment management
 python-dotenv>=1.0.0

--- a/examples/integrations/proxy-mode/typescript/package.json
+++ b/examples/integrations/proxy-mode/typescript/package.json
@@ -10,7 +10,7 @@
     "dev": "ts-node src/index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.3.0",
+    "@axonflow/sdk": "^5.4.0",
     "dotenv": "^16.6.1"
   },
   "devDependencies": {

--- a/examples/integrations/semantic-kernel/java/pom.xml
+++ b/examples/integrations/semantic-kernel/java/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.3.0</version>
+            <version>5.4.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/integrations/semantic-kernel/typescript/package.json
+++ b/examples/integrations/semantic-kernel/typescript/package.json
@@ -9,7 +9,7 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.3.0"
+    "@axonflow/sdk": "^5.4.0"
   },
   "devDependencies": {
     "@types/node": "^20.10.0",

--- a/examples/integrations/spring-boot/pom.xml
+++ b/examples/integrations/spring-boot/pom.xml
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.3.0</version>
+            <version>5.4.0</version>
         </dependency>
 
         <!-- OpenAI for Gateway Mode demo -->

--- a/examples/interceptors/java/pom.xml
+++ b/examples/interceptors/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.3.0</version>
+            <version>5.4.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/interceptors/python/requirements.txt
+++ b/examples/interceptors/python/requirements.txt
@@ -1,2 +1,2 @@
-axonflow>=6.3.0
+axonflow>=6.4.0
 openai>=1.0.0

--- a/examples/interceptors/typescript/package.json
+++ b/examples/interceptors/typescript/package.json
@@ -7,7 +7,7 @@
     "start": "ts-node src/index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.3.0",
+    "@axonflow/sdk": "^5.4.0",
     "dotenv": "^16.3.1",
     "openai": "^4.20.0"
   },

--- a/examples/llm-providers/azure-openai/pii-detection/python/requirements.txt
+++ b/examples/llm-providers/azure-openai/pii-detection/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=6.3.0
+axonflow>=6.4.0

--- a/examples/llm-providers/azure-openai/sqli-scanning/typescript/package.json
+++ b/examples/llm-providers/azure-openai/sqli-scanning/typescript/package.json
@@ -8,7 +8,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.3.0"
+    "@axonflow/sdk": "^5.4.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/examples/llm-providers/mistral/hello-world/java/pom.xml
+++ b/examples/llm-providers/mistral/hello-world/java/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.3.0</version>
+            <version>5.4.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>

--- a/examples/llm-providers/mistral/hello-world/python/requirements.txt
+++ b/examples/llm-providers/mistral/hello-world/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=6.3.0
+axonflow>=6.4.0

--- a/examples/llm-providers/mistral/hello-world/typescript/package.json
+++ b/examples/llm-providers/mistral/hello-world/typescript/package.json
@@ -7,7 +7,7 @@
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.3.0"
+    "@axonflow/sdk": "^5.4.0"
   },
   "devDependencies": {
     "tsx": "^4.7.0",

--- a/examples/llm-routing/e2e-tests/java/pom.xml
+++ b/examples/llm-routing/e2e-tests/java/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.3.0</version>
+            <version>5.4.0</version>
         </dependency>
         <!-- Override transitive jackson for GHSA-72hv-8253-57qq -->
         <dependency>

--- a/examples/llm-routing/e2e-tests/python/requirements.txt
+++ b/examples/llm-routing/e2e-tests/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=6.3.0
+axonflow>=6.4.0

--- a/examples/llm-routing/e2e-tests/typescript/package.json
+++ b/examples/llm-routing/e2e-tests/typescript/package.json
@@ -7,7 +7,7 @@
     "test": "ts-node main.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.3.0"
+    "@axonflow/sdk": "^5.4.0"
   },
   "devDependencies": {
     "ts-node": "^10.9.0",

--- a/examples/llm-routing/java/pom.xml
+++ b/examples/llm-routing/java/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.3.0</version>
+            <version>5.4.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/llm-routing/python/requirements.txt
+++ b/examples/llm-routing/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=6.3.0
+axonflow>=6.4.0

--- a/examples/llm-routing/typescript/package.json
+++ b/examples/llm-routing/typescript/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx provider-routing.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.3.0"
+    "@axonflow/sdk": "^5.4.0"
   },
   "devDependencies": {
     "typescript": "^5.3.0",

--- a/examples/map-confirm-mode/java/pom.xml
+++ b/examples/map-confirm-mode/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.3.0</version>
+            <version>5.4.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/map-confirm-mode/python/requirements.txt
+++ b/examples/map-confirm-mode/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=6.3.0
+axonflow>=6.4.0

--- a/examples/map-confirm-mode/typescript/package.json
+++ b/examples/map-confirm-mode/typescript/package.json
@@ -9,7 +9,7 @@
     "start": "npx tsx src/index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.3.0"
+    "@axonflow/sdk": "^5.4.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/examples/map-lifecycle/java/pom.xml
+++ b/examples/map-lifecycle/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.3.0</version>
+            <version>5.4.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/map-lifecycle/python/requirements.txt
+++ b/examples/map-lifecycle/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=6.3.0
+axonflow>=6.4.0

--- a/examples/map-lifecycle/typescript/package.json
+++ b/examples/map-lifecycle/typescript/package.json
@@ -9,7 +9,7 @@
     "start": "npx tsx src/index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.3.0"
+    "@axonflow/sdk": "^5.4.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/examples/map/java/pom.xml
+++ b/examples/map/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.3.0</version>
+            <version>5.4.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/map/python/requirements.txt
+++ b/examples/map/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=6.3.0
+axonflow>=6.4.0

--- a/examples/map/typescript/package.json
+++ b/examples/map/typescript/package.json
@@ -9,7 +9,7 @@
     "start": "npx tsx src/index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.3.0"
+    "@axonflow/sdk": "^5.4.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/examples/mcp-audit/java/pom.xml
+++ b/examples/mcp-audit/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.3.0</version>
+            <version>5.4.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/mcp-audit/python/requirements.txt
+++ b/examples/mcp-audit/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=6.3.0
+axonflow>=6.4.0

--- a/examples/mcp-audit/typescript/package.json
+++ b/examples/mcp-audit/typescript/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.3.0"
+    "@axonflow/sdk": "^5.4.0"
   },
   "devDependencies": {
     "tsx": "^4.7.0",

--- a/examples/mcp-connectors/cloud-storage/java/pom.xml
+++ b/examples/mcp-connectors/cloud-storage/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.3.0</version>
+            <version>5.4.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/mcp-connectors/cloud-storage/python/requirements.txt
+++ b/examples/mcp-connectors/cloud-storage/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=6.3.0
+axonflow>=6.4.0

--- a/examples/mcp-connectors/cloud-storage/typescript/package.json
+++ b/examples/mcp-connectors/cloud-storage/typescript/package.json
@@ -7,7 +7,7 @@
     "start": "ts-node src/index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.3.0"
+    "@axonflow/sdk": "^5.4.0"
   },
   "devDependencies": {
     "ts-node": "^10.9.2",

--- a/examples/mcp-connectors/java/pom.xml
+++ b/examples/mcp-connectors/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.3.0</version>
+            <version>5.4.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/mcp-connectors/python/requirements.txt
+++ b/examples/mcp-connectors/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=6.3.0
+axonflow>=6.4.0

--- a/examples/mcp-policies/check-endpoints/java/pom.xml
+++ b/examples/mcp-policies/check-endpoints/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.3.0</version>
+            <version>5.4.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/mcp-policies/check-endpoints/python/requirements.txt
+++ b/examples/mcp-policies/check-endpoints/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=6.3.0
+axonflow>=6.4.0

--- a/examples/mcp-policies/check-endpoints/typescript/package.json
+++ b/examples/mcp-policies/check-endpoints/typescript/package.json
@@ -7,7 +7,7 @@
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.3.0"
+    "@axonflow/sdk": "^5.4.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/examples/mcp-policies/java/pom.xml
+++ b/examples/mcp-policies/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.3.0</version>
+            <version>5.4.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/mcp-policies/pii-redaction/java/pom.xml
+++ b/examples/mcp-policies/pii-redaction/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.3.0</version>
+            <version>5.4.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/mcp-policies/pii-redaction/python/requirements.txt
+++ b/examples/mcp-policies/pii-redaction/python/requirements.txt
@@ -1,2 +1,2 @@
-axonflow>=6.3.0
+axonflow>=6.4.0
 python-dotenv>=1.0.0

--- a/examples/mcp-policies/pii-redaction/typescript/package.json
+++ b/examples/mcp-policies/pii-redaction/typescript/package.json
@@ -7,7 +7,7 @@
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.3.0"
+    "@axonflow/sdk": "^5.4.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/examples/mcp-policies/python/requirements.txt
+++ b/examples/mcp-policies/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=6.3.0
+axonflow>=6.4.0

--- a/examples/mcp-policies/typescript/package.json
+++ b/examples/mcp-policies/typescript/package.json
@@ -7,7 +7,7 @@
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.3.0"
+    "@axonflow/sdk": "^5.4.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/examples/media-governance-policies/java/pom.xml
+++ b/examples/media-governance-policies/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.3.0</version>
+            <version>5.4.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/media-governance-policies/python/requirements.txt
+++ b/examples/media-governance-policies/python/requirements.txt
@@ -1,2 +1,2 @@
-axonflow>=6.3.0
+axonflow>=6.4.0
 python-dotenv>=1.0.0

--- a/examples/media-governance-policies/typescript/package.json
+++ b/examples/media-governance-policies/typescript/package.json
@@ -7,7 +7,7 @@
     "start": "ts-node main.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.3.0",
+    "@axonflow/sdk": "^5.4.0",
     "dotenv": "^16.3.1"
   },
   "devDependencies": {

--- a/examples/media-governance/java/pom.xml
+++ b/examples/media-governance/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.3.0</version>
+            <version>5.4.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/media-governance/python/requirements.txt
+++ b/examples/media-governance/python/requirements.txt
@@ -1,2 +1,2 @@
-axonflow>=6.3.0
+axonflow>=6.4.0
 python-dotenv>=1.0.0

--- a/examples/media-governance/typescript/package.json
+++ b/examples/media-governance/typescript/package.json
@@ -7,7 +7,7 @@
     "start": "ts-node index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.3.0",
+    "@axonflow/sdk": "^5.4.0",
     "dotenv": "^16.3.1"
   },
   "devDependencies": {

--- a/examples/pii-detection/java/pom.xml
+++ b/examples/pii-detection/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.3.0</version>
+            <version>5.4.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/pii-detection/python/requirements.txt
+++ b/examples/pii-detection/python/requirements.txt
@@ -1,2 +1,2 @@
-axonflow>=6.3.0
+axonflow>=6.4.0
 python-dotenv>=1.0.0

--- a/examples/pii-detection/typescript/package.json
+++ b/examples/pii-detection/typescript/package.json
@@ -7,7 +7,7 @@
     "start": "ts-node index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.3.0",
+    "@axonflow/sdk": "^5.4.0",
     "dotenv": "^16.3.1"
   },
   "devDependencies": {

--- a/examples/policies/crud/requirements.txt
+++ b/examples/policies/crud/requirements.txt
@@ -1,5 +1,5 @@
 # AxonFlow SDK
-axonflow>=6.3.0
+axonflow>=6.4.0
 
 # HTTP client for direct API calls
 httpx>=0.25.0

--- a/examples/policies/java/pom.xml
+++ b/examples/policies/java/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.3.0</version>
+            <version>5.4.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/policies/python/requirements.txt
+++ b/examples/policies/python/requirements.txt
@@ -1,5 +1,5 @@
 # AxonFlow SDK (from feature branch)
-axonflow>=6.3.0
+axonflow>=6.4.0
 
 # For loading environment variables
 python-dotenv>=1.0.0

--- a/examples/policies/typescript/package.json
+++ b/examples/policies/typescript/package.json
@@ -10,7 +10,7 @@
     "all": "npm run create && npm run list && npm run test-pattern"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.3.0"
+    "@axonflow/sdk": "^5.4.0"
   },
   "devDependencies": {
     "tsx": "^4.7.0",

--- a/examples/policy-configuration/java/pom.xml
+++ b/examples/policy-configuration/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.3.0</version>
+            <version>5.4.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/policy-configuration/python/requirements.txt
+++ b/examples/policy-configuration/python/requirements.txt
@@ -1,2 +1,2 @@
-axonflow>=6.3.0
+axonflow>=6.4.0
 python-dotenv>=1.0.0

--- a/examples/policy-configuration/typescript/package.json
+++ b/examples/policy-configuration/typescript/package.json
@@ -7,7 +7,7 @@
     "start": "ts-node index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.3.0",
+    "@axonflow/sdk": "^5.4.0",
     "dotenv": "^16.3.1"
   },
   "devDependencies": {

--- a/examples/retry-semantics/java/pom.xml
+++ b/examples/retry-semantics/java/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.3.0</version>
+            <version>5.4.0</version>
         </dependency>
     </dependencies>
 </project>

--- a/examples/sdk-audit/java/pom.xml
+++ b/examples/sdk-audit/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.3.0</version>
+            <version>5.4.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/sdk-audit/python/requirements.txt
+++ b/examples/sdk-audit/python/requirements.txt
@@ -1,2 +1,2 @@
-axonflow>=6.3.0
+axonflow>=6.4.0
 python-dotenv>=1.0.0

--- a/examples/sdk-audit/typescript/package.json
+++ b/examples/sdk-audit/typescript/package.json
@@ -13,7 +13,7 @@
   "author": "AxonFlow",
   "license": "MIT",
   "dependencies": {
-    "@axonflow/sdk": "^5.3.0",
+    "@axonflow/sdk": "^5.4.0",
     "dotenv": "^16.3.0"
   },
   "devDependencies": {

--- a/examples/singapore-pii/java/pom.xml
+++ b/examples/singapore-pii/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.3.0</version>
+            <version>5.4.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/singapore-pii/python/requirements.txt
+++ b/examples/singapore-pii/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=6.3.0
+axonflow>=6.4.0

--- a/examples/singapore-pii/typescript/package.json
+++ b/examples/singapore-pii/typescript/package.json
@@ -8,7 +8,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.3.0"
+    "@axonflow/sdk": "^5.4.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/examples/sqli-detection/java/pom.xml
+++ b/examples/sqli-detection/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.3.0</version>
+            <version>5.4.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/sqli-detection/python/requirements.txt
+++ b/examples/sqli-detection/python/requirements.txt
@@ -1,2 +1,2 @@
-axonflow>=6.3.0
+axonflow>=6.4.0
 python-dotenv>=1.0.0

--- a/examples/sqli-detection/typescript/package.json
+++ b/examples/sqli-detection/typescript/package.json
@@ -7,7 +7,7 @@
     "start": "ts-node index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.3.0",
+    "@axonflow/sdk": "^5.4.0",
     "dotenv": "^16.3.1"
   },
   "devDependencies": {

--- a/examples/static-policies/java/pom.xml
+++ b/examples/static-policies/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.3.0</version>
+            <version>5.4.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/static-policies/python/requirements.txt
+++ b/examples/static-policies/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=6.3.0
+axonflow>=6.4.0

--- a/examples/static-policies/typescript/package.json
+++ b/examples/static-policies/typescript/package.json
@@ -7,7 +7,7 @@
     "start": "npx ts-node index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.3.0"
+    "@axonflow/sdk": "^5.4.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/examples/version-check/java/pom.xml
+++ b/examples/version-check/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.3.0</version>
+            <version>5.4.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/examples/version-check/python/requirements.txt
+++ b/examples/version-check/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=6.3.0
+axonflow>=6.4.0

--- a/examples/version-check/typescript/package.json
+++ b/examples/version-check/typescript/package.json
@@ -7,7 +7,7 @@
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.3.0"
+    "@axonflow/sdk": "^5.4.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/examples/webhooks/java/pom.xml
+++ b/examples/webhooks/java/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.3.0</version>
+            <version>5.4.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/webhooks/python/requirements.txt
+++ b/examples/webhooks/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=6.3.0
+axonflow>=6.4.0

--- a/examples/webhooks/typescript/package.json
+++ b/examples/webhooks/typescript/package.json
@@ -7,7 +7,7 @@
     "start": "npx ts-node src/index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.3.0",
+    "@axonflow/sdk": "^5.4.0",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.0"
   }

--- a/examples/workflow-control/java/pom.xml
+++ b/examples/workflow-control/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.3.0</version>
+            <version>5.4.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/workflow-control/python/requirements.txt
+++ b/examples/workflow-control/python/requirements.txt
@@ -1,3 +1,3 @@
-axonflow>=6.3.0
+axonflow>=6.4.0
 python-dotenv>=1.0.0
 langgraph>=0.2.0

--- a/examples/workflow-control/typescript/package.json
+++ b/examples/workflow-control/typescript/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.3.0",
+    "@axonflow/sdk": "^5.4.0",
     "dotenv": "^16.3.1"
   },
   "devDependencies": {

--- a/examples/workflow-fail/java/pom.xml
+++ b/examples/workflow-fail/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.3.0</version>
+            <version>5.4.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/workflow-fail/python/requirements.txt
+++ b/examples/workflow-fail/python/requirements.txt
@@ -1,2 +1,2 @@
-axonflow>=6.3.0
+axonflow>=6.4.0
 python-dotenv>=1.0.0

--- a/examples/workflow-fail/typescript/package.json
+++ b/examples/workflow-fail/typescript/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.3.0",
+    "@axonflow/sdk": "^5.4.0",
     "dotenv": "^16.3.1"
   },
   "devDependencies": {

--- a/examples/workflow-policy/java/pom.xml
+++ b/examples/workflow-policy/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.3.0</version>
+            <version>5.4.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/workflow-policy/python/requirements.txt
+++ b/examples/workflow-policy/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=6.3.0
+axonflow>=6.4.0

--- a/examples/workflow-policy/typescript/package.json
+++ b/examples/workflow-policy/typescript/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.3.0"
+    "@axonflow/sdk": "^5.4.0"
   },
   "devDependencies": {
     "tsx": "^4.0.0",

--- a/examples/workflows/01-simple-sequential/package.json
+++ b/examples/workflows/01-simple-sequential/package.json
@@ -7,7 +7,7 @@
     "start": "npx ts-node main.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.3.0"
+    "@axonflow/sdk": "^5.4.0"
   },
   "devDependencies": {
     "ts-node": "^10.9.2",

--- a/examples/workflows/01-simple-sequential/pom.xml
+++ b/examples/workflows/01-simple-sequential/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.3.0</version>
+            <version>5.4.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/workflows/01-simple-sequential/requirements.txt
+++ b/examples/workflows/01-simple-sequential/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=6.3.0
+axonflow>=6.4.0

--- a/examples/workflows/02-parallel-execution/package.json
+++ b/examples/workflows/02-parallel-execution/package.json
@@ -7,7 +7,7 @@
     "start": "npx ts-node main.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.3.0"
+    "@axonflow/sdk": "^5.4.0"
   },
   "devDependencies": {
     "ts-node": "^10.9.2",

--- a/examples/workflows/02-parallel-execution/pom.xml
+++ b/examples/workflows/02-parallel-execution/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.3.0</version>
+            <version>5.4.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/workflows/02-parallel-execution/requirements.txt
+++ b/examples/workflows/02-parallel-execution/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=6.3.0
+axonflow>=6.4.0

--- a/examples/workflows/03-conditional-logic/package.json
+++ b/examples/workflows/03-conditional-logic/package.json
@@ -7,7 +7,7 @@
     "start": "npx ts-node main.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.3.0"
+    "@axonflow/sdk": "^5.4.0"
   },
   "devDependencies": {
     "ts-node": "^10.9.2",

--- a/examples/workflows/03-conditional-logic/pom.xml
+++ b/examples/workflows/03-conditional-logic/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.3.0</version>
+            <version>5.4.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/workflows/03-conditional-logic/requirements.txt
+++ b/examples/workflows/03-conditional-logic/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=6.3.0
+axonflow>=6.4.0

--- a/examples/workflows/04-travel-booking-fallbacks/package.json
+++ b/examples/workflows/04-travel-booking-fallbacks/package.json
@@ -7,7 +7,7 @@
     "start": "npx ts-node main.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.3.0"
+    "@axonflow/sdk": "^5.4.0"
   },
   "devDependencies": {
     "ts-node": "^10.9.2",

--- a/examples/workflows/04-travel-booking-fallbacks/pom.xml
+++ b/examples/workflows/04-travel-booking-fallbacks/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.3.0</version>
+            <version>5.4.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/workflows/04-travel-booking-fallbacks/requirements.txt
+++ b/examples/workflows/04-travel-booking-fallbacks/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=6.3.0
+axonflow>=6.4.0

--- a/examples/workflows/05-data-pipeline/package.json
+++ b/examples/workflows/05-data-pipeline/package.json
@@ -7,7 +7,7 @@
     "start": "npx ts-node main.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.3.0"
+    "@axonflow/sdk": "^5.4.0"
   },
   "devDependencies": {
     "ts-node": "^10.9.2",

--- a/examples/workflows/05-data-pipeline/pom.xml
+++ b/examples/workflows/05-data-pipeline/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.3.0</version>
+            <version>5.4.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/workflows/05-data-pipeline/requirements.txt
+++ b/examples/workflows/05-data-pipeline/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=6.3.0
+axonflow>=6.4.0

--- a/examples/workflows/06-multi-step-approval/package.json
+++ b/examples/workflows/06-multi-step-approval/package.json
@@ -7,7 +7,7 @@
     "start": "npx ts-node main.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.3.0"
+    "@axonflow/sdk": "^5.4.0"
   },
   "devDependencies": {
     "ts-node": "^10.9.2",

--- a/examples/workflows/06-multi-step-approval/pom.xml
+++ b/examples/workflows/06-multi-step-approval/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.3.0</version>
+            <version>5.4.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/workflows/06-multi-step-approval/requirements.txt
+++ b/examples/workflows/06-multi-step-approval/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=6.3.0
+axonflow>=6.4.0

--- a/platform/agent/capabilities.go
+++ b/platform/agent/capabilities.go
@@ -45,10 +45,10 @@ func getSDKCompatibility() SDKCompatInfo {
 			"java":       "5.0.0",
 		},
 		RecommendedSDKVersion: map[string]string{
-			"python":     "6.3.0",
-			"typescript": "5.3.0",
-			"go":         "5.3.0",
-			"java":       "5.3.0",
+			"python":     "6.4.0",
+			"typescript": "5.4.0",
+			"go":         "5.4.0",
+			"java":       "5.4.0",
 		},
 	}
 }

--- a/platform/orchestrator/capabilities.go
+++ b/platform/orchestrator/capabilities.go
@@ -61,10 +61,10 @@ func getSDKCompatibility() SDKCompatInfo {
 			"java":       "3.0.0",
 		},
 		RecommendedSDKVersion: map[string]string{
-			"python":     "6.3.0",
-			"typescript": "5.3.0",
-			"go":         "5.3.0",
-			"java":       "5.3.0",
+			"python":     "6.4.0",
+			"typescript": "5.4.0",
+			"go":         "5.4.0",
+			"java":       "5.4.0",
 		},
 	}
 }


### PR DESCRIPTION
Bump SDK and plugin versions across examples and documentation to match v7.1.0 platform release.