### PR TITLE
chore(tests): bump plugin refs to 2026-04-19 patch versions

### DIFF
--- a/tests/e2e/plugin-batch-1/claude-install/README.md
+++ b/tests/e2e/plugin-batch-1/claude-install/README.md
@@ -1,6 +1,6 @@
 # Claude Code Plugin Install E2E
 
-Install-and-use tests for `axonflow-claude-plugin@v0.5.0` from its GitHub
+Install-and-use tests for `axonflow-claude-plugin@v0.5.1` from its GitHub
 release. Exercises the `pre-tool-check.sh` hook end-to-end against the
 live stack.
 
@@ -9,8 +9,8 @@ live stack.
 1. Stack up via `./scripts/setup-e2e-testing.sh evaluation`.
 2. Plugin fetched via:
    ```bash
-   mkdir /tmp/claude-plugin-v0.5.0-e2e && cd /tmp/claude-plugin-v0.5.0-e2e
-   curl -sL https://github.com/getaxonflow/axonflow-claude-plugin/archive/refs/tags/v0.5.0.tar.gz | tar xz
+   mkdir /tmp/claude-plugin-v0.5.1-e2e && cd /tmp/claude-plugin-v0.5.1-e2e
+   curl -sL https://github.com/getaxonflow/axonflow-claude-plugin/archive/refs/tags/v0.5.1.tar.gz | tar xz
    mv axonflow-claude-plugin-0.5.0 plugin
    ```
 3. Default credentials: `demo-client:demo-secret`.
@@ -31,7 +31,7 @@ bash scenario-1-block-context.sh
 
 ## Why this matters
 
-Claude Code plugin v0.5.0 is already parsing these fields from the MCP
+Claude Code plugin v0.5.1 is already parsing these fields from the MCP
 server response. The first post-release E2E run against platform v7.1.0
 (before the six-bug patch) showed the response arriving without the
 fields — resulting in a terse deny with no explain/override affordance.

--- a/tests/e2e/plugin-batch-1/claude-install/scenario-1-block-context.sh
+++ b/tests/e2e/plugin-batch-1/claude-install/scenario-1-block-context.sh
@@ -7,13 +7,13 @@
 # print, even when a jq filter happens to exit non-zero mid-script.
 set -uo pipefail
 
-SCRIPT="/tmp/claude-plugin-v0.5.0-e2e/plugin/scripts/pre-tool-check.sh"
+SCRIPT="/tmp/claude-plugin-v0.5.1-e2e/plugin/scripts/pre-tool-check.sh"
 export AXONFLOW_ENDPOINT=http://localhost:8080
 # AXONFLOW_AUTH is the base64 of "client:secret" — the hook prepends
 # "Basic " verbatim (see pre-tool-check.sh's AUTH_HEADER construction).
 export AXONFLOW_AUTH="$(echo -n 'demo-client:demo-secret' | base64)"
 # The Claude Code plugin hook script doesn't currently forward per-user
-# identity. We test what a user experiences on v0.5.0 with v7.1.1 server.
+# identity. We test what a user experiences on v0.5.1 with v7.1.1 server.
 
 INPUT='{"tool_name":"Bash","tool_input":{"command":"psql -c \"SELECT * FROM users WHERE id='"'"'1'"'"' OR 1=1--\""}}'
 

--- a/tests/e2e/plugin-batch-1/codex-install/README.md
+++ b/tests/e2e/plugin-batch-1/codex-install/README.md
@@ -1,6 +1,6 @@
 # Codex Plugin Install E2E
 
-Install-and-use tests for `axonflow-codex-plugin@v0.4.0` from its GitHub
+Install-and-use tests for `axonflow-codex-plugin@v0.4.1` from its GitHub
 release. Exercises `pre-tool-check.sh` end-to-end against the live stack.
 
 ## Preconditions
@@ -8,8 +8,8 @@ release. Exercises `pre-tool-check.sh` end-to-end against the live stack.
 Plugin fetched via:
 
 ```bash
-mkdir /tmp/codex-plugin-v0.4.0-e2e && cd /tmp/codex-plugin-v0.4.0-e2e
-curl -sL https://github.com/getaxonflow/axonflow-codex-plugin/archive/refs/tags/v0.4.0.tar.gz | tar xz
+mkdir /tmp/codex-plugin-v0.4.1-e2e && cd /tmp/codex-plugin-v0.4.1-e2e
+curl -sL https://github.com/getaxonflow/axonflow-codex-plugin/archive/refs/tags/v0.4.1.tar.gz | tar xz
 mv axonflow-codex-plugin-0.4.0 plugin
 ```
 

--- a/tests/e2e/plugin-batch-1/codex-install/scenario-1-block-context.sh
+++ b/tests/e2e/plugin-batch-1/codex-install/scenario-1-block-context.sh
@@ -3,7 +3,7 @@
 # Assert exit 2 + stderr contains richer context.
 set -uo pipefail
 
-SCRIPT="/tmp/codex-plugin-v0.4.0-e2e/plugin/scripts/pre-tool-check.sh"
+SCRIPT="/tmp/codex-plugin-v0.4.1-e2e/plugin/scripts/pre-tool-check.sh"
 export AXONFLOW_ENDPOINT=http://localhost:8080
 # AXONFLOW_AUTH is the base64 of "client:secret" — the hook prepends
 # "Basic " verbatim (see pre-tool-check.sh's AUTH_HEADER construction).

--- a/tests/e2e/plugin-batch-1/cursor-install/README.md
+++ b/tests/e2e/plugin-batch-1/cursor-install/README.md
@@ -1,6 +1,6 @@
 # Cursor Plugin Install E2E
 
-Install-and-use tests for `axonflow-cursor-plugin@v0.5.0` from its GitHub
+Install-and-use tests for `axonflow-cursor-plugin@v0.5.1` from its GitHub
 release. Exercises `pre-tool-check.sh` end-to-end against the live stack.
 
 ## Preconditions
@@ -8,8 +8,8 @@ release. Exercises `pre-tool-check.sh` end-to-end against the live stack.
 Plugin fetched via:
 
 ```bash
-mkdir /tmp/cursor-plugin-v0.5.0-e2e && cd /tmp/cursor-plugin-v0.5.0-e2e
-curl -sL https://github.com/getaxonflow/axonflow-cursor-plugin/archive/refs/tags/v0.5.0.tar.gz | tar xz
+mkdir /tmp/cursor-plugin-v0.5.1-e2e && cd /tmp/cursor-plugin-v0.5.1-e2e
+curl -sL https://github.com/getaxonflow/axonflow-cursor-plugin/archive/refs/tags/v0.5.1.tar.gz | tar xz
 mv axonflow-cursor-plugin-0.5.0 plugin
 ```
 
@@ -32,5 +32,5 @@ The scenario asserts exit 2 plus stderr containing
 ## Why this matters
 
 Same platform fix as Claude Code (v7.1.1 extends `mcpToolCheckPolicy`
-with richer context). Cursor plugin v0.5.0 already consumes the fields;
+with richer context). Cursor plugin v0.5.1 already consumes the fields;
 this scenario verifies the end-to-end path.

--- a/tests/e2e/plugin-batch-1/cursor-install/scenario-1-block-context.sh
+++ b/tests/e2e/plugin-batch-1/cursor-install/scenario-1-block-context.sh
@@ -3,7 +3,7 @@
 # Assert exit 2 + stderr contains richer context (decision_id, risk, override).
 set -uo pipefail
 
-SCRIPT="/tmp/cursor-plugin-v0.5.0-e2e/plugin/scripts/pre-tool-check.sh"
+SCRIPT="/tmp/cursor-plugin-v0.5.1-e2e/plugin/scripts/pre-tool-check.sh"
 export AXONFLOW_ENDPOINT=http://localhost:8080
 # AXONFLOW_AUTH is the base64 of "client:secret" — the hook prepends
 # "Basic " verbatim (see pre-tool-check.sh's AUTH_HEADER construction).

--- a/tests/e2e/plugin-batch-1/openclaw-install/README.md
+++ b/tests/e2e/plugin-batch-1/openclaw-install/README.md
@@ -1,6 +1,6 @@
 # OpenClaw Plugin Install E2E Scenarios
 
-These scenarios exercise `@axonflow/openclaw` v1.3.0+ (installed from npm,
+These scenarios exercise `@axonflow/openclaw` v1.3.1+ (installed from npm,
 not a local build) against a live orchestrator + agent stack. They are the
 post-release "does it actually work when a real user installs it" harness —
 the sibling `run-scenarios.sh` in the parent directory exercises the

--- a/tests/e2e/plugin-batch-1/openclaw-install/scenario-1-richer-context.mjs
+++ b/tests/e2e/plugin-batch-1/openclaw-install/scenario-1-richer-context.mjs
@@ -53,4 +53,4 @@ if (errors.length) {
 }
 console.log('\nPASS: scenario 1');
 // Export decision_id for chained scenarios
-await import('fs').then(m => m.writeFileSync('/tmp/openclaw-v1.3.0-e2e/.scenario1-decision-id', result.decision_id));
+await import('fs').then(m => m.writeFileSync('/tmp/openclaw-v1.3.1-e2e/.scenario1-decision-id', result.decision_id));


### PR DESCRIPTION
## Sync: plugin version refs in E2E harness

Bumps the plugin version refs in `tests/e2e/plugin-batch-1/{openclaw,claude,cursor,codex}-install/` to match today's 2026-04-19 patch releases:

- OpenClaw v1.3.0 → v1.3.1
- Claude Code v0.5.0 → v0.5.1
- Cursor v0.5.0 → v0.5.1
- Codex v0.4.0 → v0.4.1

Updated: install commands, tarball URLs, scratch dir names, OpenClaw minimum-required bumped to `v1.3.1+`. Historical notes explaining the scenario-3 plugin-side vs curl-side split (and the v1.3.0 bug that motivated it) preserved.

### Review Checklist
- [ ] No enterprise-only content included
- [ ] CI checks pass