### PR TITLE
chore(release): v7.2.0 — agent proxy + timeout knobs + security hardening

### DIFF
--- a/.github/scripts/validate-version-alignment.sh
+++ b/.github/scripts/validate-version-alignment.sh
@@ -7,8 +7,12 @@ set -euo pipefail
 
 ERRORS=0
 
-# Extract latest version from CHANGELOG.md (first ## [x.y.z] line)
-LATEST_VERSION=$(grep -m1 '^## \[' CHANGELOG.md | sed 's/## \[\(.*\)\].*/\1/')
+# Extract latest *released* version from CHANGELOG.md (first ## [x.y.z] line that
+# isn't the Keep-a-Changelog "Unreleased" placeholder). The Unreleased section
+# accumulates in-flight changes between tags and must not be used as the
+# expected-version target — version defaults across the repo only get bumped
+# when we actually cut a tag.
+LATEST_VERSION=$(grep -m1 -E '^## \[[0-9]' CHANGELOG.md | sed 's/## \[\(.*\)\].*/\1/')
 
 if [ -z "$LATEST_VERSION" ]; then
     echo "❌ Could not extract version from CHANGELOG.md"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,426 @@ All notable changes to AxonFlow will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+Each entry is grouped by edition: **Community** changes also ship in the
+community mirror, **Enterprise** changes are EE-only.
+
 ---
+
+## [7.2.0] - 2026-04-20 — The Bug Bash Bonanza 🪲🔨
+
+A focused hardening release: a full sweep across the Customer Portal
+HTTP surface, tenant-scope fail-closed enforcement on every
+read-and-action endpoint, three new public platform knobs for the
+MAP plan-execution budget, dedicated HTTP examples for every route
+the Portal calls, a login-endpoint fix that closes an
+org-enumeration leak via both response body and timing, and fixes
+to make MAP plans run the full 5 minutes the server is happy to
+give them. MINOR per semver — additive surface only; every 7.1.x
+caller keeps working without changes.
+
+### Added
+
+#### Community
+
+- **`AXONFLOW_MAP_MAX_TIMEOUT_SECONDS` orchestrator env.** Caps the
+  MAP plan-execution budget without a binary rebuild. Clamped to
+  60..1800 seconds; default 300. The effective value is logged at
+  startup when non-default. Pairs with the new
+  `AlbIdleTimeoutSeconds` CFN parameter on the community-saas
+  template (default 300, same 60..1800 range), wired via `!Ref` so
+  operators can tune the ALB's `idle_timeout.timeout_seconds` at
+  `update-stack` time. Raise both together — the ALB must be
+  greater than or equal to the orchestrator cap or long plans 504
+  at the front door before the orchestrator finishes.
+
+#### Enterprise
+
+- **`AlbIdleTimeoutSeconds` CloudFormation parameter on the
+  AWS Marketplace template.** Mirror of the Community knob.
+- **`middleware.MaxBodyBytesMiddleware` exported on the Customer
+  Portal.** Caps every POST/PUT/PATCH request body at 1 MiB by
+  default; `MaxBodyBytesMiddlewareWithLimit(n int64)` returns a
+  variant for routes that legitimately need a larger ceiling (SAML
+  metadata, future file uploads). GET/HEAD are not wrapped.
+- **Per-feature HTTP examples for every route the Portal UI
+  calls.** Each example is runnable against a local Docker Compose
+  stack and covers one topic end-to-end:
+    - Full RBI AI-system lifecycle: register → validate → incident
+      → kill-switch → board report → audit export.
+    - SEBI dashboard, retention, readiness, and audit export.
+    - EU AI Act conformity, accuracy/bias, and async export jobs.
+    - Compliance evidence bundle (summary + stream-download).
+    - Decision explainability with the cross-tenant 404 guard
+      asserted.
+    - License, deployment, nodes, and session metadata.
+    - Policy bundle export/import with `overwrite_mode` semantics.
+    - Full `/api/v1/auth/*` walkthrough: login, session, logout,
+      SSO availability, forgot-password, reset-password,
+      change-password — including the auth-enum identical-body
+      assertions.
+  A curl-based smoke runner covers every Portal API route (44
+  total) without needing a browser, pairing with the Playwright
+  health spec so CI and demo-freeze runs have a Playwright-free
+  verification path. Every script passes `shellcheck` and runs
+  green against local compose.
+- **Compliance → Evidence Export Download button.** The Compliance
+  page showed per-type record counts (audit logs, workflow steps,
+  HITL approvals) but had no way to actually download the bundle.
+  Added a Download Evidence button that streams the JSON bundle as
+  a blob with a 30-day default window (the backend caps by tier)
+  and saves as `axonflow-evidence-<start>-to-<end>.json`. Disabled
+  with a tooltip explanation when counts are zero. Surfaces any
+  backend error (tier / license / quota) as an inline alert
+  instead of silently doing nothing.
+
+### Fixed
+
+#### Community
+
+- **Agent now proxies `/api/v1/euaiact/*` to the orchestrator.**
+  The single-entry-point mux listed `/rbi`, `/sebi`, and
+  `/masfeat` alongside the rest of the compliance family but
+  omitted `/euaiact`, so every EU AI Act call that landed on the
+  front-door ALB returned `404 page not found` and the Portal's
+  Compliance page reported the module as "not enabled for this
+  tenant" even though peer modules rendered fine. Added the prefix
+  to both the router and the proxy-allow-list.
+- **Canonical `/api/v1/policy-overrides` alias on the agent.** The
+  Portal's overrides handler proxies to this path, matching the
+  `policy-categories` / `static-policies` / `dynamic-policies`
+  naming pattern; the agent previously only exposed the tenant
+  override list under `/api/v1/static-policies/overrides`.
+  Callers using the canonical path hit 404 and the Portal's
+  Policies → Overrides tab rendered empty. Same handler, new
+  path, auth unchanged.
+- **Agent `/health` includes `tier`.** The validated license tier
+  (`Community` / `Evaluation` / `Professional` / `Enterprise` /
+  `starting`) is now surfaced on the health response. Operators
+  querying `curl /health | jq .tier` used to get `"unknown"`
+  because the field was not present.
+- **Front-door ALB idle timeout 60s → 300s; orchestrator plan
+  budget capped to match.** MAP plans chain multiple LLM calls
+  (~15s each); a typical 5-step plan routinely ran past the
+  default 60s idle timeout, the ALB killed the connection, and
+  the caller saw `HTTP 504 Gateway Time-out` mid-stream even
+  though the orchestrator was still working. Aligned the
+  end-to-end chain so no link is shorter than the plan budget:
+  the ALB idle timeout is 300s by default (non-disruptive
+  attribute change; `update-stack` applies without ECS task
+  churn), the orchestrator's plan-execution timeout caps at the
+  same value, and the trip-planner demo backend's write timeout
+  is raised from 120s to 300s. SDK note: the TypeScript SDK's
+  default `mapTimeout` is 120s; clients relying on the default
+  will cut off at 120s before the server cap takes effect. Pass
+  `mapTimeout: 300000` on the SDK client config to match.
+- **Orchestrator policy type allowlist accepts `context_aware`.**
+  Three seeded system policies (Tenant Isolation, Debug Mode
+  Restriction, Sensitive Data Control) ship with
+  `policy_type=context_aware`; any update through
+  `PUT /api/v1/policies/{id}` returned 400 because that type was
+  missing from the allowlist.
+- **`POST /api/v1/policies/{id}/overrides` accepts
+  `require_approval` (HITL).** The override validator's allow-list
+  was hand-written as `{block, redact, warn, log}`, silently
+  dropping the HITL action even though the rest of the stack
+  accepted it end-to-end. Standardised on a single canonical list
+  of valid actions:
+    - Policy authoring — `alert`, `block`, `log`, `modify_risk`,
+      `redact`, `require_approval`, `route`, `warn`.
+    - Override endpoint (terminal-action subset) — `block`,
+      `require_approval`, `redact`, `warn`, `log`. Authoring-only
+      actions are deliberately excluded — they have no
+      terminal-action meaning and the agent's override repository
+      would reject them anyway.
+- **Test / Edit / Delete / Versions of legacy-named policies no
+  longer 400.** The policy-ID validator only accepted UUIDs and
+  the `sys_*` prefix, so seeded policies like
+  `sensitive_data_control` and `tenant_isolation` failed every
+  per-policy action with "Invalid policy ID format". Allowlist now
+  also accepts the legacy snake-case form.
+- **`GET /api/v1/policies` honours the `tier` and `category` query
+  params.** The orchestrator's list handler dropped both at the
+  handler boundary even though the repo supported them. Without
+  this every Tier / Category dropdown in the Portal's
+  `/policies` page returned the full unfiltered list.
+- **Legacy V1 HMAC license format purged from active code and
+  deploy scripts.** The V2 Ed25519 format has been the only
+  accepted key for months; stale HMAC references across deploy
+  scripts, CFN, the marketplace license-validator Lambda, the
+  marketplace README, and test compose files would have produced
+  confusing failures in a clean shell. The rejection-path code
+  that returns `"V1 license format no longer supported"` is kept
+  so an old key ever surfacing gets a clear error, not silent
+  acceptance. Technical docs that still treated V1 as a live
+  format now carry a deprecation banner pointing readers at the
+  V2 keygen invocation.
+
+#### Enterprise
+
+- **RBI FREE-AI: registering an AI system no longer 500s.** The
+  repository's INSERT listed `board_approval_required`, but that
+  column is a stored-generated column computed from
+  `risk_category`. PostgreSQL rejected every write with
+  `cannot insert a non-DEFAULT value into column
+  board_approval_required`, so the Portal's RBI compliance page
+  could never progress past step 1. Removed the column from the
+  INSERT and UPDATE statements; the Go struct field is still
+  populated at read time.
+- **RBI FREE-AI: generating a board report no longer 500s.** The
+  service layer set `generation_method = "automated"` but the
+  database check constraint only accepts `'automatic'` or
+  `'manual'`. Fixed the literal.
+- **Marketplace CloudFormation: Agent security group can reach the
+  Customer Portal.** Per the single-entry-point architecture,
+  every public request funnels through the Agent, which then
+  proxies `/api/v1/auth/*`, `/api/v1/portal/*`,
+  `/api/v1/code-governance/*`, and `/api/v1/git-providers/*` to
+  the Customer Portal over Cloud Map. The security group allowed
+  ALB → Portal and Portal → Agent but nothing allowed Agent →
+  Portal, so every auth call hitting the raw stack domain timed
+  out after 30 seconds and fell back to `503 Backend service
+  unavailable`. The vanity-domain host-header rule routed
+  directly to the UI and masked the issue during demo prep; only
+  requests on the raw stack domain surfaced it. Applies on
+  `update-stack` without recycling ECS tasks.
+- **Usage & Billing no longer returns zeros for every tenant.**
+  The daily rollup was defined but never invoked — no scheduler,
+  no goroutine, no on-demand call — so the rollup table stayed
+  empty forever and the Portal's summary and time-series queries
+  returned zeros even when the underlying events had rows. The
+  aggregator is now idempotent (re-running an overlapping window
+  recomputes the bucket rather than adding to it) and is called
+  on-demand from the Usage handlers before they query the
+  rollup — self-healing, no scheduler required. A pre-existing
+  latent bug that surfaced once rollups populated
+  (`COALESCE(AVG())` returns numeric, the scan target was int)
+  is fixed in the same change.
+- **`GET /api/v1/export/usage` no longer 500s.** The handler
+  queried columns that didn't exist (`policy_id`, `latency_ms`,
+  `success` — the real columns are `policy_decision`,
+  `response_time_ms`, and a derived success flag), constructed
+  `INTERVAL '$2 days'` which is not valid PostgreSQL
+  parameterization (the `$2` inside a string literal is treated
+  as literal characters, not a placeholder), and ignored the
+  `start` / `end` query params the UI sends (only honouring a
+  legacy `days=` param). Rewritten against the per-request
+  metering table with correct columns, proper date-range handling
+  for RFC3339 timestamps or `YYYY-MM-DD` dates, and surfaced DB
+  errors in the server log instead of swallowing them behind the
+  generic `"Database error"` response.
+- **`GET /api/v1/license/status` no longer 500s for orgs without
+  an `expires_at`.** The handler scanned the column into a
+  non-nullable type; NULL expiry blew up inside `Scan`. Switched
+  to a nullable target and treats NULL as ACTIVE.
+- **`GET /api/v1/admin/organizations/{id}` no longer 500s.** The
+  join against the SSO configuration table used the wrong join
+  column; every org detail page 500'd with `pq: column
+  s.org_id does not exist`.
+- **Admin org list queries fixed against the heartbeat schema.**
+  Both the list and detail endpoints joined `agent_heartbeats` on
+  column names that don't exist (`organization_id`,
+  `last_heartbeat_at`); the real columns are `org_id` and
+  `last_heartbeat`. Both endpoints returned 500 with
+  `pq: column "organization_id" does not exist`.
+- **Customer Portal Docker image builds with the Enterprise Go
+  tag.** The Portal Dockerfile previously hard-coded a Community
+  build, so `license.GenerateLicenseKey` always returned the
+  Community stub and admin onboarding 500'd on every call,
+  leaving the orgs table empty and the SaaS deployment with no
+  orgs to log in as.
+- **Dashboard "Workflows Run" counts MAP plans too.** The
+  dashboard summary queried the WCP-only execution endpoint, so
+  MAP-only tenants saw `Workflows Run: 0` even after running
+  plans. Now queries the cross-type unified executions endpoint
+  with a fallback to the legacy shape for older server builds.
+- **Dashboard no longer renders "Welcome," with an empty name.**
+  The page mounted before `AuthContext.checkSession()` resolved,
+  so the heading printed "Welcome," and the License Status card
+  printed an empty Organization ID. The dashboard now waits on
+  the session-loading gate.
+- **Sidebar pending-approvals badge no longer fires a console
+  401 on first paint.** The poll fired from a `useEffect` on
+  mount without a user guard; on a hard refresh the first poll
+  raced the session check and hit the catch-all orchestrator
+  proxy without an authenticated session. The poll now waits
+  for the user to be non-null and re-runs when the user
+  changes.
+- **`setup-vanity-domain` workflow overwrites stale CFN-managed
+  ALB private-DNS aliases.** When a stack is rebuilt the old ALB
+  DNS goes away; the workflow used to refuse to touch the
+  existing record, leaving the Portal UI's API backend URL
+  resolving to a deleted ALB inside the VPC — surfaced as 503
+  "Backend service unavailable" on the login page. The workflow
+  now upserts when the existing target matches the CFN naming
+  pattern, and continues to skip operator-managed records.
+- **Policy editor accepts `context_aware` and exposes
+  `require_approval`.** Mirrors the orchestrator allowlist change
+  above; users can now author HITL policies end-to-end without
+  the request-level 400 that previously dropped the action at
+  the Portal boundary.
+- **Policy modal interactions no longer swallowed by the
+  backdrop.** A CSS stacking-context bug made Save Changes,
+  Cancel, and every form input unclickable; the Edit-policy
+  flow looked broken. Promoted the dialog content to a higher
+  z-index.
+- **Modal form inputs readable in OS dark mode.** A leftover
+  `prefers-color-scheme: dark` block from the create-next-app
+  template repointed form text to near-white over a hardcoded
+  white modal, so field values looked empty. The block is
+  removed and native controls (checkboxes, scrollbars) now
+  follow the light color scheme.
+- **`/export` page no longer logs a React hydration error.** The
+  date-range hint rendered `new Date().toLocaleDateString()`
+  directly in JSX, producing different output on the SSR pass
+  vs the client. Deferred the dates behind a `mounted` flag.
+- **`POST /api/v1/admin/onboard-customer` accepts an optional
+  `license_key`.** Lets operators register an org against an
+  already-minted license (Lambda bootstrap, key-rotation
+  scripts, existing SDK customers) without forcing the Portal
+  to re-key. When set, in-process generation is skipped and
+  the existing Secrets Manager entry is left untouched.
+- **Marketplace CloudFormation: orchestrator connector secrets
+  resolve under the per-stack environment name.** Fourteen
+  connector secret paths used the wrong path component; on any
+  non-default stack every connector came up with empty
+  credentials. The `TaskExecutionRole` IAM grant now matches
+  the per-stack path as well, with an `AllowedPattern` on
+  `EnvironmentName` so typos fail at `CreateChangeSet` time
+  rather than at runtime.
+
+### Security
+
+#### Community
+
+- **Internal-service auth no longer accepts a static fallback
+  token in non-Community deployments.** When the
+  internal-service secret was unset, the agent fell through to
+  a literal-string compare against a constant. Any caller
+  knowing that constant could supply internal-service headers
+  and impersonate the orchestrator, injecting arbitrary
+  `X-Tenant-ID` / `X-Org-ID` for cross-tenant access. The
+  fallback path is now gated to Community / Community-SaaS
+  modes only; outside those a one-time security warning is
+  logged at startup. HMAC and legacy plain-secret paths are
+  unchanged.
+- **Orchestrator audit handler fails closed when proxy auth is
+  missing in non-Community deployments.** The handler
+  previously skipped the proxy-auth validation entirely when
+  the token validator was nil — the same misconfiguration
+  shape that enabled the agent fallback bypass above. An
+  attacker reaching the orchestrator directly could spoof
+  `X-Org-ID` for cross-tenant audit attribution. The handler
+  now returns 403 if the validator is nil and the deployment
+  mode is not Community.
+- **`GET /api/v1/decisions/{id}/explain` filters tenant in the
+  SELECT clause.** The handler used to look up the audit entry
+  by `decision_id` only and post-check the tenant; the
+  short-circuit on email failed open whenever the user-email
+  column was NULL, and the email check itself was bypassable
+  by an attacker who happened to share an email with the
+  decision owner across tenants. Now: `X-Tenant-ID` is
+  required, the SELECT binds on `(decisionID, callerTenant)`,
+  and cross-tenant requests return 404 (not 403) so the
+  response shape doesn't leak whether `decision_id` exists in
+  another tenant. The post-fetch tenant comparison is kept as
+  defense-in-depth.
+- **`POST /api/v1/evidence/export` and `GET /api/v1/evidence/summary`
+  fail closed when the tenant scope is missing.** Both endpoints
+  previously fell back to an empty-string tenant when neither
+  `X-Tenant-ID` nor a context-stored `tenant_id` was set, then
+  ran SQL with `WHERE tenant_id = ''` — zero rows in practice
+  but silently burned a daily-export quota slot for an empty
+  bucket and would have leaked data the moment a downstream
+  query stopped filtering. Both now return 401
+  `TENANT_REQUIRED` when neither source provides a scope.
+- **`POST /api/v1/policies/simulate` and
+  `POST /api/v1/policies/{id}/impact-report` adopt the same
+  fail-closed tenant resolution.** Same header-then-context-
+  then-fall-through-to-empty pattern as evidence/export; would
+  have shared a global empty-tenant rate-limit bucket when
+  called without `X-Tenant-ID`.
+- **`POST /api/v1/cost/estimate` and
+  `GET /api/v1/plans/{id}/cost` reject anonymous callers.**
+  Both substituted a `"_default"` literal for an empty
+  `X-Tenant-ID`, so every unauthenticated caller drained the
+  same daily quota. Both now return 401 `TENANT_REQUIRED`.
+- **`GET /api/v1/audit/tenant/{tenant_id}` requires
+  `X-Tenant-ID`.** The URL-vs-session tenant mismatch check
+  was gated on a non-empty session tenant, so omitting the
+  header bypassed the cross-check entirely. The header is now
+  required; mismatches still return 403.
+- **`/api/v1/audit/search` enforces tenant scoping from the
+  trusted header.** The handler ignored the proxy-injected
+  tenant header and only filtered on caller-supplied criteria,
+  so a Portal user for tenant A could read tenant B's audit
+  logs by POSTing to `/api/v1/audit/search`. The header is now
+  required and decoded into a JSON-tag-ignored field so a
+  malicious payload cannot override it. The same path also
+  silently-disabled tenant filtering on
+  `/api/v1/audit/tenant/{id}` because the tenant-only struct
+  shape no longer matched after a `StartTime` field was added;
+  the new SQL filter fixes that too.
+- **`/api/v1/audit/tenant/{tenant_id}` rejects URL paths that
+  don't match the session tenant.** Without the cross-check a
+  Portal user for tenant A could read tenant B's audit history
+  by browsing to `/api/v1/audit/tenant/B`.
+
+#### Enterprise
+
+- **Customer Portal login no longer leaks org existence or auth
+  mode.** `POST /api/v1/auth/login` returned three
+  distinguishable failure responses that together let an
+  unauthenticated caller enumerate valid org IDs and classify
+  each org by auth mode:
+    - Unknown org: `401 "Invalid credentials"` (no bcrypt work).
+    - Known org with no password set (SSO-only): `401 "Password
+      authentication not enabled for this organization"` (no
+      bcrypt work).
+    - Known org, bad password: `401 "Invalid credentials"`
+      (full bcrypt compare).
+  The distinct no-password body outed which orgs existed and
+  which were password-backed; even with a uniform body the
+  missing bcrypt on the first two branches leaked the same bit
+  through response timing. Every failure now returns `"Invalid
+  credentials"`; the no-password branch runs a throwaway
+  bcrypt compare against a fixed placeholder hash so the
+  timing profile matches a real check. SSO-only orgs cannot
+  log in through this path — they are simply indistinguishable
+  from wrong-password attempts to an external caller.
+- **Customer Portal request-body size capped at 1 MiB.** The
+  Portal had no upstream bound on JSON-decode; a single
+  multi-GB POST could pin goroutines and memory. The new
+  middleware caps POST/PUT/PATCH bodies at 1 MiB by default
+  and is wired into the Portal's outer chain so SCIM, admin,
+  and session-protected handlers all inherit it.
+- **System policies visible in the Customer Portal.** The
+  Portal's fetch-static-policies call landed on the agent
+  without internal-service credentials and was denied 401, so
+  the Static (Read-only) count showed 0 next to a Total
+  Policies of 17 — the 80+ PII / SQLi / dangerous-commands
+  rules were invisible. Three paired changes restore
+  visibility: the agent accepts internal-service credentials
+  from headers alongside the hint-based path, the Portal
+  signs every agent call with the internal-service secret,
+  and CloudFormation injects that secret into the Portal task
+  definition. Missing-secret deployments log a startup
+  warning and continue with empty static policies so dev
+  environments degrade gracefully.
+- **`POST /api/v1/admin/onboard-customer` is no longer
+  unauthenticated, and supplied `license_key` payloads are
+  verified.** The route was registered on the bare router
+  with a "legacy / no auth for backward compatibility"
+  comment; anyone reachable on the Portal could hit it,
+  write rows into the orgs table, mint license keys, and
+  overwrite Secrets Manager entries. Two paired fixes close
+  the gap: the route now lives under the admin subrouter
+  that runs the admin auth middleware (API key required in
+  SaaS production; optional otherwise), and when the request
+  supplies `license_key` the handler validates the Ed25519
+  signature, expiry, and signed org/tier match before
+  accepting. The signed payload's `expires_at` and
+  `max_nodes` win over the request body — the body cannot
+  widen what the license actually grants.
 
 ## [7.1.1] - 2026-04-19
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,7 +87,7 @@ services:
       DEPLOYMENT_MODE: ${DEPLOYMENT_MODE:-community}
       AXONFLOW_INTEGRATIONS: ${AXONFLOW_INTEGRATIONS:-}
       AXONFLOW_LICENSE_KEY: ${AXONFLOW_LICENSE_KEY:-}
-      AXONFLOW_VERSION: "${AXONFLOW_VERSION:-7.1.1}"
+      AXONFLOW_VERSION: "${AXONFLOW_VERSION:-7.2.0}"
 
       # Media governance (v4.5.0+) - set to "true" to enable in Community mode
       MEDIA_GOVERNANCE_ENABLED: ${MEDIA_GOVERNANCE_ENABLED:-}
@@ -223,7 +223,7 @@ services:
       PORT: 8081
       DEPLOYMENT_MODE: ${DEPLOYMENT_MODE:-community}
       AXONFLOW_LICENSE_KEY: ${AXONFLOW_LICENSE_KEY:-}
-      AXONFLOW_VERSION: "${AXONFLOW_VERSION:-7.1.1}"
+      AXONFLOW_VERSION: "${AXONFLOW_VERSION:-7.2.0}"
 
       # Media governance (v4.5.0+) - set to "true" to enable in Community mode
       MEDIA_GOVERNANCE_ENABLED: ${MEDIA_GOVERNANCE_ENABLED:-}

--- a/docs/sdk/typescript-quickstart.md
+++ b/docs/sdk/typescript-quickstart.md
@@ -356,6 +356,11 @@ const client = new AxonFlow({
 });
 ```
 
+> **MAP plans with 5+ steps**: the platform's front-door ALB and orchestrator
+> plan budget are both set to 300 seconds. The SDK default of 120s will cut
+> off a 5-step plan before the server does — pass `mapTimeout: 300000` to let
+> the full plan complete.
+
 ## Deployment
 
 The SDK works in any Node.js 18+ environment:

--- a/platform/agent/Dockerfile
+++ b/platform/agent/Dockerfile
@@ -125,7 +125,7 @@ RUN set -e && \
 # Final stage - minimal runtime image
 FROM alpine:3.23
 
-ARG AXONFLOW_VERSION=7.1.1
+ARG AXONFLOW_VERSION=7.2.0
 ENV AXONFLOW_VERSION=${AXONFLOW_VERSION}
 
 # AWS Marketplace metadata

--- a/platform/agent/auth.go
+++ b/platform/agent/auth.go
@@ -418,8 +418,24 @@ func apiAuthMiddleware(next http.Handler) http.Handler {
 			return
 		}
 
+		// Internal-service auth via headers — used by the customer-portal
+		// to call agent endpoints (e.g. /static-policies/effective) without
+		// holding a customer license. The portal signs each request with
+		// AXONFLOW_INTERNAL_SERVICE_SECRET and supplies the tenant scope it
+		// has resolved from the user's session. Authenticate() looks for the
+		// signed credentials in `hints` only, so we have to lift them off the
+		// request headers ourselves before calling it.
+		var hints *AuthHints
+		if svcID := r.Header.Get("X-Internal-Service-ID"); svcID != "" {
+			hints = &AuthHints{
+				ClientID:  svcID,
+				UserToken: r.Header.Get("X-Internal-Service-Token"),
+				TenantID:  r.Header.Get("X-Tenant-ID"),
+			}
+		}
+
 		// Use unified Authenticate() for all deployment modes
-		auth, authErr := Authenticate(r, nil)
+		auth, authErr := Authenticate(r, hints)
 		if authErr != nil {
 			if authErr.RetryAfter != "" {
 				w.Header().Set("Retry-After", authErr.RetryAfter)
@@ -446,7 +462,10 @@ func apiAuthMiddleware(next http.Handler) http.Handler {
 		// X-Tenant-ID header is deprecated — tenant is derived from auth credentials.
 		// Accept and ignore for transition period while SDKs are updated (Phase 2-3).
 		// Auth-derived tenant always takes precedence.
-		if headerTenant := r.Header.Get("X-Tenant-ID"); headerTenant != "" {
+		// Skip the warning for internal-service callers (the customer-portal
+		// intentionally supplies the tenant scope via X-Tenant-ID and the
+		// Authenticate() internal-service path already consumes it).
+		if headerTenant := r.Header.Get("X-Tenant-ID"); headerTenant != "" && auth.Kind != AuthKindInternalService {
 			log.Printf("[API Auth] DEPRECATED: X-Tenant-ID header '%s' ignored — using auth-derived tenant '%s'. Update your SDK to remove this header.",
 				logutil.Sanitize(headerTenant), logutil.Sanitize(tenantID))
 		}

--- a/platform/agent/authenticator.go
+++ b/platform/agent/authenticator.go
@@ -118,7 +118,12 @@ func Authenticate(r *http.Request, hints *AuthHints) (*AuthResult, *AuthError) {
 	// orchestrator doesn't have community-saas bcrypt credentials or enterprise
 	// license keys — it uses its own HMAC token for authentication.
 	if hints != nil && hints.ClientID != "" && hints.UserToken != "" {
-		if serviceauth.IsValidInternalServiceRequest(hints.ClientID, hints.UserToken, internalTokenValidator) {
+		// Allow the static fallback token only in Community / Community-SaaS deployments,
+		// where shipping with no shared secret is part of the dev experience. Enterprise
+		// deployments must always validate against a configured HMAC secret — otherwise
+		// the literal TokenFallback could be used to impersonate the orchestrator.
+		allowFallback := isCommunityMode() || isCommunitySaasMode()
+		if serviceauth.IsValidInternalServiceRequest(hints.ClientID, hints.UserToken, internalTokenValidator, allowFallback) {
 			tenantID := hints.TenantID
 			if tenantID == "" {
 				tenantID = hints.ClientID

--- a/platform/agent/community_saas_telemetry.go
+++ b/platform/agent/community_saas_telemetry.go
@@ -16,6 +16,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/google/uuid"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
 const (
@@ -28,7 +30,41 @@ const (
 
 	// telemetryTTLDays is the TTL for telemetry events in DynamoDB.
 	telemetryTTLDays = 30
+
+	// telemetryCanaryTimeout bounds the startup write used to verify DynamoDB
+	// + KMS permissions. Kept short so a transient AWS slowdown at startup
+	// does not delay agent readiness.
+	telemetryCanaryTimeout = 5 * time.Second
 )
+
+// telemetryWritesTotal counts DynamoDB PutItem outcomes so silent-failure
+// periods (e.g. missing kms:Decrypt on the task role) are visible in Grafana
+// and can be alerted on. The label distinguishes "success", "failure", and
+// the canary equivalents for the startup probe.
+var telemetryWritesTotal = promauto.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "axonflow_community_saas_telemetry_writes_total",
+		Help: "Total community SaaS telemetry write attempts by outcome.",
+	},
+	[]string{"result"},
+)
+
+// telemetryInitFailuresTotal is incremented when the startup canary PutItem
+// fails. A nonzero value after an agent restart means the task cannot write
+// telemetry — almost always an IAM/KMS policy drift on the task role.
+var telemetryInitFailuresTotal = promauto.NewCounter(
+	prometheus.CounterOpts{
+		Name: "axonflow_community_saas_telemetry_init_failures_total",
+		Help: "Count of community SaaS telemetry startup canary PutItem failures.",
+	},
+)
+
+// dynamodbPutter is the minimal surface of the DynamoDB client this package
+// needs. Narrowing the dependency lets tests inject a fake without pulling
+// the full SDK Client.
+type dynamodbPutter interface {
+	PutItem(ctx context.Context, input *dynamodb.PutItemInput, opts ...func(*dynamodb.Options)) (*dynamodb.PutItemOutput, error)
+}
 
 // CommunitySaaSTelemetry records per-request usage events to DynamoDB.
 // Active only when DEPLOYMENT_MODE=community-saas AND COMMUNITY_SAAS_TELEMETRY_TABLE is set.
@@ -38,7 +74,7 @@ const (
 //
 // Does NOT record: request/response body, query params, IP addresses, auth headers.
 type CommunitySaaSTelemetry struct {
-	client    *dynamodb.Client
+	client    dynamodbPutter
 	tableName string
 	version   string
 	enabled   bool
@@ -55,6 +91,11 @@ type telemetryEvent struct {
 // NewCommunitySaaSTelemetry creates a new telemetry middleware.
 // Returns a no-op instance if tableName is empty (local dev without DynamoDB).
 // Starts a bounded worker pool for writing events to DynamoDB.
+//
+// On successful construction, runs a synchronous canary PutItem to verify the
+// DynamoDB + KMS permission chain end-to-end. The canary failure is logged at
+// ERROR and surfaced through the init-failures Prometheus counter, but never
+// blocks agent startup — telemetry is best-effort by design.
 func NewCommunitySaaSTelemetry(tableName, platformVersion string) *CommunitySaaSTelemetry {
 	if tableName == "" {
 		log.Println("[CSAAS-TELEMETRY] Disabled (COMMUNITY_SAAS_TELEMETRY_TABLE is empty)")
@@ -75,6 +116,12 @@ func NewCommunitySaaSTelemetry(tableName, platformVersion string) *CommunitySaaS
 	}
 
 	client := dynamodb.NewFromConfig(cfg)
+	return newWithClient(client, tableName, platformVersion)
+}
+
+// newWithClient assembles the struct and starts workers, separated from
+// NewCommunitySaaSTelemetry so tests can inject a fake dynamodbPutter.
+func newWithClient(client dynamodbPutter, tableName, platformVersion string) *CommunitySaaSTelemetry {
 	eventChan := make(chan telemetryEvent, telemetryEventBufferSize)
 
 	t := &CommunitySaaSTelemetry{
@@ -91,7 +138,57 @@ func NewCommunitySaaSTelemetry(tableName, platformVersion string) *CommunitySaaS
 	}
 
 	log.Printf("[CSAAS-TELEMETRY] Enabled — writing to table %s (%d workers)", tableName, telemetryWorkers)
+
+	// Synchronous startup probe. Runs inline so the first line of CloudWatch
+	// after "[CSAAS-TELEMETRY] Enabled —" is either a success confirmation or
+	// a loud failure. Never blocks on error — agent keeps running.
+	t.runStartupCanary(context.Background())
+
 	return t
+}
+
+// runStartupCanary writes a synthetic telemetry record to verify the full
+// DynamoDB + KMS + IAM chain at startup. A failure here means subsequent
+// real writes will also fail, and should trigger an oncall alert through
+// the init-failures counter.
+//
+// Does not block or unwind on failure: telemetry stays "enabled" so the app
+// does not crash, but the operator-visible signal (log + counter) catches
+// the misconfiguration within seconds of deploy.
+func (t *CommunitySaaSTelemetry) runStartupCanary(ctx context.Context) {
+	canaryCtx, cancel := context.WithTimeout(ctx, telemetryCanaryTimeout)
+	defer cancel()
+
+	now := time.Now().UTC()
+	correlationID := "canary-" + uuid.NewString()
+	ttl := now.Add(telemetryTTLDays * 24 * time.Hour).Unix()
+
+	item := map[string]types.AttributeValue{
+		"correlation_id":   &types.AttributeValueMemberS{Value: correlationID},
+		"timestamp":        &types.AttributeValueMemberS{Value: now.Format(time.RFC3339)},
+		"tenant_id":        &types.AttributeValueMemberS{Value: "__canary__"},
+		"endpoint":         &types.AttributeValueMemberS{Value: "__startup_canary__"},
+		"method":           &types.AttributeValueMemberS{Value: "CANARY"},
+		"status_code":      &types.AttributeValueMemberN{Value: "0"},
+		"platform_version": &types.AttributeValueMemberS{Value: t.version},
+		"source":           &types.AttributeValueMemberS{Value: "community-saas"},
+		"ttl":              &types.AttributeValueMemberN{Value: strconv.FormatInt(ttl, 10)},
+	}
+
+	_, err := t.client.PutItem(canaryCtx, &dynamodb.PutItemInput{
+		TableName: aws.String(t.tableName),
+		Item:      item,
+	})
+	if err != nil {
+		log.Printf("[CSAAS-TELEMETRY] STARTUP CANARY FAILED — real telemetry writes will also fail. "+
+			"Check task role has kms:Decrypt + kms:GenerateDataKey on the telemetry table's KMS key. Error: %v", err)
+		telemetryInitFailuresTotal.Inc()
+		telemetryWritesTotal.WithLabelValues("canary_failure").Inc()
+		return
+	}
+
+	log.Printf("[CSAAS-TELEMETRY] Startup canary OK — DynamoDB + KMS permissions verified")
+	telemetryWritesTotal.WithLabelValues("canary_success").Inc()
 }
 
 // worker drains the event channel and writes to DynamoDB.
@@ -168,6 +265,7 @@ func (t *CommunitySaaSTelemetry) Middleware(next http.Handler) http.Handler {
 
 // writeEvent writes a single usage event to DynamoDB.
 // Errors are logged but never propagated — telemetry must not affect request flow.
+// Every call bumps the writes_total counter so silent failures surface in metrics.
 func (t *CommunitySaaSTelemetry) writeEvent(event telemetryEvent) {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
@@ -194,7 +292,10 @@ func (t *CommunitySaaSTelemetry) writeEvent(event telemetryEvent) {
 	})
 	if err != nil {
 		log.Printf("[CSAAS-TELEMETRY] DynamoDB PutItem failed (non-fatal): %v", err)
+		telemetryWritesTotal.WithLabelValues("failure").Inc()
+		return
 	}
+	telemetryWritesTotal.WithLabelValues("success").Inc()
 }
 
 // statusWriter wraps http.ResponseWriter to capture the status code.

--- a/platform/agent/community_saas_telemetry_test.go
+++ b/platform/agent/community_saas_telemetry_test.go
@@ -5,10 +5,31 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 )
+
+// fakePutter is a test double for dynamodbPutter. It records every PutItem
+// call and returns err (if set) on every call.
+type fakePutter struct {
+	calls []*dynamodb.PutItemInput
+	err   error
+}
+
+func (f *fakePutter) PutItem(_ context.Context, input *dynamodb.PutItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.PutItemOutput, error) {
+	f.calls = append(f.calls, input)
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &dynamodb.PutItemOutput{}, nil
+}
 
 func TestNewCommunitySaaSTelemetry_Disabled(t *testing.T) {
 	tel := NewCommunitySaaSTelemetry("", "6.2.0")
@@ -260,6 +281,115 @@ func TestSetTelemetryTenantID_WithoutContainer(t *testing.T) {
 	// SetTelemetryTenantID should be a no-op when no container in context
 	ctx := context.Background()
 	SetTelemetryTenantID(ctx, "test-tenant") // should not panic
+}
+
+// getStringAttr extracts a string value from an aws-sdk-go-v2 DynamoDB item map.
+// Fails the test if the field is missing or not of type AttributeValueMemberS.
+func getStringAttr(t *testing.T, item map[string]types.AttributeValue, field string) string {
+	t.Helper()
+	v, ok := item[field]
+	if !ok {
+		t.Fatalf("missing field %q in item", field)
+	}
+	s, ok := v.(*types.AttributeValueMemberS)
+	if !ok {
+		t.Fatalf("field %q is not a string attribute, got %T", field, v)
+	}
+	return s.Value
+}
+
+func TestStartupCanary_Success(t *testing.T) {
+	before := testutil.ToFloat64(telemetryInitFailuresTotal)
+	beforeSuccess := testutil.ToFloat64(telemetryWritesTotal.WithLabelValues("canary_success"))
+
+	fake := &fakePutter{}
+	tel := newWithClient(fake, "test-table", "7.1.0")
+	defer close(tel.eventChan)
+
+	if len(fake.calls) != 1 {
+		t.Fatalf("expected 1 canary PutItem, got %d", len(fake.calls))
+	}
+	if v := testutil.ToFloat64(telemetryInitFailuresTotal); v != before {
+		t.Errorf("init-failures counter moved on success: was %v, now %v", before, v)
+	}
+	if v := testutil.ToFloat64(telemetryWritesTotal.WithLabelValues("canary_success")); v != beforeSuccess+1 {
+		t.Errorf("canary_success counter did not bump: was %v, now %v", beforeSuccess, v)
+	}
+}
+
+func TestStartupCanary_FailureSurfacesInMetrics(t *testing.T) {
+	// A PutItem error at startup must bump both init-failures and
+	// canary_failure counters, and the agent must still come up (enabled=true).
+	beforeInit := testutil.ToFloat64(telemetryInitFailuresTotal)
+	beforeFail := testutil.ToFloat64(telemetryWritesTotal.WithLabelValues("canary_failure"))
+
+	fake := &fakePutter{err: errors.New("AccessDeniedException: kms:Decrypt not authorized")}
+	tel := newWithClient(fake, "test-table", "7.1.0")
+	defer close(tel.eventChan)
+
+	if !tel.enabled {
+		t.Error("canary failure must NOT disable telemetry (best-effort design)")
+	}
+	if v := testutil.ToFloat64(telemetryInitFailuresTotal); v != beforeInit+1 {
+		t.Errorf("init-failures counter did not bump on canary failure: was %v, now %v", beforeInit, v)
+	}
+	if v := testutil.ToFloat64(telemetryWritesTotal.WithLabelValues("canary_failure")); v != beforeFail+1 {
+		t.Errorf("canary_failure counter did not bump: was %v, now %v", beforeFail, v)
+	}
+}
+
+func TestWriteEvent_SuccessBumpsCounter(t *testing.T) {
+	before := testutil.ToFloat64(telemetryWritesTotal.WithLabelValues("success"))
+
+	fake := &fakePutter{}
+	tel := &CommunitySaaSTelemetry{client: fake, tableName: "test-table", version: "7.1.0", enabled: true, eventChan: make(chan telemetryEvent, 1)}
+	tel.writeEvent(telemetryEvent{tenantID: "cs_x", endpoint: "/api/request", method: "POST", statusCode: 200})
+
+	if v := testutil.ToFloat64(telemetryWritesTotal.WithLabelValues("success")); v != before+1 {
+		t.Errorf("success counter did not bump: was %v, now %v", before, v)
+	}
+}
+
+func TestWriteEvent_FailureBumpsCounter(t *testing.T) {
+	before := testutil.ToFloat64(telemetryWritesTotal.WithLabelValues("failure"))
+
+	fake := &fakePutter{err: errors.New("ThrottlingException")}
+	tel := &CommunitySaaSTelemetry{client: fake, tableName: "test-table", version: "7.1.0", enabled: true, eventChan: make(chan telemetryEvent, 1)}
+	tel.writeEvent(telemetryEvent{tenantID: "cs_x", endpoint: "/api/request", method: "POST", statusCode: 200})
+
+	if v := testutil.ToFloat64(telemetryWritesTotal.WithLabelValues("failure")); v != before+1 {
+		t.Errorf("failure counter did not bump: was %v, now %v", before, v)
+	}
+}
+
+func TestStartupCanary_RecordShape(t *testing.T) {
+	// The canary record must be identifiable so reporting can exclude it
+	// from real-usage counts: tenant_id="__canary__", correlation_id prefixed
+	// with "canary-", method="CANARY", endpoint="__startup_canary__".
+	fake := &fakePutter{}
+	tel := newWithClient(fake, "test-table", "7.1.0")
+	defer close(tel.eventChan)
+
+	if len(fake.calls) != 1 {
+		t.Fatalf("expected 1 canary call, got %d", len(fake.calls))
+	}
+	item := fake.calls[0].Item
+
+	if id := getStringAttr(t, item, "correlation_id"); !strings.HasPrefix(id, "canary-") {
+		t.Errorf("correlation_id should start with canary-, got %q", id)
+	}
+	if v := getStringAttr(t, item, "tenant_id"); v != "__canary__" {
+		t.Errorf("tenant_id want __canary__, got %q", v)
+	}
+	if v := getStringAttr(t, item, "method"); v != "CANARY" {
+		t.Errorf("method want CANARY, got %q", v)
+	}
+	if v := getStringAttr(t, item, "endpoint"); v != "__startup_canary__" {
+		t.Errorf("endpoint want __startup_canary__, got %q", v)
+	}
+	if v := getStringAttr(t, item, "source"); v != "community-saas" {
+		t.Errorf("source want community-saas, got %q", v)
+	}
 }
 
 func TestTelemetryMiddleware_ContextPropagation(t *testing.T) {

--- a/platform/agent/mcp_handler_test.go
+++ b/platform/agent/mcp_handler_test.go
@@ -874,12 +874,25 @@ func TestIsValidInternalServiceRequest_FallbackToken(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := serviceauth.IsValidInternalServiceRequest(tt.clientID, tt.token, nil)
+			got := serviceauth.IsValidInternalServiceRequest(tt.clientID, tt.token, nil, true)
 			if got != tt.want {
-				t.Errorf("IsValidInternalServiceRequest(%q, %q, nil) = %v, want %v",
+				t.Errorf("IsValidInternalServiceRequest(%q, %q, nil, true) = %v, want %v",
 					tt.clientID, tt.token, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestIsValidInternalServiceRequest_FallbackRejectedInStrictMode(t *testing.T) {
+	serviceauth.ResetWarnings()
+
+	// In strict mode (allowFallback=false, validator nil) every request must be rejected.
+	// This guards Enterprise deployments where a missing AXONFLOW_INTERNAL_SERVICE_SECRET
+	// must NOT silently let the literal TokenFallback through.
+	for _, tok := range []string{serviceauth.TokenFallback, "anything", ""} {
+		if serviceauth.IsValidInternalServiceRequest(serviceauth.ClientID, tok, nil, false) {
+			t.Errorf("expected rejection for token %q with nil validator + allowFallback=false", tok)
+		}
 	}
 }
 
@@ -932,9 +945,9 @@ func TestIsValidInternalServiceRequest_WithHMACToken(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			serviceauth.ResetWarnings()
-			got := serviceauth.IsValidInternalServiceRequest(tt.clientID, tt.token, val)
+			got := serviceauth.IsValidInternalServiceRequest(tt.clientID, tt.token, val, false)
 			if got != tt.want {
-				t.Errorf("IsValidInternalServiceRequest(%q, token, val) = %v, want %v",
+				t.Errorf("IsValidInternalServiceRequest(%q, token, val, false) = %v, want %v",
 					tt.clientID, got, tt.want)
 			}
 		})
@@ -956,7 +969,7 @@ func TestIsValidInternalServiceRequest_LegacyDeprecation(t *testing.T) {
 	val := serviceauth.NewTokenValidator(testSecret, clock, serviceauth.DefaultClockSkew)
 
 	// Sending the raw secret (legacy path) should be accepted but triggers deprecation warning
-	got := serviceauth.IsValidInternalServiceRequest(serviceauth.ClientID, testSecret, val)
+	got := serviceauth.IsValidInternalServiceRequest(serviceauth.ClientID, testSecret, val, false)
 	if !got {
 		t.Error("legacy plain-secret token should be accepted for backward compatibility")
 	}

--- a/platform/agent/policy_categories.go
+++ b/platform/agent/policy_categories.go
@@ -3,6 +3,10 @@
 
 package agent
 
+import (
+	sharedpolicy "axonflow/platform/shared/policy"
+)
+
 // PolicyCategory represents the category classification for policies.
 // Categories are used for organizing and filtering policies in the UI and API.
 type PolicyCategory string
@@ -202,25 +206,24 @@ const (
 	ActionLog OverrideAction = "log"
 )
 
-// AllOverrideActions returns all valid override actions.
+// AllOverrideActions returns all valid override actions. The canonical list
+// lives in platform/shared/policy.ValidOverrideActions; this function is a
+// typed view for callers using the local OverrideAction string-newtype. Both
+// the customer-portal override validator and this agent-side repository now
+// agree on the same set.
 func AllOverrideActions() []OverrideAction {
-	return []OverrideAction{
-		ActionBlock,
-		ActionRequireApproval,
-		ActionRedact,
-		ActionWarn,
-		ActionLog,
+	out := make([]OverrideAction, 0, len(sharedpolicy.ValidOverrideActions))
+	for _, a := range sharedpolicy.ValidOverrideActions {
+		out = append(out, OverrideAction(a))
 	}
+	return out
 }
 
-// IsValidOverrideAction returns true if the action is valid.
+// IsValidOverrideAction returns true if the action is valid. Delegates to the
+// canonical list in platform/shared/policy so the agent and the customer-portal
+// override validator can never drift.
 func IsValidOverrideAction(action OverrideAction) bool {
-	for _, a := range AllOverrideActions() {
-		if a == action {
-			return true
-		}
-	}
-	return false
+	return sharedpolicy.IsValidOverrideAction(string(action))
 }
 
 // ActionRestrictiveness returns the restrictiveness level of an action.

--- a/platform/agent/proxy.go
+++ b/platform/agent/proxy.go
@@ -285,6 +285,9 @@ func (h *ReverseProxyHandler) RegisterProxyRoutes(r *mux.Router) {
 	// MAS FEAT Compliance (Singapore) - Enterprise feature
 	r.PathPrefix("/api/v1/masfeat").HandlerFunc(orchAuth).Methods("GET", "POST", "PUT", "DELETE", "OPTIONS")
 
+	// EU AI Act Compliance (Europe) - Enterprise feature
+	r.PathPrefix("/api/v1/euaiact").HandlerFunc(orchAuth).Methods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+
 	// Workflow Control Plane (#834)
 	r.PathPrefix("/api/v1/workflows").HandlerFunc(orchAuth).Methods("GET", "POST", "PUT", "DELETE", "OPTIONS")
 
@@ -364,6 +367,7 @@ func IsProxiedPath(path string) bool {
 		strings.HasPrefix(path, "/api/v1/executions") ||
 		strings.HasPrefix(path, "/api/v1/audit") ||
 		strings.HasPrefix(path, "/api/v1/llm-providers") ||
+		strings.HasPrefix(path, "/api/v1/euaiact") ||
 		strings.HasPrefix(path, "/api/v1/masfeat") ||
 		strings.HasPrefix(path, "/api/v1/rbi") ||
 		strings.HasPrefix(path, "/api/v1/sebi") ||

--- a/platform/agent/proxy_test.go
+++ b/platform/agent/proxy_test.go
@@ -411,6 +411,15 @@ func TestIsProxiedPath(t *testing.T) {
 		{"/api/v1/executions/123", true},
 		{"/api/v1/llm-providers", true},
 		{"/api/v1/llm-providers/openai", true},
+		// Compliance modules — all four must proxy. Missing any one here
+		// is how #1646 (EU AI Act conformity 404) happened: euaiact was
+		// left out of IsProxiedPath while rbi/sebi/masfeat were listed.
+		{"/api/v1/euaiact/conformity", true},
+		{"/api/v1/euaiact/accuracy", true},
+		{"/api/v1/euaiact/export", true},
+		{"/api/v1/masfeat/registry", true},
+		{"/api/v1/rbi/ai-systems", true},
+		{"/api/v1/sebi/dashboard", true},
 		// Portal paths - auth
 		{"/api/v1/auth/login", true},
 		{"/api/v1/auth/logout", true},

--- a/platform/agent/run.go
+++ b/platform/agent/run.go
@@ -355,6 +355,14 @@ func substituteGrafanaPassword(sqlContent string) (string, error) {
 // This allows the health endpoint to respond immediately while initialization happens
 var appReady atomic.Bool
 
+// licenseTier is captured at license-validation time and surfaced in
+// /health so operators (and the setup-e2e-testing script's `jq .tier`
+// check) can distinguish Community / Evaluation / Professional /
+// Enterprise without hitting a separate license endpoint. Empty string
+// means "license not yet validated" (startup phase) or "community
+// build" (no license required).
+var licenseTier atomic.Value // string
+
 // Global router and server - allows health checks to pass immediately while initialization happens
 var (
 	globalRouter *mux.Router
@@ -404,6 +412,7 @@ func readinessAwareHealthHandler(w http.ResponseWriter, r *http.Request) {
 	if err := json.NewEncoder(w).Encode(map[string]interface{}{
 		"status":             status,
 		"service":            "axonflow-agent",
+		"tier":               currentLicenseTier(),
 		"timestamp":          time.Now().UTC(),
 		"version":            GetPlatformVersion(),
 		"capabilities":       getCapabilities(),
@@ -411,6 +420,23 @@ func readinessAwareHealthHandler(w http.ResponseWriter, r *http.Request) {
 	}); err != nil {
 		log.Printf("Error encoding health response: %v", err)
 	}
+}
+
+// currentLicenseTier returns the tier captured at license validation, or
+// "community" for builds that ran without a license (community mode).
+// Safe to call before initialization — returns "starting".
+func currentLicenseTier() string {
+	v := licenseTier.Load()
+	if v == nil {
+		if appReady.Load() {
+			return "community"
+		}
+		return "starting"
+	}
+	if s, ok := v.(string); ok && s != "" {
+		return s
+	}
+	return "community"
 }
 
 // Run is the exported entry point for the agent service.
@@ -480,6 +506,7 @@ func Run() {
 
 		log.Printf("✅ License validated successfully")
 		log.Printf("   Tier: %s", result.Tier)
+		licenseTier.Store(string(result.Tier))
 		log.Printf("   Org: %s", deploymentOrgID)
 		log.Printf("   Max Nodes: %d", result.MaxNodes)
 		log.Printf("   Expires: %s", result.ExpiresAt.Format("2006-01-02"))
@@ -1029,6 +1056,7 @@ func healthHandler(w http.ResponseWriter, r *http.Request) {
 	if err := json.NewEncoder(w).Encode(map[string]interface{}{
 		"status":             "healthy",
 		"service":            "axonflow-agent",
+		"tier":               currentLicenseTier(),
 		"timestamp":          time.Now().UTC(),
 		"version":            GetPlatformVersion(),
 		"capabilities":       getCapabilities(),

--- a/platform/agent/static_policy_api_handlers.go
+++ b/platform/agent/static_policy_api_handlers.go
@@ -98,6 +98,15 @@ func RegisterStaticPolicyHandlers(router *mux.Router, db *sql.DB) {
 	sub.HandleFunc("/{id}/override", handler.HandleDeleteOverride).Methods("DELETE")
 
 	log.Println("✅ Static Policy API routes registered (12 endpoints, auth-protected)")
+
+	// Canonical policy-overrides alias — customer-portal (and any external
+	// client looking for a tenant-wide override list) expects this path.
+	// Previously only /api/v1/static-policies/overrides was reachable, and
+	// the portal was hitting this path and getting 404s.
+	overridesAlias := router.PathPrefix("/api/v1/policy-overrides").Subrouter()
+	overridesAlias.Use(apiAuthMiddleware)
+	overridesAlias.HandleFunc("", handler.HandleListOverrides).Methods("GET")
+	log.Println("✅ Canonical /api/v1/policy-overrides alias registered (GET, auth-protected)")
 }
 
 // HandleListStaticPolicies handles GET /api/v1/static-policies

--- a/platform/orchestrator/Dockerfile
+++ b/platform/orchestrator/Dockerfile
@@ -136,7 +136,7 @@ RUN set -e && \
 # Final stage - minimal runtime image
 FROM alpine:3.23
 
-ARG AXONFLOW_VERSION=7.1.1
+ARG AXONFLOW_VERSION=7.2.0
 ENV AXONFLOW_VERSION=${AXONFLOW_VERSION}
 
 # AWS Marketplace metadata

--- a/platform/orchestrator/audit_logger.go
+++ b/platform/orchestrator/audit_logger.go
@@ -33,6 +33,7 @@ import (
 type auditSearchCriteria struct {
 	UserEmail   string
 	ClientID    string
+	TenantID    string
 	StartTime   time.Time
 	EndTime     time.Time
 	RequestType string
@@ -69,6 +70,10 @@ func asAuditSearchCriteria(criteria interface{}) (auditSearchCriteria, bool) {
 		case "ClientID":
 			if fv.Kind() == reflect.String {
 				out.ClientID = fv.String()
+			}
+		case "TenantID":
+			if fv.Kind() == reflect.String {
+				out.TenantID = fv.String()
 			}
 		case "StartTime":
 			if ts, ok := fv.Interface().(time.Time); ok {
@@ -544,6 +549,16 @@ func (l *AuditLogger) SearchAuditLogs(criteria interface{}) ([]*AuditEntry, erro
 		if searchReq.ClientID != "" {
 			query += fmt.Sprintf(" AND client_id = $%d", argIndex)
 			args = append(args, searchReq.ClientID)
+			argIndex++
+		}
+		// Tenant scoping. The handler force-injects this from the trusted
+		// X-Tenant-ID header; without it the search returned every tenant's
+		// audit logs to any caller (cross-tenant data leak: a portal user
+		// for tenant A could read tenant B's audit history simply by
+		// posting to /api/v1/audit/search).
+		if searchReq.TenantID != "" {
+			query += fmt.Sprintf(" AND tenant_id = $%d", argIndex)
+			args = append(args, searchReq.TenantID)
 			argIndex++
 		}
 		if !searchReq.StartTime.IsZero() {

--- a/platform/orchestrator/audit_tool_call_handler_test.go
+++ b/platform/orchestrator/audit_tool_call_handler_test.go
@@ -449,6 +449,7 @@ func TestAuditToolCallHandler_ProxyAuthTenantDiffers(t *testing.T) {
 func TestAuditToolCallHandler_NoProxyAuthNeededWithoutSecret(t *testing.T) {
 	// When proxyTokenValidator is nil (no AXONFLOW_INTERNAL_SERVICE_SECRET), proxy auth is skipped.
 	// This is the community/dev mode where orchestrator is accessed directly.
+	t.Setenv("DEPLOYMENT_MODE", "community")
 	origLogger := auditLogger
 	auditLogger = &AuditLogger{
 		auditQueue:   make(chan *AuditEntry, 100),
@@ -476,6 +477,43 @@ func TestAuditToolCallHandler_NoProxyAuthNeededWithoutSecret(t *testing.T) {
 
 	if rr.Code != http.StatusCreated {
 		t.Errorf("Expected status 201 in community mode without proxy auth, got %d. Body: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestAuditToolCallHandler_FailsClosedWhenSecretMissingInEnterpriseMode(t *testing.T) {
+	// When proxyTokenValidator is nil AND we are NOT in Community mode, every
+	// request must be rejected. Otherwise an Enterprise/SaaS rollout that forgot
+	// to set AXONFLOW_INTERNAL_SERVICE_SECRET would silently accept any caller
+	// who can reach the orchestrator directly, letting them spoof X-Org-ID for
+	// audit attribution against another tenant.
+	for _, mode := range []string{"enterprise", "community-saas", "in-vpc-enterprise"} {
+		t.Run(mode, func(t *testing.T) {
+			t.Setenv("DEPLOYMENT_MODE", mode)
+			origLogger := auditLogger
+			auditLogger = &AuditLogger{
+				auditQueue:   make(chan *AuditEntry, 100),
+				shutdownChan: make(chan struct{}),
+			}
+			origValidator := proxyTokenValidator
+			proxyTokenValidator = nil // simulate missing secret
+			defer func() {
+				auditLogger = origLogger
+				proxyTokenValidator = origValidator
+			}()
+
+			body, _ := json.Marshal(map[string]interface{}{"tool_name": "getUserInfo"})
+			req := httptest.NewRequest("POST", "/api/v1/audit/tool-call", bytes.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			setBasicAuth(req)
+
+			rr := httptest.NewRecorder()
+			auditToolCallHandler(rr, req)
+
+			if rr.Code != http.StatusForbidden {
+				t.Errorf("expected 403 when proxyTokenValidator is nil in %s mode, got %d. Body: %s",
+					mode, rr.Code, rr.Body.String())
+			}
+		})
 	}
 }
 

--- a/platform/orchestrator/cloudstorage/storage.go
+++ b/platform/orchestrator/cloudstorage/storage.go
@@ -125,8 +125,8 @@ type LocalConfig struct {
 }
 
 // NewStorageConfigFromEnv builds a StorageConfig from AUDIT_EXPORT_* environment variables.
-// This centralises the env-to-config mapping so that both platform/orchestrator/run.go
-// and ee/platform/orchestrator/compliance_init.go use the same logic.
+// Centralises the env-to-config mapping for every orchestrator caller that needs
+// a storage backend.
 func NewStorageConfigFromEnv() StorageConfig {
 	var gcsCredentialsJSON []byte
 	if v := os.Getenv("AUDIT_EXPORT_GCS_CREDENTIALS_JSON"); v != "" {

--- a/platform/orchestrator/cost_estimation_handler.go
+++ b/platform/orchestrator/cost_estimation_handler.go
@@ -99,10 +99,13 @@ func estimatePlanCostHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Enforce daily rate limit per tenant (after validation)
-	tenantID := r.Header.Get("X-Tenant-ID")
+	// Enforce daily rate limit per tenant (after validation). Fail closed on
+	// missing tenant scope rather than sharing a `_default` global bucket
+	// across all unauthenticated callers (#1623 retro): every legitimate
+	// caller flows through the AxonFlow Agent gateway which sets X-Tenant-ID.
+	tenantID := resolveTenantOrFail(w, r, "cost/estimate")
 	if tenantID == "" {
-		tenantID = "_default"
+		return // resolveTenantOrFail already wrote a 401
 	}
 	if tierChecker != nil {
 		limit := tierChecker.MaxCostEstimatesPerDay()
@@ -184,10 +187,11 @@ func getPlanCostHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Enforce daily rate limit per tenant (after input validation)
-	tenantID := r.Header.Get("X-Tenant-ID")
+	// Enforce daily rate limit per tenant (after input validation). See
+	// resolveTenantOrFail rationale at the parallel call site above.
+	tenantID := resolveTenantOrFail(w, r, "cost/estimate-plan")
 	if tenantID == "" {
-		tenantID = "_default"
+		return // resolveTenantOrFail already wrote a 401
 	}
 	if tierChecker != nil {
 		limit := tierChecker.MaxCostEstimatesPerDay()

--- a/platform/orchestrator/cost_estimation_handler_test.go
+++ b/platform/orchestrator/cost_estimation_handler_test.go
@@ -38,6 +38,7 @@ func TestEstimatePlanCostHandler_Success(t *testing.T) {
 
 	bodyBytes, _ := json.Marshal(body)
 	req := httptest.NewRequest("POST", "/api/v1/plans/estimate", bytes.NewReader(bodyBytes))
+	req.Header.Set("X-Tenant-ID", "test-tenant")
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 
@@ -75,6 +76,7 @@ func TestEstimatePlanCostHandler_EmptySteps(t *testing.T) {
 	body := CostEstimateRequest{Steps: []WorkflowStep{}}
 	bodyBytes, _ := json.Marshal(body)
 	req := httptest.NewRequest("POST", "/api/v1/plans/estimate", bytes.NewReader(bodyBytes))
+	req.Header.Set("X-Tenant-ID", "test-tenant")
 	w := httptest.NewRecorder()
 
 	estimatePlanCostHandler(w, req)
@@ -95,6 +97,7 @@ func TestEstimatePlanCostHandler_NoPlanningEngine(t *testing.T) {
 	}
 	bodyBytes, _ := json.Marshal(body)
 	req := httptest.NewRequest("POST", "/api/v1/plans/estimate", bytes.NewReader(bodyBytes))
+	req.Header.Set("X-Tenant-ID", "test-tenant")
 	w := httptest.NewRecorder()
 
 	estimatePlanCostHandler(w, req)
@@ -126,6 +129,7 @@ func TestEstimatePlanCostHandler_DefaultProviderFromRequest(t *testing.T) {
 	}
 	bodyBytes, _ := json.Marshal(body)
 	req := httptest.NewRequest("POST", "/api/v1/plans/estimate", bytes.NewReader(bodyBytes))
+	req.Header.Set("X-Tenant-ID", "test-tenant")
 	w := httptest.NewRecorder()
 
 	estimatePlanCostHandler(w, req)

--- a/platform/orchestrator/dynamic_policy_handlers.go
+++ b/platform/orchestrator/dynamic_policy_handlers.go
@@ -15,6 +15,7 @@ import (
 	"encoding/json"
 	"log"
 	"net/http"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -612,10 +613,23 @@ func (h *DynamicPolicyAPIHandler) handleCORS(w http.ResponseWriter, r *http.Requ
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// isValidPolicyID accepts UUIDs and system policy IDs (sys_* prefix).
+// isValidPolicyID accepts UUIDs, system policy IDs (sys_* prefix), and the
+// legacy snake_case identifiers used by migration 010_policy_tables.sql
+// (e.g. "sensitive_data_control") that pre-date the sys_* convention.
+// Without the legacy form every Test / Edit / Delete / Versions action on
+// those policies 400s with "Invalid policy ID format".
+//
+// The pattern is intentionally narrow — letters, digits, underscores, hyphens —
+// to keep the validator a defense-in-depth check; the actual SQL lookups are
+// parameterized.
+var legacyPolicyIDPattern = regexp.MustCompile(`^[a-z][a-z0-9_-]{1,127}$`)
+
 func isValidPolicyID(id string) bool {
 	if _, err := uuid.Parse(id); err == nil {
 		return true
 	}
-	return strings.HasPrefix(id, "sys_")
+	if strings.HasPrefix(id, "sys_") {
+		return true
+	}
+	return legacyPolicyIDPattern.MatchString(id)
 }

--- a/platform/orchestrator/dynamic_policy_handlers_test.go
+++ b/platform/orchestrator/dynamic_policy_handlers_test.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -320,7 +321,10 @@ func TestDynamicPolicyAPI_GetDynamicPolicy_InvalidID(t *testing.T) {
 	r := mux.NewRouter()
 	handler.RegisterRoutes(r)
 
-	req := httptest.NewRequest("GET", "/api/v1/dynamic-policies/not-a-uuid", nil)
+	// "BAD_ID!" — uppercase + bang — fails UUID parse, sys_* prefix, AND the
+	// legacy snake-case regex (^[a-z][a-z0-9_-]+$). Plain "not-a-uuid" is now
+	// a legitimate legacy ID (e.g. sensitive_data_control from migration 010).
+	req := httptest.NewRequest("GET", "/api/v1/dynamic-policies/BAD_ID%21", nil)
 	req.Header.Set("X-Tenant-ID", "test-tenant")
 	w := httptest.NewRecorder()
 
@@ -1670,4 +1674,92 @@ func TestDynamicPolicyAPI_Effective_Options(t *testing.T) {
 	if w.Code != http.StatusNoContent {
 		t.Errorf("Expected status 204, got %d", w.Code)
 	}
+}
+
+// TestIsValidPolicyID locks in the three ID shapes the handler must accept
+// and the shapes it must reject. Without the legacy snake_case branch, every
+// Test / Edit / Delete / Versions action on policies seeded by
+// migrations/core/010_policy_tables.sql (e.g. sensitive_data_control,
+// high_risk_block, sql_injection_union) 400s with "Invalid policy ID format".
+// These tests exist so the next refactor can't silently bring that
+// regression back.
+func TestIsValidPolicyID(t *testing.T) {
+	t.Run("accepts valid UUIDs", func(t *testing.T) {
+		for _, id := range []string{
+			"550e8400-e29b-41d4-a716-446655440000",
+			"00000000-0000-0000-0000-000000000000",
+			"AABBCCDD-AABB-CCDD-AABB-CCDDEEFF0011", // uppercase hex accepted by uuid.Parse
+		} {
+			if !isValidPolicyID(id) {
+				t.Errorf("UUID %q should be valid", id)
+			}
+		}
+	})
+
+	t.Run("accepts sys_* prefix", func(t *testing.T) {
+		for _, id := range []string{
+			"sys_pii_ssn",
+			"sys_dyn_tenant_isolation", // seeded in a later migration
+			"sys_media_pii",
+		} {
+			if !isValidPolicyID(id) {
+				t.Errorf("sys_* id %q should be valid", id)
+			}
+		}
+	})
+
+	t.Run("accepts legacy snake_case seed IDs (migration 010)", func(t *testing.T) {
+		// Exact identifiers seeded by migrations/core/010_policy_tables.sql.
+		// Verified against the SQL INSERT statements — do not replace with
+		// synthetic names; these are the real IDs users will click on.
+		for _, id := range []string{
+			// dynamic_policies seeds
+			"high_risk_block",
+			"sensitive_data_control",
+			// static_policies seeds
+			"sql_injection_union",
+			"sql_injection_or",
+			"drop_table_prevention",
+			"truncate_prevention",
+			"pii_ssn_detection",
+			// shape coverage (not real seeds, but within the regex)
+			"a-b-c",      // hyphens allowed
+			"policy_1_2", // digits allowed
+		} {
+			if !isValidPolicyID(id) {
+				t.Errorf("legacy seed id %q should be valid (accepted by ^[a-z][a-z0-9_-]{1,127}$)", id)
+			}
+		}
+	})
+
+	t.Run("accepts 128-char legacy ID boundary", func(t *testing.T) {
+		// Regex is ^[a-z][a-z0-9_-]{1,127}$ — total length 2..128. Confirm
+		// the upper bound explicitly so a future tweak to the quantifier
+		// surfaces immediately.
+		boundary := "a" + strings.Repeat("b", 127) // 128 chars total
+		if !isValidPolicyID(boundary) {
+			t.Errorf("128-char legacy id should be valid; got rejection for len=%d", len(boundary))
+		}
+	})
+
+	t.Run("rejects obviously invalid inputs", func(t *testing.T) {
+		for _, id := range []string{
+			"",                             // empty
+			"a",                            // single char — regex requires min length 2 (first char + at least 1 more)
+			"UPPERCASE_ID",                 // caps forbidden — prevents accidental matches on arbitrary headers
+			"123leading_digit",             // must start with letter
+			"name with spaces",             // space forbidden
+			"name\nwith\nnewline",          // newline forbidden
+			"name;drop_table",              // semicolon forbidden
+			"_leading_underscore",          // must start with [a-z]
+			"-leading-hyphen",              // must start with [a-z]
+			"' OR 1=1 --",                  // SQLi-ish; SQL is parameterized but the validator is the outer guard
+			"a" + strings.Repeat("b", 128), // 129 chars — over the 128 cap
+			"café",                         // non-ASCII outside [a-z0-9_-]
+		} {
+			if isValidPolicyID(id) {
+				t.Errorf("invalid id %q (len %d) should be rejected", id, len(id))
+			}
+		}
+	})
 }

--- a/platform/orchestrator/evidence_export_handler.go
+++ b/platform/orchestrator/evidence_export_handler.go
@@ -62,6 +62,34 @@ func (rl *exportRateLimiter) tryConsume(tenantID string, limit int) (bool, int) 
 	return true, current + 1
 }
 
+// resolveTenantOrFail resolves the tenant scope for a compliance/evidence
+// request. The X-Tenant-ID header is the trusted, proxy-injected value (set by
+// apiAuthMiddleware after authentication); the request context is a
+// belt-and-braces fallback for paths that don't traverse the proxy.
+//
+// If neither produces a non-empty tenant, the function writes a 401 to w and
+// returns "". Callers MUST early-return on the empty result. We fail closed:
+// the alternative (running the SQL with `tenant_id = ”`) currently happens to
+// return zero rows but quietly burns the daily export quota for an empty
+// tenant bucket and would silently leak data the moment a downstream query
+// stops filtering on tenant_id. Per #1623 retro: explicit 401, no implicit
+// degrade.
+func resolveTenantOrFail(w http.ResponseWriter, r *http.Request, endpoint string) string {
+	tenantID := r.Header.Get("X-Tenant-ID")
+	if tenantID == "" {
+		if tid, ok := r.Context().Value("tenant_id").(string); ok {
+			tenantID = tid
+		}
+	}
+	if tenantID == "" {
+		log.Printf("[%s] BLOCKED: tenant scope missing from X-Tenant-ID header and request context", endpoint)
+		writeJSONError(w, http.StatusUnauthorized, "TENANT_REQUIRED",
+			"X-Tenant-ID header is required for this endpoint (set by the AxonFlow Agent gateway).")
+		return ""
+	}
+	return tenantID
+}
+
 // NewEvidenceExportHandler creates a new evidence export handler.
 func NewEvidenceExportHandler(db *sql.DB, tierChecker LicenseChecker) *EvidenceExportHandler {
 	return &EvidenceExportHandler{
@@ -102,11 +130,9 @@ func (h *EvidenceExportHandler) ExportEvidence(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	tenantID := r.Header.Get("X-Tenant-ID")
+	tenantID := resolveTenantOrFail(w, r, "evidence/export")
 	if tenantID == "" {
-		if tid, ok := r.Context().Value("tenant_id").(string); ok {
-			tenantID = tid
-		}
+		return // resolveTenantOrFail already wrote a 401
 	}
 
 	// Rate limit
@@ -237,11 +263,9 @@ func (h *EvidenceExportHandler) GetEvidenceSummary(w http.ResponseWriter, r *htt
 		return
 	}
 
-	tenantID := r.Header.Get("X-Tenant-ID")
+	tenantID := resolveTenantOrFail(w, r, "evidence/summary")
 	if tenantID == "" {
-		if tid, ok := r.Context().Value("tenant_id").(string); ok {
-			tenantID = tid
-		}
+		return // resolveTenantOrFail already wrote a 401
 	}
 
 	windowDays := h.tierChecker.MaxEvidenceWindowDays()

--- a/platform/orchestrator/evidence_export_handler_test.go
+++ b/platform/orchestrator/evidence_export_handler_test.go
@@ -863,3 +863,70 @@ func TestEvalDisclaimer(t *testing.T) {
 		t.Errorf("Unexpected disclaimer: %s", evalDisclaimer)
 	}
 }
+
+func TestExportEvidence_RequiresTenant(t *testing.T) {
+	checker := &mockLicenseCheckerForSim{
+		tier:                     license.TierEvaluation,
+		evidenceExportEnabled:    true,
+		maxEvidenceExportsPerDay: 3,
+		maxEvidenceExportRecords: 5000,
+		maxEvidenceWindowDays:    14,
+	}
+	handler := NewEvidenceExportHandler(nil, checker)
+	handler.rateLimiter = &exportRateLimiter{
+		counts:  make(map[string]int),
+		resetAt: nextUTCMidnight(),
+	}
+
+	body, _ := json.Marshal(EvidenceExportRequest{StartDate: "2026-02-01"})
+	req := httptest.NewRequest("POST", "/api/v1/evidence/export", bytes.NewReader(body))
+	// Deliberately do NOT set X-Tenant-ID and do NOT seed tenant_id in context.
+	w := httptest.NewRecorder()
+
+	handler.ExportEvidence(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("Expected 401 when tenant scope is missing, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var errResp map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&errResp); err != nil {
+		t.Fatalf("Failed to decode error response: %v", err)
+	}
+	if errResp["code"] != "TENANT_REQUIRED" {
+		t.Errorf("Expected error code TENANT_REQUIRED, got %q", errResp["code"])
+	}
+
+	// Confirm rate limiter was NOT bumped — would have cost the empty bucket
+	// a slot under the old behavior.
+	if got := handler.rateLimiter.counts[""]; got != 0 {
+		t.Errorf("Expected empty-tenant bucket to remain at 0, got %d", got)
+	}
+}
+
+func TestGetEvidenceSummary_RequiresTenant(t *testing.T) {
+	checker := &mockLicenseCheckerForSim{
+		tier:                  license.TierEvaluation,
+		evidenceExportEnabled: true,
+		maxEvidenceWindowDays: 14,
+	}
+	handler := NewEvidenceExportHandler(nil, checker)
+
+	req := httptest.NewRequest("GET", "/api/v1/evidence/summary", nil)
+	// Deliberately no tenant header, no context.
+	w := httptest.NewRecorder()
+
+	handler.GetEvidenceSummary(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("Expected 401 when tenant scope is missing, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var errResp map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&errResp); err != nil {
+		t.Fatalf("Failed to decode error response: %v", err)
+	}
+	if errResp["code"] != "TENANT_REQUIRED" {
+		t.Errorf("Expected error code TENANT_REQUIRED, got %q", errResp["code"])
+	}
+}

--- a/platform/orchestrator/explain_handler.go
+++ b/platform/orchestrator/explain_handler.go
@@ -19,18 +19,18 @@ import (
 // Additive fields may be added with omitempty; renames/removals require
 // a major version bump.
 type DecisionExplanation struct {
-	DecisionID                string             `json:"decision_id"`
-	Timestamp                 time.Time          `json:"timestamp"`
-	PolicyMatches             []ExplainPolicy    `json:"policy_matches"`
-	MatchedRules              []ExplainRule      `json:"matched_rules,omitempty"`
-	Decision                  string             `json:"decision"` // "allow"|"deny"|"require_approval"
-	Reason                    string             `json:"reason"`
-	RiskLevel                 string             `json:"risk_level,omitempty"`
-	OverrideAvailable         bool               `json:"override_available"`
-	OverrideExistingID        string             `json:"override_existing_id,omitempty"`
-	HistoricalHitCountSession int                `json:"historical_hit_count_session"`
-	PolicySourceLink          string             `json:"policy_source_link,omitempty"`
-	ToolSignature             string             `json:"tool_signature,omitempty"`
+	DecisionID                string          `json:"decision_id"`
+	Timestamp                 time.Time       `json:"timestamp"`
+	PolicyMatches             []ExplainPolicy `json:"policy_matches"`
+	MatchedRules              []ExplainRule   `json:"matched_rules,omitempty"`
+	Decision                  string          `json:"decision"` // "allow"|"deny"|"require_approval"
+	Reason                    string          `json:"reason"`
+	RiskLevel                 string          `json:"risk_level,omitempty"`
+	OverrideAvailable         bool            `json:"override_available"`
+	OverrideExistingID        string          `json:"override_existing_id,omitempty"`
+	HistoricalHitCountSession int             `json:"historical_hit_count_session"`
+	PolicySourceLink          string          `json:"policy_source_link,omitempty"`
+	ToolSignature             string          `json:"tool_signature,omitempty"`
 }
 
 // ExplainPolicy is a policy reference returned inside an explanation.
@@ -70,8 +70,22 @@ func explainDecisionHandler(w http.ResponseWriter, r *http.Request) {
 		callerEmail = r.Header.Get("X-User-ID")
 	}
 	callerTenant := r.Header.Get("X-Tenant-ID")
+	if callerTenant == "" {
+		// Fail closed (#1623 retro): without a trusted tenant scope on the
+		// request, post-fetch authorization could be bypassed by simply
+		// omitting the header — the entryUserEmail==callerEmail short-circuit
+		// would also pass for an attacker spoofing X-User-Email. Require the
+		// header explicitly; the AxonFlow Agent gateway always sets it after
+		// authentication.
+		sendErrorResponse(w, "X-Tenant-ID header is required", http.StatusUnauthorized)
+		return
+	}
 
-	// Look up the audit entry by decision_id.
+	// Look up the audit entry by (decision_id, tenant_id). Filtering tenant in
+	// the SELECT makes cross-tenant reads structurally impossible — earlier
+	// the WHERE was decision_id only and authorization was a post-fetch
+	// comparison, which silently failed open whenever entryUserEmail was NULL
+	// (no .Valid skip path) or whenever the same email existed across tenants.
 	// policy_details JSONB contains decision_id; we use a functional index.
 	// The reason string is kept inside policy_details → reason, not a direct
 	// audit_logs column, so the SELECT list has five projections and the
@@ -88,11 +102,15 @@ func explainDecisionHandler(w http.ResponseWriter, r *http.Request) {
 		SELECT user_email, tenant_id, timestamp, policy_decision, policy_details
 		FROM audit_logs
 		WHERE policy_details->>'decision_id' = $1
+		  AND tenant_id = $2
 		ORDER BY timestamp DESC LIMIT 1
-	`, decisionID).Scan(&entryUserEmail, &entryTenant, &entryTime,
+	`, decisionID, callerTenant).Scan(&entryUserEmail, &entryTenant, &entryTime,
 		&entryDecision, &entryDetails)
 
 	if err == sql.ErrNoRows {
+		// 404 (rather than 403) so the response shape is identical for
+		// "decision doesn't exist in your tenant" and "decision exists in a
+		// different tenant" — denies an enumeration oracle.
 		sendErrorResponse(w, "Decision not found or past retention window", http.StatusNotFound)
 		return
 	}
@@ -102,14 +120,25 @@ func explainDecisionHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Authorization: caller can explain only their own decisions unless they
-	// belong to the same tenant (admin authz is out of scope for this handler
-	// and deferred to a dedicated policy adapter).
+	// Per-user authorization within the tenant: a caller can explain only their
+	// own decisions, or any decision in the same tenant if they're a peer.
+	// (Admin authz is deferred to a dedicated policy adapter.) The SELECT above
+	// already guarantees same-tenant; this block is the additional within-
+	// tenant scoping. Defense in depth: also reject if entryTenant somehow
+	// disagrees with callerTenant (should be impossible after the WHERE clause,
+	// but guards against a future SELECT change).
+	if entryTenant.Valid && entryTenant.String != callerTenant {
+		log.Printf("explain decision: SELECT/auth mismatch: entry_tenant=%q caller_tenant=%q",
+			entryTenant.String, callerTenant)
+		sendErrorResponse(w, "Not authorized to explain this decision", http.StatusForbidden)
+		return
+	}
 	if entryUserEmail.Valid && entryUserEmail.String != callerEmail {
-		if !entryTenant.Valid || entryTenant.String != callerTenant {
-			sendErrorResponse(w, "Not authorized to explain this decision", http.StatusForbidden)
-			return
-		}
+		// Different user inside the same tenant — for now treat as allowed
+		// (peer visibility within a tenant is the existing contract).
+		// Hook for stricter future enforcement: enforce here when the policy
+		// adapter is wired.
+		_ = entryUserEmail.String
 	}
 
 	// Parse policy_details JSON.

--- a/platform/orchestrator/explain_handler_test.go
+++ b/platform/orchestrator/explain_handler_test.go
@@ -4,8 +4,14 @@
 package orchestrator
 
 import (
+	"database/sql"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/gorilla/mux"
 )
 
 func TestBuildExplanation_EmptyDetails(t *testing.T) {
@@ -151,5 +157,73 @@ func TestBuildExplanation_ExtractsReason(t *testing.T) {
 	}
 	if exp.Decision != "require_approval" {
 		t.Errorf("Decision = %q", exp.Decision)
+	}
+}
+
+func TestExplainDecision_RequiresTenantHeader(t *testing.T) {
+	req := httptest.NewRequest("GET", "/api/v1/decisions/dec-1/explain", nil)
+	req = mux.SetURLVars(req, map[string]string{"id": "dec-1"})
+	// Deliberately no X-Tenant-ID
+	req.Header.Set("X-User-Email", "alice@example.com")
+	w := httptest.NewRecorder()
+
+	explainDecisionHandler(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 when X-Tenant-ID missing, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestExplainDecision_RequiresDecisionID(t *testing.T) {
+	req := httptest.NewRequest("GET", "/api/v1/decisions//explain", nil)
+	req = mux.SetURLVars(req, map[string]string{"id": ""})
+	req.Header.Set("X-Tenant-ID", "tenant-a")
+	req.Header.Set("X-User-Email", "alice@example.com")
+	w := httptest.NewRecorder()
+
+	explainDecisionHandler(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 when decision_id missing, got %d", w.Code)
+	}
+}
+
+func TestExplainDecision_CrossTenantReturns404(t *testing.T) {
+	// Setup mock DB. The explain handler uses the package-level usageDB; swap it
+	// for a sqlmock instance for the duration of this test.
+	mockDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer mockDB.Close()
+
+	origDB := usageDB
+	usageDB = mockDB
+	defer func() { usageDB = origDB }()
+
+	// The fix: tenant_id filter is in the SELECT. A request for decision dec-1
+	// from tenant-b must not return rows that belong to tenant-a — the SQL must
+	// receive both decisionID and tenantID as positional args, and the mock
+	// responds with ErrNoRows. The handler must surface that as 404 (not 403)
+	// so attackers cannot enumerate decision_id existence across tenants.
+	mock.ExpectQuery(`SELECT user_email, tenant_id, timestamp, policy_decision, policy_details`).
+		WithArgs("dec-1", "tenant-b").
+		WillReturnError(sql.ErrNoRows)
+
+	req := httptest.NewRequest("GET", "/api/v1/decisions/dec-1/explain", nil)
+	req = mux.SetURLVars(req, map[string]string{"id": "dec-1"})
+	req.Header.Set("X-Tenant-ID", "tenant-b")
+	req.Header.Set("X-User-Email", "bob@example.com")
+	w := httptest.NewRecorder()
+
+	explainDecisionHandler(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 when decision belongs to different tenant, got %d: %s",
+			w.Code, w.Body.String())
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("sqlmock expectations: %v", err)
 	}
 }

--- a/platform/orchestrator/plugin_batch1_coverage_test.go
+++ b/platform/orchestrator/plugin_batch1_coverage_test.go
@@ -209,7 +209,7 @@ func TestCreateOverrideHandler_RejectsCriticalRisk(t *testing.T) {
 		mock.ExpectQuery("SELECT risk_level, allow_override, id::text").
 			WithArgs("pol-crit").
 			WillReturnRows(sqlmock.NewRows([]string{"risk_level", "allow_override", "id"}).
-			AddRow("critical", false, "00000000-0000-0000-0000-000000000001"))
+				AddRow("critical", false, "00000000-0000-0000-0000-000000000001"))
 
 		body, _ := json.Marshal(CreateOverrideRequest{
 			PolicyID: "pol-crit", PolicyType: "static", OverrideReason: "test",
@@ -231,7 +231,7 @@ func TestCreateOverrideHandler_RejectsAllowOverrideFalse(t *testing.T) {
 		mock.ExpectQuery("SELECT COALESCE\\(risk_level").
 			WithArgs("pol-1").
 			WillReturnRows(sqlmock.NewRows([]string{"risk_level", "allow_override", "id"}).
-			AddRow("medium", false, "00000000-0000-0000-0000-000000000001"))
+				AddRow("medium", false, "00000000-0000-0000-0000-000000000001"))
 
 		body, _ := json.Marshal(CreateOverrideRequest{
 			PolicyID: "pol-1", PolicyType: "dynamic", OverrideReason: "test",
@@ -304,8 +304,9 @@ func TestExplainDecisionHandler_RequiresID(t *testing.T) {
 
 func TestExplainDecisionHandler_NotFound(t *testing.T) {
 	withUsageDB(t, func(mock sqlmock.Sqlmock) {
+		// SELECT now binds (decisionID, callerTenant) — see #1623 retro fix.
 		mock.ExpectQuery("SELECT user_email.+FROM audit_logs WHERE").
-			WithArgs("dec-missing").
+			WithArgs("dec-missing", "tenant-x").
 			WillReturnError(sql.ErrNoRows)
 
 		req := httptest.NewRequest("GET", "/api/v1/decisions/dec-missing/explain", nil)
@@ -328,7 +329,7 @@ func TestExplainDecisionHandler_HappyPath(t *testing.T) {
 		ts := time.Now().UTC()
 		details := `{"policy_matches":[{"policy_id":"p-1","policy_name":"Test","risk_level":"medium","allow_override":true}],"tool_signature":"Bash"}`
 		mock.ExpectQuery("SELECT user_email.+FROM audit_logs WHERE").
-			WithArgs("dec-1").
+			WithArgs("dec-1", "tenant-x").
 			WillReturnRows(sqlmock.NewRows([]string{
 				"user_email", "tenant_id", "timestamp", "policy_decision", "policy_details",
 			}).AddRow("dev@x.com", "tenant-x", ts, "blocked", details))
@@ -369,14 +370,17 @@ func TestExplainDecisionHandler_HappyPath(t *testing.T) {
 	})
 }
 
-func TestExplainDecisionHandler_CrossTenantForbidden(t *testing.T) {
+// TestExplainDecisionHandler_CrossTenantReturnsNoOracle is the post-fix
+// equivalent of the old _CrossTenantForbidden test. With tenant_id baked into
+// the SELECT, an attacker in tenant-x simply cannot SELECT a row from
+// tenant-other — the SQL returns ErrNoRows and the handler responds 404 so
+// the existence of dec-1 in another tenant cannot be inferred from the
+// response code.
+func TestExplainDecisionHandler_CrossTenantReturnsNoOracle(t *testing.T) {
 	withUsageDB(t, func(mock sqlmock.Sqlmock) {
-		ts := time.Now().UTC()
 		mock.ExpectQuery("SELECT user_email.+FROM audit_logs WHERE").
-			WithArgs("dec-1").
-			WillReturnRows(sqlmock.NewRows([]string{
-				"user_email", "tenant_id", "timestamp", "policy_decision", "policy_details",
-			}).AddRow("owner@other.com", "tenant-other", ts, "blocked", "{}"))
+			WithArgs("dec-1", "tenant-x").
+			WillReturnError(sql.ErrNoRows)
 
 		req := httptest.NewRequest("GET", "/api/v1/decisions/dec-1/explain", nil)
 		req = mux.SetURLVars(req, map[string]string{"id": "dec-1"})
@@ -385,8 +389,8 @@ func TestExplainDecisionHandler_CrossTenantForbidden(t *testing.T) {
 		rr := httptest.NewRecorder()
 		explainDecisionHandler(rr, req)
 
-		if rr.Code != http.StatusForbidden {
-			t.Errorf("status = %d, want 403", rr.Code)
+		if rr.Code != http.StatusNotFound {
+			t.Errorf("status = %d, want 404 (no enumeration oracle)", rr.Code)
 		}
 	})
 }
@@ -916,7 +920,7 @@ func TestListOverridesHandler_QueryError(t *testing.T) {
 func TestExplainDecisionHandler_LookupError(t *testing.T) {
 	withUsageDB(t, func(mock sqlmock.Sqlmock) {
 		mock.ExpectQuery("SELECT user_email.+FROM audit_logs WHERE").
-			WithArgs("dec-1").
+			WithArgs("dec-1", "tenant-x").
 			WillReturnError(sql.ErrConnDone)
 
 		req := httptest.NewRequest("GET", "/api/v1/decisions/dec-1/explain", nil)
@@ -932,28 +936,29 @@ func TestExplainDecisionHandler_LookupError(t *testing.T) {
 	})
 }
 
-// TestExplainDecisionHandler_ForbiddenCrossTenant locks in the access
-// control: a caller whose email and tenant both differ from the owning
-// audit entry cannot explain someone else's decision.
-func TestExplainDecisionHandler_ForbiddenCrossTenant(t *testing.T) {
+// TestExplainDecisionHandler_CrossTenantReturns404 locks in the access
+// control: a caller from tenant-b who asks about a decision that lives in
+// tenant-a gets 404 (not 403). The fix moved tenant filtering into the SELECT
+// (was previously a post-fetch comparison), so cross-tenant requests return
+// no rows and surface as 404 — denying an enumeration oracle that 403 would
+// otherwise leak ("this ID exists, but not for you").
+func TestExplainDecisionHandler_CrossTenantReturns404(t *testing.T) {
 	withUsageDB(t, func(mock sqlmock.Sqlmock) {
-		rows := sqlmock.NewRows([]string{
-			"user_email", "tenant_id", "timestamp", "policy_decision", "policy_details",
-		}).AddRow("alice@a.com", "tenant-a", time.Now(), "deny", `{"reason":"pol blocked"}`)
-
+		// SELECT now takes (decisionID, callerTenant). Caller is tenant-b, so
+		// tenant-a's row is structurally unreachable — sqlmock returns ErrNoRows.
 		mock.ExpectQuery("SELECT user_email.+FROM audit_logs WHERE").
-			WithArgs("dec-1").
-			WillReturnRows(rows)
+			WithArgs("dec-1", "tenant-b").
+			WillReturnError(sql.ErrNoRows)
 
 		req := httptest.NewRequest("GET", "/api/v1/decisions/dec-1/explain", nil)
 		req = mux.SetURLVars(req, map[string]string{"id": "dec-1"})
-		req.Header.Set("X-Tenant-ID", "tenant-b")       // different tenant
-		req.Header.Set("X-User-Email", "bob@b.com")    // different caller
+		req.Header.Set("X-Tenant-ID", "tenant-b")   // different tenant
+		req.Header.Set("X-User-Email", "bob@b.com") // different caller
 		rr := httptest.NewRecorder()
 		explainDecisionHandler(rr, req)
 
-		if rr.Code != http.StatusForbidden {
-			t.Errorf("status = %d, want 403; body=%s", rr.Code, rr.Body.String())
+		if rr.Code != http.StatusNotFound {
+			t.Errorf("status = %d, want 404; body=%s", rr.Code, rr.Body.String())
 		}
 	})
 }
@@ -994,5 +999,3 @@ func TestApplyOverrideToResult_HappyPath(t *testing.T) {
 		}
 	})
 }
-
-

--- a/platform/orchestrator/policy_api_handlers.go
+++ b/platform/orchestrator/policy_api_handlers.go
@@ -156,11 +156,19 @@ func (h *PolicyAPIHandler) createPolicy(w http.ResponseWriter, r *http.Request, 
 func (h *PolicyAPIHandler) listPolicies(w http.ResponseWriter, r *http.Request, tenantID string) {
 	params := ListPoliciesParams{
 		Type:     r.URL.Query().Get("type"),
+		Category: r.URL.Query().Get("category"),
 		Search:   r.URL.Query().Get("search"),
 		SortBy:   r.URL.Query().Get("sort_by"),
 		SortDir:  r.URL.Query().Get("sort_dir"),
 		Page:     1,
 		PageSize: 20,
+	}
+
+	// Tier filter: query string -> *PolicyTier (only set when caller asked,
+	// so the repo can distinguish "filter by tier=system" from "no tier filter").
+	if tierStr := r.URL.Query().Get("tier"); tierStr != "" {
+		t := PolicyTier(tierStr)
+		params.Tier = &t
 	}
 
 	if pageStr := r.URL.Query().Get("page"); pageStr != "" {

--- a/platform/orchestrator/policy_api_handlers_test.go
+++ b/platform/orchestrator/policy_api_handlers_test.go
@@ -402,7 +402,10 @@ func TestPolicyAPIHandler_HandlePolicyByID_InvalidUUID(t *testing.T) {
 	mock := &mockPolicyService{}
 	handler := NewPolicyAPIHandler(mock)
 
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/policies/not-a-uuid", nil)
+	// "Bad ID!" — uppercase + space + bang — fails UUID parse, sys_* prefix,
+	// AND the legacy snake-case regex. Plain "not-a-uuid" is now a legitimate
+	// legacy ID (e.g. sensitive_data_control from migration 010).
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/policies/Bad%20ID%21", nil)
 	req.Header.Set("X-Tenant-ID", "tenant-123")
 	w := httptest.NewRecorder()
 

--- a/platform/orchestrator/policy_api_repository.go
+++ b/platform/orchestrator/policy_api_repository.go
@@ -175,6 +175,15 @@ func (r *PolicyRepository) List(ctx context.Context, tenantID string, params Lis
 		argIndex++
 	}
 
+	// Tier filter (system / organization / tenant). The handler only sets
+	// params.Tier when the caller supplied ?tier=... in the query string,
+	// so a nil pointer means "no tier filter" rather than "tier=''".
+	if params.Tier != nil && *params.Tier != "" {
+		whereConditions = append(whereConditions, fmt.Sprintf("tier = $%d", argIndex))
+		args = append(args, string(*params.Tier))
+		argIndex++
+	}
+
 	if params.Search != "" {
 		whereConditions = append(whereConditions, fmt.Sprintf("(name ILIKE $%d OR description ILIKE $%d)", argIndex, argIndex))
 		args = append(args, "%"+params.Search+"%")

--- a/platform/orchestrator/policy_api_service.go
+++ b/platform/orchestrator/policy_api_service.go
@@ -403,7 +403,7 @@ func (s *PolicyService) validateCreateRequest(req *CreatePolicyRequest) error {
 	} else if !s.isValidPolicyType(string(req.Type)) {
 		errors = append(errors, PolicyFieldError{
 			Field:   "type",
-			Message: "Type must be one of: content, user, risk, cost, media, rate-limit, budget, time-access, role-access, mcp, connector",
+			Message: "Type must be one of: content, user, risk, cost, context_aware, media, rate-limit, budget, time-access, role-access, mcp, connector",
 		})
 	}
 
@@ -474,7 +474,7 @@ func (s *PolicyService) validateUpdateRequest(req *UpdatePolicyRequest) error {
 	if req.Type != nil && !s.isValidPolicyType(string(*req.Type)) {
 		errors = append(errors, PolicyFieldError{
 			Field:   "type",
-			Message: "Type must be one of: content, user, risk, cost, media, rate-limit, budget, time-access, role-access, mcp, connector",
+			Message: "Type must be one of: content, user, risk, cost, context_aware, media, rate-limit, budget, time-access, role-access, mcp, connector",
 		})
 	}
 

--- a/platform/orchestrator/policy_api_types.go
+++ b/platform/orchestrator/policy_api_types.go
@@ -14,6 +14,8 @@ package orchestrator
 import (
 	"context"
 	"time"
+
+	sharedpolicy "axonflow/platform/shared/policy"
 )
 
 // PolicyTier represents the tier level in the policy hierarchy.
@@ -45,34 +47,34 @@ const (
 
 // PolicyResource represents a policy for the API (extends DynamicPolicy with API-specific fields)
 type PolicyResource struct {
-	ID          string            `json:"id"`
-	Name        string            `json:"name"`
-	Description string            `json:"description,omitempty"`
-	Type        string            `json:"type"` // content, user, risk, cost
-	Category    string            `json:"category,omitempty"` // dynamic-risk, dynamic-compliance, etc.
-	Tier        PolicyTier        `json:"tier"`               // system, organization, tenant
-	Conditions  []PolicyCondition `json:"conditions"`
-	Actions     []PolicyAction    `json:"actions"`
-	Priority    int               `json:"priority"`
-	Enabled     bool              `json:"enabled"`
-	Version     int               `json:"version"`
-	TenantID    string            `json:"tenant_id"`
-	OrganizationID string         `json:"organization_id,omitempty"` // For org-tier policies
-	Tags        []string          `json:"tags,omitempty"`
-	CreatedAt   time.Time         `json:"created_at"`
-	UpdatedAt   time.Time         `json:"updated_at"`
-	CreatedBy   string            `json:"created_by,omitempty"`
-	UpdatedBy   string            `json:"updated_by,omitempty"`
-	DeletedAt   *time.Time        `json:"deleted_at,omitempty"`
+	ID             string            `json:"id"`
+	Name           string            `json:"name"`
+	Description    string            `json:"description,omitempty"`
+	Type           string            `json:"type"`               // content, user, risk, cost
+	Category       string            `json:"category,omitempty"` // dynamic-risk, dynamic-compliance, etc.
+	Tier           PolicyTier        `json:"tier"`               // system, organization, tenant
+	Conditions     []PolicyCondition `json:"conditions"`
+	Actions        []PolicyAction    `json:"actions"`
+	Priority       int               `json:"priority"`
+	Enabled        bool              `json:"enabled"`
+	Version        int               `json:"version"`
+	TenantID       string            `json:"tenant_id"`
+	OrganizationID string            `json:"organization_id,omitempty"` // For org-tier policies
+	Tags           []string          `json:"tags,omitempty"`
+	CreatedAt      time.Time         `json:"created_at"`
+	UpdatedAt      time.Time         `json:"updated_at"`
+	CreatedBy      string            `json:"created_by,omitempty"`
+	UpdatedBy      string            `json:"updated_by,omitempty"`
+	DeletedAt      *time.Time        `json:"deleted_at,omitempty"`
 }
 
 // CreatePolicyRequest for POST /api/v1/policies
 type CreatePolicyRequest struct {
 	Name        string            `json:"name"`
 	Description string            `json:"description"`
-	Type        string            `json:"type"` // content, user, risk, cost
+	Type        string            `json:"type"`               // content, user, risk, cost
 	Category    string            `json:"category,omitempty"` // dynamic-risk, dynamic-compliance, etc.
-	Tier        PolicyTier        `json:"tier,omitempty"` // Only 'organization' or 'tenant' allowed via API
+	Tier        PolicyTier        `json:"tier,omitempty"`     // Only 'organization' or 'tenant' allowed via API
 	Conditions  []PolicyCondition `json:"conditions"`
 	Actions     []PolicyAction    `json:"actions"`
 	Priority    int               `json:"priority"`
@@ -158,10 +160,10 @@ type TriggeredAction struct {
 
 // ImportPoliciesResponse for bulk import
 type ImportPoliciesResponse struct {
-	Created  int      `json:"created"`
-	Updated  int      `json:"updated"`
-	Skipped  int      `json:"skipped"`
-	Errors   []string `json:"errors,omitempty"`
+	Created int      `json:"created"`
+	Updated int      `json:"updated"`
+	Skipped int      `json:"skipped"`
+	Errors  []string `json:"errors,omitempty"`
 }
 
 // ExportPoliciesResponse for bulk export
@@ -208,10 +210,11 @@ type PolicyFieldError struct {
 // Note: MCP-specific types (rate-limit, budget, time-access, role-access, mcp, connector)
 // are used by the MCP Dynamic Policy Handler for connector-level policy enforcement.
 var ValidPolicyTypes = []string{
-	"content", "user", "risk", "cost",        // Standard policy types
-	"media",                                   // Media governance policies
-	"rate-limit", "budget", "time-access",    // MCP rate/budget controls
-	"role-access", "mcp", "connector",        // MCP access controls
+	"content", "user", "risk", "cost", // Standard policy types
+	"context_aware",                       // Context-aware (tenant isolation, debug restrict, sensitive-data control — see system_policies_seed.go)
+	"media",                               // Media governance policies
+	"rate-limit", "budget", "time-access", // MCP rate/budget controls
+	"role-access", "mcp", "connector", // MCP access controls
 }
 
 // ValidPolicyOperators for condition validation
@@ -255,9 +258,13 @@ var ValidPolicyFields = []string{
 	"media.extracted_text_length",
 }
 
-// Valid action types
-// Issue #1082: Added require_approval for WCP HITL integration
-var ValidActionTypes = []string{"block", "redact", "alert", "log", "route", "modify_risk", "require_approval"}
+// Valid action types — re-exported from platform/shared/policy as the single
+// source of truth (also consumed by the customer-portal override validator).
+// Adding a new action type requires updating sharedpolicy.ValidActionTypes only.
+//
+// Copied (not aliased) so callers cannot mutate the shared backing array via
+// append; treat as READ-ONLY.
+var ValidActionTypes = append([]string(nil), sharedpolicy.ValidActionTypes...)
 
 // PolicyServicer defines the interface for policy service operations
 // This interface enables dependency injection and testability

--- a/platform/orchestrator/policy_api_types_test.go
+++ b/platform/orchestrator/policy_api_types_test.go
@@ -145,7 +145,9 @@ func TestValidActionTypes_NotEmpty(t *testing.T) {
 }
 
 func TestValidActionTypes_ContainsExpected(t *testing.T) {
-	expected := []string{"block", "redact", "alert", "log", "route", "modify_risk", "require_approval"}
+	// Includes "warn" since the policy engine emits it (shared/policy/types.go),
+	// and the customer-portal override validator now mirrors this list.
+	expected := []string{"block", "redact", "alert", "log", "route", "modify_risk", "require_approval", "warn"}
 	for _, exp := range expected {
 		found := false
 		for _, at := range ValidActionTypes {

--- a/platform/orchestrator/policy_simulation_handler.go
+++ b/platform/orchestrator/policy_simulation_handler.go
@@ -110,11 +110,9 @@ func (h *PolicySimulationHandler) SimulatePolicies(w http.ResponseWriter, r *htt
 		return
 	}
 
-	tenantID := r.Header.Get("X-Tenant-ID")
+	tenantID := resolveTenantOrFail(w, r, "policy/simulate")
 	if tenantID == "" {
-		if tid, ok := r.Context().Value("tenant_id").(string); ok {
-			tenantID = tid
-		}
+		return // resolveTenantOrFail already wrote a 401
 	}
 
 	// Rate limit check
@@ -223,11 +221,9 @@ func (h *PolicySimulationHandler) ImpactReport(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	tenantID := r.Header.Get("X-Tenant-ID")
+	tenantID := resolveTenantOrFail(w, r, "policy/impact-report")
 	if tenantID == "" {
-		if tid, ok := r.Context().Value("tenant_id").(string); ok {
-			tenantID = tid
-		}
+		return // resolveTenantOrFail already wrote a 401
 	}
 
 	if h.policyService == nil {

--- a/platform/orchestrator/run.go
+++ b/platform/orchestrator/run.go
@@ -38,24 +38,24 @@ import (
 
 	"axonflow/platform/agent"
 	"axonflow/platform/agent/license"
-	"axonflow/platform/shared/serviceauth"
-	sharedpolicy "axonflow/platform/shared/policy"
 	"axonflow/platform/agent/node_enforcement"
 	"axonflow/platform/orchestrator/cloudstorage" // Cloud storage backends for audit exports (#589)
 	"axonflow/platform/orchestrator/cost"         // Cost controls & budget management (#764)
 	"axonflow/platform/orchestrator/euaiact"      // EU AI Act compliance - Community stub or EE impl
 	"axonflow/platform/orchestrator/llm"
-	"axonflow/platform/orchestrator/media"   // Media governance analysis pipeline
-	"axonflow/platform/orchestrator/masfeat"          // MAS FEAT module - Community stub or EE impl
-	"axonflow/platform/orchestrator/planning"         // MAP two-step execution (#927)
-	"axonflow/platform/orchestrator/rbi"              // RBI FREE-AI module - Community stub or EE impl
-	"axonflow/platform/orchestrator/replay"           // Execution replay/debug mode (#763)
-	"axonflow/platform/orchestrator/sebi"             // SEBI AI/ML module - Community stub or EE impl
-	"axonflow/platform/orchestrator/ui"               // Embedded execution viewer UI
+	"axonflow/platform/orchestrator/masfeat"  // MAS FEAT module - Community stub or EE impl
+	"axonflow/platform/orchestrator/media"    // Media governance analysis pipeline
+	"axonflow/platform/orchestrator/planning" // MAP two-step execution (#927)
+	"axonflow/platform/orchestrator/rbi"      // RBI FREE-AI module - Community stub or EE impl
+	"axonflow/platform/orchestrator/replay"   // Execution replay/debug mode (#763)
+	"axonflow/platform/orchestrator/sebi"     // SEBI AI/ML module - Community stub or EE impl
+	"axonflow/platform/orchestrator/ui"       // Embedded execution viewer UI
 	"axonflow/platform/orchestrator/webhooks"
 	"axonflow/platform/orchestrator/workflow_control" // Workflow Control Plane V1 (#834)
 	"axonflow/platform/shared/execution"              // Unified execution tracking (#1075)
 	logutil "axonflow/platform/shared/logger"
+	sharedpolicy "axonflow/platform/shared/policy"
+	"axonflow/platform/shared/serviceauth"
 )
 
 // AxonFlow Orchestrator - Dynamic Policy Enforcement & LLM Routing Engine
@@ -128,10 +128,10 @@ var (
 	unifiedExecutionHandler *UnifiedExecutionHandler // Unified execution status API
 
 	// Media Governance Pipeline
-	mediaPipeline      *media.Pipeline              // Media analysis pipeline (image governance)
+	mediaPipeline       *media.Pipeline              // Media analysis pipeline (image governance)
 	mediaGovConfigStore *MediaGovernanceConfigStore  // Per-tenant media governance config
-	mediaGovHandler    *MediaGovernanceHandler       // Media governance API handler
-	mediaAuditHandler  *MediaGovernanceAuditHandler  // Media audit export handler (Enterprise)
+	mediaGovHandler     *MediaGovernanceHandler      // Media governance API handler
+	mediaAuditHandler   *MediaGovernanceAuditHandler // Media audit export handler (Enterprise)
 
 	// Tier enforcement
 	tierChecker         LicenseChecker       // Global tier-aware license checker
@@ -263,7 +263,7 @@ type OrchestratorRequest struct {
 
 // MediaContentRequest represents a media item in the API request.
 type MediaContentRequest struct {
-	Source     string `json:"source"`               // "base64" or "url"
+	Source     string `json:"source"`                // "base64" or "url"
 	Base64Data string `json:"base64_data,omitempty"` // Base64-encoded image data
 	URL        string `json:"url,omitempty"`         // Image URL
 	MIMEType   string `json:"mime_type"`             // e.g., "image/jpeg"
@@ -300,9 +300,9 @@ type OrchestratorResponse struct {
 
 // MediaAnalysisResponse contains aggregated media analysis results in the API response.
 type MediaAnalysisResponse struct {
-	Results          []MediaAnalysisItemResponse `json:"results"`
-	TotalCostUSD     float64                     `json:"total_cost_usd"`
-	AnalysisTimeMs   int64                       `json:"analysis_time_ms"`
+	Results        []MediaAnalysisItemResponse `json:"results"`
+	TotalCostUSD   float64                     `json:"total_cost_usd"`
+	AnalysisTimeMs int64                       `json:"analysis_time_ms"`
 }
 
 // MediaAnalysisItemResponse contains analysis results for a single media item.
@@ -330,7 +330,7 @@ type PolicyEvaluationResult struct {
 	Allowed          bool     `json:"allowed"`
 	AppliedPolicies  []string `json:"applied_policies"`
 	RiskScore        float64  `json:"risk_score"`
-	Severity         string   `json:"severity,omitempty"`          // Highest severity of matched policies: critical, high, medium, low
+	Severity         string   `json:"severity,omitempty"`           // Highest severity of matched policies: critical, high, medium, low
 	SeverityPolicyID string   `json:"severity_policy_id,omitempty"` // Policy that contributed the highest severity
 	RequiredActions  []string `json:"required_actions"`
 	ProcessingTimeMs int64    `json:"processing_time_ms"`
@@ -343,9 +343,9 @@ type PolicyEvaluationResult struct {
 
 	// Override enforcement (ADR-044): when a session override flipped a deny
 	// into an allow, these fields record which override was applied.
-	OverrideApplied    bool   `json:"override_applied,omitempty"`
-	OverrideID         string `json:"override_id,omitempty"`
-	OverrideReason     string `json:"override_reason,omitempty"`
+	OverrideApplied bool   `json:"override_applied,omitempty"`
+	OverrideID      string `json:"override_id,omitempty"`
+	OverrideReason  string `json:"override_reason,omitempty"`
 
 	// LLM Routing overrides from dynamic policies
 	PreferredProvider string   `json:"preferred_provider,omitempty"` // Preferred LLM provider
@@ -562,13 +562,13 @@ func Run() {
 	r.HandleFunc("/api/v1/workflows/executions/{id}/hitl-status", getHITLExecutionStatusHandler).Methods("GET")
 
 	// Multi-Agent Planning endpoints (v0.1 + v1.0)
-	r.HandleFunc("/api/v1/plan", planRequestHandler).Methods("POST")                // GeneratePlan (stores plan)
-	r.HandleFunc("/api/v1/plan/execute", executePlanHandler).Methods("POST")        // ExecutePlan (executes stored plan)
-	r.HandleFunc("/api/v1/plan/{id}", getPlanStatusHandler).Methods("GET")          // GetPlanStatus (retrieve plan)
-	r.HandleFunc("/api/v1/plan/{id}/cancel", cancelPlanHandler).Methods("POST")     // CancelPlan (MAP v1.0)
-	r.HandleFunc("/api/v1/plan/{id}/versions", getPlanVersionsHandler).Methods("GET") // GetPlanVersions (MAP v1.0)
-	r.HandleFunc("/api/v1/plan/{id}", updatePlanHandler).Methods("PUT")             // UpdatePlan (MAP v1.0)
-	r.HandleFunc("/api/v1/plan/{id}/resume", resumePlanHandler).Methods("POST")     // ResumePlan (MAP v1.0, Enterprise)
+	r.HandleFunc("/api/v1/plan", planRequestHandler).Methods("POST")                                 // GeneratePlan (stores plan)
+	r.HandleFunc("/api/v1/plan/execute", executePlanHandler).Methods("POST")                         // ExecutePlan (executes stored plan)
+	r.HandleFunc("/api/v1/plan/{id}", getPlanStatusHandler).Methods("GET")                           // GetPlanStatus (retrieve plan)
+	r.HandleFunc("/api/v1/plan/{id}/cancel", cancelPlanHandler).Methods("POST")                      // CancelPlan (MAP v1.0)
+	r.HandleFunc("/api/v1/plan/{id}/versions", getPlanVersionsHandler).Methods("GET")                // GetPlanVersions (MAP v1.0)
+	r.HandleFunc("/api/v1/plan/{id}", updatePlanHandler).Methods("PUT")                              // UpdatePlan (MAP v1.0)
+	r.HandleFunc("/api/v1/plan/{id}/resume", resumePlanHandler).Methods("POST")                      // ResumePlan (MAP v1.0, Enterprise)
 	r.HandleFunc("/api/v1/plan/{id}/rollback/{version:[0-9]+}", rollbackPlanHandler).Methods("POST") // RollbackPlan (MAP v1.0, Enterprise)
 
 	// MAP step approval endpoints (v4.3.0, Enterprise — #1076)
@@ -576,8 +576,8 @@ func Run() {
 	r.HandleFunc("/api/v1/plans/{id}/steps/{step_id}/reject", mapStepRejectHandler).Methods("POST")
 
 	// Cost Estimation endpoints (v4.3.0)
-	r.HandleFunc("/api/v1/plans/estimate", estimatePlanCostHandler).Methods("POST")  // EstimatePlanCost
-	r.HandleFunc("/api/v1/plans/{id}/cost", getPlanCostHandler).Methods("GET")       // GetPlanCost
+	r.HandleFunc("/api/v1/plans/estimate", estimatePlanCostHandler).Methods("POST") // EstimatePlanCost
+	r.HandleFunc("/api/v1/plans/{id}/cost", getPlanCostHandler).Methods("GET")      // GetPlanCost
 
 	// MCP Connector Marketplace endpoints (v0.2)
 	r.HandleFunc("/api/v1/connectors", listConnectorsHandler).Methods("GET")
@@ -998,9 +998,9 @@ func initializeComponents() {
 	// Create registry with tier-aware provider count limit
 	llmRegistry := llm.NewRegistry(llm.WithMaxProviders(tierChecker.MaxLLMProviders()))
 	bootstrapResult, err := llm.BootstrapFromEnv(&llm.BootstrapConfig{
-		SkipHealthCheck:  false, // Perform health checks on startup
-		ProviderConfigs:  providerConfigs,
-		Registry:         llmRegistry,
+		SkipHealthCheck: false, // Perform health checks on startup
+		ProviderConfigs: providerConfigs,
+		Registry:        llmRegistry,
 	})
 	if err != nil {
 		log.Printf("⚠️  LLM bootstrap error: %v (LLM features may be unavailable)", err)
@@ -1551,13 +1551,13 @@ func healthHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	health := map[string]interface{}{
-		"status":             "healthy",
-		"service":            "axonflow-orchestrator",
-		"version":            getPlatformVersion(),
-		"timestamp":          time.Now().UTC(),
-		"components":         components,
-		"capabilities":       getCapabilities(),
-		"sdk_compatibility":  getSDKCompatibility(),
+		"status":            "healthy",
+		"service":           "axonflow-orchestrator",
+		"version":           getPlatformVersion(),
+		"timestamp":         time.Now().UTC(),
+		"components":        components,
+		"capabilities":      getCapabilities(),
+		"sdk_compatibility": getSDKCompatibility(),
 		"features": map[string]bool{
 			"multi_agent_planning": planningEngine != nil && resultAggregator != nil,
 			"sebi_compliance":      sebiModule != nil && sebiModule.IsHealthy(),
@@ -2326,6 +2326,7 @@ func auditSearchHandler(w http.ResponseWriter, r *http.Request) {
 	var searchReq struct {
 		UserEmail   string    `json:"user_email,omitempty"`
 		ClientID    string    `json:"client_id,omitempty"`
+		TenantID    string    `json:"-"` // force-set from X-Tenant-ID; never client-controlled
 		StartTime   time.Time `json:"start_time"`
 		EndTime     time.Time `json:"end_time"`
 		RequestType string    `json:"request_type,omitempty"`
@@ -2337,6 +2338,18 @@ func auditSearchHandler(w http.ResponseWriter, r *http.Request) {
 
 	if err := json.NewDecoder(r.Body).Decode(&searchReq); err != nil {
 		sendErrorResponse(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	// Force tenant scoping from the proxy-injected header. Anyone reaching this
+	// handler over the customer-portal proxy carries the session's tenant_id;
+	// without this filter the query returned every tenant's audit logs to any
+	// caller. The header is JSON-tag-ignored on the decoder so a malicious
+	// payload can't override it.
+	searchReq.TenantID = r.Header.Get("X-Tenant-ID")
+	if searchReq.TenantID == "" {
+		log.Printf("[audit/search] BLOCKED: missing X-Tenant-ID header from %s", r.RemoteAddr)
+		sendErrorResponse(w, "tenant scoping required", http.StatusUnauthorized)
 		return
 	}
 
@@ -2396,6 +2409,29 @@ func tenantAuditLogsHandler(w http.ResponseWriter, r *http.Request) {
 
 	if tenantID == "" {
 		sendErrorResponse(w, "Tenant ID is required", http.StatusBadRequest)
+		return
+	}
+
+	// Reject any URL-supplied tenant that doesn't match the proxy-injected
+	// session tenant. Without this check a portal user for tenant A could
+	// read tenant B's audit logs by browsing to /api/v1/audit/tenant/B.
+	//
+	// Fail-closed on missing session tenant too (#1623 retro): the previous
+	// `sessionTenant != ""` gate let callers bypass the cross-check by
+	// omitting the X-Tenant-ID header — the AxonFlow Agent gateway always
+	// sets it after authentication, so a missing header means an unauthenticated
+	// request reached the orchestrator directly.
+	sessionTenant := r.Header.Get("X-Tenant-ID")
+	if sessionTenant == "" {
+		log.Printf("[audit/tenant] BLOCKED: missing X-Tenant-ID header for URL tenant %q from %s",
+			logutil.Sanitize(tenantID), r.RemoteAddr)
+		sendErrorResponse(w, "X-Tenant-ID header is required", http.StatusUnauthorized)
+		return
+	}
+	if sessionTenant != tenantID {
+		log.Printf("[audit/tenant] BLOCKED: URL tenant %q does not match session tenant %q from %s",
+			logutil.Sanitize(tenantID), logutil.Sanitize(sessionTenant), r.RemoteAddr)
+		sendErrorResponse(w, "tenant scope mismatch", http.StatusForbidden)
 		return
 	}
 
@@ -2461,7 +2497,19 @@ func auditToolCallHandler(w http.ResponseWriter, r *http.Request) {
 	// Verify request came through the Agent gateway (not direct access).
 	// The Agent proxy injects X-Axonflow-Proxy-Auth with an HMAC-signed token.
 	// When AXONFLOW_INTERNAL_SERVICE_SECRET is configured, reject unverified requests.
+	//
+	// In Community mode the secret is optional, so an unset validator is
+	// expected and the proxy-auth check is skipped. In any non-Community mode
+	// (Enterprise, Community-SaaS) an unset validator means the deployment is
+	// misconfigured — fail closed rather than silently accepting unauthenticated
+	// requests that could spoof X-Tenant-ID / X-Org-ID for cross-tenant audit
+	// attribution.
 	proxyToken := r.Header.Get("X-Axonflow-Proxy-Auth")
+	if proxyTokenValidator == nil && !isCommunityMode() {
+		log.Printf("[AuditToolCall] BLOCKED: %s not configured in non-Community deployment — proxy-auth validation cannot run", serviceauth.SecretEnvVar)
+		sendErrorResponse(w, "Unauthorized: internal-service auth not configured", http.StatusForbidden)
+		return
+	}
 	if proxyTokenValidator != nil {
 		if proxyToken == "" {
 			log.Printf("[AuditToolCall] BLOCKED: missing proxy auth header (direct access attempt)")
@@ -2675,12 +2723,72 @@ func sendErrorResponse(w http.ResponseWriter, message string, statusCode int) {
 // planExecutionTimeout returns the context timeout for MAP plan execution.
 // Scales to 30s per step (matching single-step resume timeout), minimum 60s.
 // Balanced mode groups steps but each LLM call can take 10-20s.
+//
+// The cap defaults to 300s to stay within the front-door ALB's default
+// idle_timeout (configured at 300s in the marketplace and community-saas
+// CFN templates). Going above the ALB timeout would let the orchestrator
+// keep computing after the client connection was already killed — the
+// caller sees a 504 mid-stream and the work is wasted. 300s covers a
+// 10-step plan at the scaling rate above.
+//
+// Operators running long plans (high-step-count MAP workflows) can raise
+// the cap by setting AXONFLOW_MAP_MAX_TIMEOUT_SECONDS. The cap is clamped
+// to [60s, 1800s] — below 60s would shorten non-plan code paths that
+// don't need the env var, above 30 minutes crosses into WCP/human-in-
+// the-loop territory where a synchronous HTTP round-trip is the wrong
+// model. When bumping the cap, also raise `AlbIdleTimeoutSeconds` on
+// the CFN stack (default 300) so the front-door doesn't cut off first.
 func planExecutionTimeout(stepCount int) time.Duration {
 	timeout := time.Duration(stepCount) * 30 * time.Second
 	if timeout < 60*time.Second {
 		timeout = 60 * time.Second
 	}
+	maxTimeout := mapMaxTimeoutFromEnv()
+	if timeout > maxTimeout {
+		timeout = maxTimeout
+	}
 	return timeout
+}
+
+// mapMaxTimeoutFromEnv reads AXONFLOW_MAP_MAX_TIMEOUT_SECONDS, clamps
+// it to [60s, 1800s], and falls back to 300s when unset/invalid. Logs
+// once-per-process at startup when a non-default value is chosen.
+var (
+	mapMaxTimeoutOnce   sync.Once
+	mapMaxTimeoutCached time.Duration
+)
+
+func mapMaxTimeoutFromEnv() time.Duration {
+	mapMaxTimeoutOnce.Do(func() {
+		const defaultTimeout = 300 * time.Second
+		const minTimeout = 60 * time.Second
+		const maxTimeout = 1800 * time.Second
+		raw := os.Getenv("AXONFLOW_MAP_MAX_TIMEOUT_SECONDS")
+		if raw == "" {
+			mapMaxTimeoutCached = defaultTimeout
+			return
+		}
+		secs, err := strconv.Atoi(raw)
+		if err != nil || secs <= 0 {
+			log.Printf("[MAP] AXONFLOW_MAP_MAX_TIMEOUT_SECONDS=%q is not a positive integer — using default %s", raw, defaultTimeout)
+			mapMaxTimeoutCached = defaultTimeout
+			return
+		}
+		chosen := time.Duration(secs) * time.Second
+		if chosen < minTimeout {
+			log.Printf("[MAP] AXONFLOW_MAP_MAX_TIMEOUT_SECONDS=%d below 60s floor — clamping to 60s", secs)
+			chosen = minTimeout
+		}
+		if chosen > maxTimeout {
+			log.Printf("[MAP] AXONFLOW_MAP_MAX_TIMEOUT_SECONDS=%d above 1800s ceiling — clamping to 1800s. Also raise AlbIdleTimeoutSeconds on the CFN stack or the front-door will 504 first.", secs)
+			chosen = maxTimeout
+		}
+		if chosen != defaultTimeout {
+			log.Printf("[MAP] planExecutionTimeout cap set to %s via AXONFLOW_MAP_MAX_TIMEOUT_SECONDS", chosen)
+		}
+		mapMaxTimeoutCached = chosen
+	})
+	return mapMaxTimeoutCached
 }
 
 // isCommunityMode returns true when running in Community mode.
@@ -4152,11 +4260,11 @@ func resumePlanHandler(w http.ResponseWriter, r *http.Request) {
 
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{
-			"plan_id":      planID,
-			"workflow_id":  targetWorkflowID,
-			"status":       "completed",
-			"step_result":  stepResult,
-			"message":      "All steps completed",
+			"plan_id":     planID,
+			"workflow_id": targetWorkflowID,
+			"status":      "completed",
+			"step_result": stepResult,
+			"message":     "All steps completed",
 		})
 		return
 	}
@@ -4174,13 +4282,13 @@ func resumePlanHandler(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(map[string]interface{}{
-		"plan_id":         planID,
-		"workflow_id":     targetWorkflowID,
-		"status":          "awaiting_approval",
-		"step_result":     stepResult,
-		"next_step":       nextStepIndex,
-		"next_step_name":  nextStep.Name,
-		"total_steps":     len(workflow.Spec.Steps),
+		"plan_id":        planID,
+		"workflow_id":    targetWorkflowID,
+		"status":         "awaiting_approval",
+		"step_result":    stepResult,
+		"next_step":      nextStepIndex,
+		"next_step_name": nextStep.Name,
+		"total_steps":    len(workflow.Spec.Steps),
 	})
 }
 

--- a/platform/orchestrator/run_test.go
+++ b/platform/orchestrator/run_test.go
@@ -215,10 +215,10 @@ func TestLoadLLMConfig(t *testing.T) {
 
 func TestHealthHandler(t *testing.T) {
 	tests := []struct {
-		name                   string
-		setupPlanningEngine    bool
-		setupResultAggregator  bool
-		expectedFeature        bool
+		name                  string
+		setupPlanningEngine   bool
+		setupResultAggregator bool
+		expectedFeature       bool
 	}{
 		{
 			name:                  "with planning engine and result aggregator",
@@ -410,15 +410,15 @@ func TestSendErrorResponse(t *testing.T) {
 
 func TestSimpleMetricsHandler(t *testing.T) {
 	tests := []struct {
-		name                      string
-		setupOrchestratorMetrics  bool
-		setupWithRequestTypes     bool
-		setupWithProviders        bool
-		setupHealthCheckPassed    bool
-		expectedFields            []string
-		expectedRequestTypes      bool
-		expectedProviders         bool
-		description               string
+		name                     string
+		setupOrchestratorMetrics bool
+		setupWithRequestTypes    bool
+		setupWithProviders       bool
+		setupHealthCheckPassed   bool
+		expectedFields           []string
+		expectedRequestTypes     bool
+		expectedProviders        bool
+		description              string
 	}{
 		{
 			name:                     "With orchestrator metrics",
@@ -433,15 +433,15 @@ func TestSimpleMetricsHandler(t *testing.T) {
 			description:              "Should return basic metrics when orchestratorMetrics is nil",
 		},
 		{
-			name:                      "With request types and providers",
-			setupOrchestratorMetrics:  true,
-			setupWithRequestTypes:     true,
-			setupWithProviders:        true,
-			setupHealthCheckPassed:    true,
-			expectedFields:            []string{"total_requests", "success_rate", "error_rate_per_sec"},
-			expectedRequestTypes:      true,
-			expectedProviders:         true,
-			description:               "Should include request_types and providers when populated",
+			name:                     "With request types and providers",
+			setupOrchestratorMetrics: true,
+			setupWithRequestTypes:    true,
+			setupWithProviders:       true,
+			setupHealthCheckPassed:   true,
+			expectedFields:           []string{"total_requests", "success_rate", "error_rate_per_sec"},
+			expectedRequestTypes:     true,
+			expectedProviders:        true,
+			description:              "Should include request_types and providers when populated",
 		},
 	}
 
@@ -1499,52 +1499,52 @@ func TestPlanRequestHandler(t *testing.T) {
 	}()
 
 	tests := []struct {
-		name               string
+		name                string
 		setupPlanningEngine bool
 		setupWorkflowEngine bool
-		setupPlanService   bool
-		requestBody        string
-		expectedStatus     int
+		setupPlanService    bool
+		requestBody         string
+		expectedStatus      int
 	}{
 		{
-			name:               "Error - planning engine not initialized",
+			name:                "Error - planning engine not initialized",
 			setupPlanningEngine: false,
 			setupWorkflowEngine: true,
-			setupPlanService:   true,
-			requestBody:        `{"query":"test"}`,
-			expectedStatus:     http.StatusServiceUnavailable,
+			setupPlanService:    true,
+			requestBody:         `{"query":"test"}`,
+			expectedStatus:      http.StatusServiceUnavailable,
 		},
 		{
-			name:               "Error - plan service not initialized",
+			name:                "Error - plan service not initialized",
 			setupPlanningEngine: true,
 			setupWorkflowEngine: true,
-			setupPlanService:   false,
-			requestBody:        `{"query":"test"}`,
-			expectedStatus:     http.StatusServiceUnavailable,
+			setupPlanService:    false,
+			requestBody:         `{"query":"test"}`,
+			expectedStatus:      http.StatusServiceUnavailable,
 		},
 		{
-			name:               "Error - invalid JSON",
+			name:                "Error - invalid JSON",
 			setupPlanningEngine: true,
 			setupWorkflowEngine: true,
-			setupPlanService:   true,
-			requestBody:        `{invalid json}`,
-			expectedStatus:     http.StatusBadRequest,
+			setupPlanService:    true,
+			requestBody:         `{invalid json}`,
+			expectedStatus:      http.StatusBadRequest,
 		},
 		{
-			name:               "Error - missing user authentication",
+			name:                "Error - missing user authentication",
 			setupPlanningEngine: true,
 			setupWorkflowEngine: true,
-			setupPlanService:   true,
-			requestBody:        `{"query":"test query"}`,
-			expectedStatus:     http.StatusUnauthorized,
+			setupPlanService:    true,
+			requestBody:         `{"query":"test query"}`,
+			expectedStatus:      http.StatusUnauthorized,
 		},
 		{
-			name:               "Error - empty query",
+			name:                "Error - empty query",
 			setupPlanningEngine: true,
 			setupWorkflowEngine: true,
-			setupPlanService:   true,
-			requestBody:        `{"query":"","user":{"id":1,"email":"test@example.com"}}`,
-			expectedStatus:     http.StatusBadRequest,
+			setupPlanService:    true,
+			requestBody:         `{"query":"","user":{"id":1,"email":"test@example.com"}}`,
+			expectedStatus:      http.StatusBadRequest,
 		},
 	}
 
@@ -1844,9 +1844,9 @@ func TestTenantWorkflowExecutionsHandler(t *testing.T) {
 // TestGetOutputKeys tests the getOutputKeys utility function
 func TestGetOutputKeys(t *testing.T) {
 	tests := []struct {
-		name     string
-		output   map[string]interface{}
-		wantLen  int
+		name    string
+		output  map[string]interface{}
+		wantLen int
 	}{
 		{
 			name: "non-empty map",
@@ -1942,32 +1942,32 @@ func TestGetResultLength(t *testing.T) {
 // TestEncodePostgreSQLPassword tests URL password encoding
 func TestEncodePostgreSQLPassword(t *testing.T) {
 	tests := []struct {
-		name     string
-		input    string
+		name  string
+		input string
 	}{
 		{
-			name:     "Simple password",
-			input:    "postgresql://user:pass@localhost:5432/db",
+			name:  "Simple password",
+			input: "postgresql://user:pass@localhost:5432/db",
 		},
 		{
-			name:     "Password with @ symbol",
-			input:    "postgresql://user:test@123@host:5432/db",
+			name:  "Password with @ symbol",
+			input: "postgresql://user:test@123@host:5432/db",
 		},
 		{
-			name:     "Password with special characters",
-			input:    "postgresql://user:p@ss!w0rd@localhost:5432/db",
+			name:  "Password with special characters",
+			input: "postgresql://user:p@ss!w0rd@localhost:5432/db",
 		},
 		{
-			name:     "No password",
-			input:    "postgresql://user@localhost:5432/db",
+			name:  "No password",
+			input: "postgresql://user@localhost:5432/db",
 		},
 		{
-			name:     "Missing scheme",
-			input:    "user:pass@localhost:5432/db",
+			name:  "Missing scheme",
+			input: "user:pass@localhost:5432/db",
 		},
 		{
-			name:     "Missing @ separator",
-			input:    "postgresql://userpass",
+			name:  "Missing @ separator",
+			input: "postgresql://userpass",
 		},
 	}
 
@@ -2401,7 +2401,6 @@ func TestListWorkflowExecutionsHandler_WithLimit(t *testing.T) {
 		})
 	}
 }
-
 
 // TestMetricsHandler_EmptyMetrics tests metrics handler with no data
 func TestMetricsHandler_EmptyMetrics(t *testing.T) {
@@ -3175,6 +3174,12 @@ func TestPlanExecutionTimeout(t *testing.T) {
 		{"three steps scales", 3, 90 * time.Second},
 		{"five steps scales", 5, 150 * time.Second},
 		{"ten steps scales", 10, 300 * time.Second},
+		// Cap at 300s to stay within the ALB idle_timeout. 11+ steps must
+		// not exceed the cap — otherwise the orchestrator would keep
+		// computing after the front-door ALB had already terminated the
+		// connection and the caller saw a 504 mid-stream.
+		{"eleven steps is capped at 300s", 11, 300 * time.Second},
+		{"thirty steps is capped at 300s", 30, 300 * time.Second},
 	}
 
 	for _, tt := range tests {
@@ -3187,3 +3192,20 @@ func TestPlanExecutionTimeout(t *testing.T) {
 	}
 }
 
+// TestTenantAuditLogsHandler_RequiresSessionTenant locks in the #1623 retro
+// follow-up: the URL-vs-session tenant mismatch check used to be gated on
+// sessionTenant != "", which let a caller bypass the cross-check by simply
+// omitting X-Tenant-ID. The header is now required (the AxonFlow Agent
+// gateway always sets it after authentication).
+func TestTenantAuditLogsHandler_RequiresSessionTenant(t *testing.T) {
+	req := httptest.NewRequest("GET", "/audit/tenant/test-tenant", nil)
+	req = mux.SetURLVars(req, map[string]string{"tenant_id": "test-tenant"})
+	// Deliberately no X-Tenant-ID header.
+	w := httptest.NewRecorder()
+
+	tenantAuditLogsHandler(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 when X-Tenant-ID is missing, got %d: %s", w.Code, w.Body.String())
+	}
+}

--- a/platform/shared/policy/types.go
+++ b/platform/shared/policy/types.go
@@ -47,6 +47,82 @@ const (
 	ActionWarn Action = "warn"
 )
 
+// ValidActionTypes is the canonical list of action `type` strings accepted by
+// the policy CRUD API and by override requests. It is the union of:
+//   - core engine actions defined above (block, redact, log, warn, require_approval)
+//   - dynamic-policy executor actions handled in db_dynamic_policies.go
+//     (alert, route, modify_risk)
+//
+// "allow" is excluded — it is an implicit default, not a policy `type`.
+//
+// This is the single source of truth. Both
+// `platform/orchestrator/policy_api_types.go` (POST /api/v1/policies) and
+// `ee/platform/customer-portal/api/policy_overrides.go` (override validator)
+// reference this list. Adding a new action type requires updating only this
+// slice.
+var ValidActionTypes = []string{
+	"alert",
+	"block",
+	"log",
+	"modify_risk",
+	"redact",
+	"require_approval",
+	"route",
+	"warn",
+}
+
+// IsValidActionType reports whether action is in ValidActionTypes.
+func IsValidActionType(action string) bool {
+	for _, a := range ValidActionTypes {
+		if action == a {
+			return true
+		}
+	}
+	return false
+}
+
+// ValidOverrideActions is the canonical list of action `type` strings that are
+// valid as the *target* of a policy override (i.e. what an operator can replace
+// the policy's existing action with). It is a deliberately narrower set than
+// ValidActionTypes:
+//
+//   - Override semantics only make sense for the engine's terminal actions
+//     (block / require_approval / redact / warn / log). Each of these decides
+//     what happens to the request once a policy fires.
+//   - alert / route / modify_risk are dynamic-policy *authoring* actions
+//     (POST /api/v1/policies). They configure a policy's side effects (LLM
+//     routing rules, risk-score deltas, alerter wiring) and have no meaning
+//     as an override of a different policy's terminal action — the agent's
+//     override repository would reject them with ErrInvalidOverrideAction.
+//
+// The agent's `AllOverrideActions` (`platform/agent/policy_categories.go`)
+// historically duplicated this list; the canonical source now lives here so
+// the customer-portal override validator and the agent override repository
+// stay in sync. Adding a new override action requires updating only this
+// slice (and likely ActionRestrictiveness in the agent for ordering).
+// Order is intentional — most restrictive first, matching
+// agent.ActionRestrictiveness so callers iterating the list see actions in
+// "block weakest-allowed override last" order.
+var ValidOverrideActions = []string{
+	"block",
+	"require_approval",
+	"redact",
+	"warn",
+	"log",
+}
+
+// IsValidOverrideAction reports whether action can be the target of a policy
+// override. See ValidOverrideActions for the rationale on which actions are in
+// scope.
+func IsValidOverrideAction(action string) bool {
+	for _, a := range ValidOverrideActions {
+		if action == a {
+			return true
+		}
+	}
+	return false
+}
+
 // PolicyCategory classifies policies for filtering and organization.
 type PolicyCategory string
 
@@ -532,13 +608,13 @@ type DynamicPolicyConfig struct {
 // Dynamic policies are disabled by default for backward compatibility.
 func DefaultDynamicPolicyConfig() DynamicPolicyConfig {
 	return DynamicPolicyConfig{
-		Enabled:                       false,
-		OrchestratorEndpoint:          "http://localhost:8081",
-		Timeout:                       5 * time.Second,
-		GracefulDegradation:           true,
-		EnabledConnectors:             nil, // All connectors when enabled
-		MaxCustomPolicyConnectorsCommunity:  2, // Community: max connectors with custom policies
-		MaxCustomPolicyConnectorsEvaluation: 5, // Evaluation: max connectors with custom policies
+		Enabled:                             false,
+		OrchestratorEndpoint:                "http://localhost:8081",
+		Timeout:                             5 * time.Second,
+		GracefulDegradation:                 true,
+		EnabledConnectors:                   nil, // All connectors when enabled
+		MaxCustomPolicyConnectorsCommunity:  2,   // Community: max connectors with custom policies
+		MaxCustomPolicyConnectorsEvaluation: 5,   // Evaluation: max connectors with custom policies
 	}
 }
 

--- a/platform/shared/policy/types_test.go
+++ b/platform/shared/policy/types_test.go
@@ -180,3 +180,78 @@ func TestGetActionForPhase(t *testing.T) {
 		})
 	}
 }
+
+func TestValidActionTypes(t *testing.T) {
+	if len(ValidActionTypes) == 0 {
+		t.Fatal("ValidActionTypes must not be empty")
+	}
+
+	mustHave := []string{
+		"block", "redact", "log", "warn",
+		"alert", "route", "modify_risk", "require_approval",
+	}
+	for _, want := range mustHave {
+		if !IsValidActionType(want) {
+			t.Errorf("ValidActionTypes is missing %q", want)
+		}
+	}
+
+	if IsValidActionType("allow") {
+		t.Error("ValidActionTypes must not include 'allow' — it is an implicit default, not a policy action type")
+	}
+	if IsValidActionType("nonsense") {
+		t.Error("IsValidActionType returned true for 'nonsense'")
+	}
+	if IsValidActionType("") {
+		t.Error("IsValidActionType returned true for empty string")
+	}
+
+	seen := make(map[string]bool, len(ValidActionTypes))
+	for _, a := range ValidActionTypes {
+		if seen[a] {
+			t.Errorf("duplicate entry in ValidActionTypes: %q", a)
+		}
+		seen[a] = true
+	}
+}
+
+func TestValidOverrideActions(t *testing.T) {
+	if len(ValidOverrideActions) == 0 {
+		t.Fatal("ValidOverrideActions must not be empty")
+	}
+
+	mustHave := []string{"block", "require_approval", "redact", "warn", "log"}
+	for _, want := range mustHave {
+		if !IsValidOverrideAction(want) {
+			t.Errorf("ValidOverrideActions is missing %q", want)
+		}
+	}
+
+	// Authoring-only actions must NOT be in the override list — they have no
+	// terminal-action meaning. Adding them would silently widen what overrides
+	// can do at the customer-portal boundary while the agent's override
+	// repository would still reject them downstream.
+	for _, mustReject := range []string{"alert", "route", "modify_risk", "allow"} {
+		if IsValidOverrideAction(mustReject) {
+			t.Errorf("ValidOverrideActions must NOT include authoring-only action %q", mustReject)
+		}
+	}
+
+	if IsValidOverrideAction("Block") {
+		t.Error("IsValidOverrideAction must be case-sensitive: 'Block' rejected")
+	}
+	if IsValidOverrideAction(" block") {
+		t.Error("IsValidOverrideAction must reject leading whitespace")
+	}
+	if IsValidOverrideAction("") {
+		t.Error("IsValidOverrideAction must reject empty string")
+	}
+
+	seen := make(map[string]bool, len(ValidOverrideActions))
+	for _, a := range ValidOverrideActions {
+		if seen[a] {
+			t.Errorf("duplicate entry in ValidOverrideActions: %q", a)
+		}
+		seen[a] = true
+	}
+}

--- a/platform/shared/serviceauth/serviceauth.go
+++ b/platform/shared/serviceauth/serviceauth.go
@@ -153,15 +153,34 @@ func (v *TokenValidator) ValidateToken(token string) (valid bool, isLegacy bool,
 }
 
 // IsValidInternalServiceRequest checks if the request is from a trusted internal service.
-// Supports HMAC tokens, legacy plain-secret tokens (with deprecation warning), and
-// fallback tokens for community/dev environments.
-func IsValidInternalServiceRequest(clientID, userToken string, validator *TokenValidator) bool {
+//
+// Authentication paths, in order:
+//  1. HMAC-signed token (preferred; requires non-nil validator)
+//  2. Legacy plain-secret token (requires non-nil validator; deprecated)
+//  3. Static fallback token (ONLY when validator is nil AND allowFallback is true)
+//
+// The fallback path exists so single-node Community/dev deployments work without
+// any secret configuration. Production/Enterprise deployments MUST set
+// AXONFLOW_INTERNAL_SERVICE_SECRET (so the caller passes a non-nil validator)
+// AND MUST pass allowFallback=false. If allowFallback=true ever leaks into a
+// deployment that lacks a configured secret, any caller knowing the literal
+// constant TokenFallback could authenticate as the orchestrator and impersonate
+// arbitrary tenants via X-Tenant-ID/X-Org-ID injection.
+//
+// Callers should gate allowFallback on `isCommunityMode() || isCommunitySaasMode()`
+// — never hard-code true.
+func IsValidInternalServiceRequest(clientID, userToken string, validator *TokenValidator, allowFallback bool) bool {
 	if clientID != ClientID {
 		return false
 	}
 
-	// No validator means no secret configured (community/dev mode)
+	// No validator means no secret configured. Only the static fallback token
+	// can satisfy this branch, and only when the caller explicitly allows it.
 	if validator == nil {
+		if !allowFallback {
+			logFallbackRejection()
+			return false
+		}
 		return userToken == TokenFallback
 	}
 
@@ -193,6 +212,7 @@ func GetInternalServiceToken(generator *TokenGenerator) string {
 var (
 	authWarningOnce       sync.Once
 	legacyDeprecationOnce sync.Once
+	fallbackRejectionOnce sync.Once
 )
 
 // LogAuthWarning logs a one-time startup warning about security configuration.
@@ -218,10 +238,24 @@ func logLegacyDeprecationWarning() {
 	})
 }
 
+// logFallbackRejection logs a one-time warning when an internal-service auth attempt
+// is rejected because no validator is configured and the caller did not allow the
+// fallback path. This usually means the deployment is missing
+// AXONFLOW_INTERNAL_SERVICE_SECRET in a non-Community mode.
+func logFallbackRejection() {
+	fallbackRejectionOnce.Do(func() {
+		log.Printf("[SECURITY] Internal service auth rejected: %s is not set in this deployment. "+
+			"Fallback token is disabled outside Community/Community-SaaS mode. "+
+			"Configure %s on every service (agent, orchestrator, customer-portal) so HMAC-signed tokens can be issued and validated.",
+			SecretEnvVar, SecretEnvVar)
+	})
+}
+
 // ResetWarnings resets the warning flags. Only for use in tests.
 func ResetWarnings() {
 	authWarningOnce = sync.Once{}
 	legacyDeprecationOnce = sync.Once{}
+	fallbackRejectionOnce = sync.Once{}
 }
 
 // computeSignature computes the first SignatureLength hex chars of HMAC-SHA256(secret, "orchestrator-internal:{timestamp}").

--- a/platform/shared/serviceauth/serviceauth_test.go
+++ b/platform/shared/serviceauth/serviceauth_test.go
@@ -227,8 +227,11 @@ func TestIsValidRequest_HMACToken(t *testing.T) {
 	val := NewTokenValidator(testSecret, clock, DefaultClockSkew)
 
 	token := gen.GenerateToken()
-	if !IsValidInternalServiceRequest(ClientID, token, val) {
-		t.Error("valid HMAC token should be accepted")
+	if !IsValidInternalServiceRequest(ClientID, token, val, false) {
+		t.Error("valid HMAC token should be accepted (allowFallback=false)")
+	}
+	if !IsValidInternalServiceRequest(ClientID, token, val, true) {
+		t.Error("valid HMAC token should be accepted (allowFallback=true)")
 	}
 }
 
@@ -237,22 +240,36 @@ func TestIsValidRequest_LegacyFallback(t *testing.T) {
 	clock := newMockClock(time.Now())
 	val := NewTokenValidator(testSecret, clock, DefaultClockSkew)
 
-	// Pass the raw secret as token (legacy behavior)
-	if !IsValidInternalServiceRequest(ClientID, testSecret, val) {
+	// Pass the raw secret as token (legacy behavior); allowFallback irrelevant when validator non-nil
+	if !IsValidInternalServiceRequest(ClientID, testSecret, val, false) {
 		t.Error("legacy plain-secret token should be accepted for backward compatibility")
 	}
 }
 
 func TestIsValidRequest_CommunityMode(t *testing.T) {
 	ResetWarnings()
-	// No validator = community/dev mode
-	if !IsValidInternalServiceRequest(ClientID, TokenFallback, nil) {
-		t.Error("fallback token should be accepted in community mode (nil validator)")
+	// No validator + allowFallback=true = community/dev mode
+	if !IsValidInternalServiceRequest(ClientID, TokenFallback, nil, true) {
+		t.Error("fallback token should be accepted in community mode (nil validator, allowFallback=true)")
 	}
 
 	// Wrong token in community mode
-	if IsValidInternalServiceRequest(ClientID, "wrong-token", nil) {
+	if IsValidInternalServiceRequest(ClientID, "wrong-token", nil, true) {
 		t.Error("wrong token should be rejected even in community mode")
+	}
+}
+
+func TestIsValidRequest_FallbackRejectedWhenNotAllowed(t *testing.T) {
+	ResetWarnings()
+	// No validator + allowFallback=false = enterprise misconfig — must reject
+	// even when the caller supplies the literal TokenFallback.
+	if IsValidInternalServiceRequest(ClientID, TokenFallback, nil, false) {
+		t.Error("fallback token MUST be rejected when allowFallback=false (enterprise mode without configured secret)")
+	}
+
+	// Anything else also rejected
+	if IsValidInternalServiceRequest(ClientID, "anything", nil, false) {
+		t.Error("arbitrary token MUST be rejected when validator is nil and allowFallback=false")
 	}
 }
 
@@ -263,13 +280,16 @@ func TestIsValidRequest_WrongClientID(t *testing.T) {
 	val := NewTokenValidator(testSecret, clock, DefaultClockSkew)
 
 	token := gen.GenerateToken()
-	if IsValidInternalServiceRequest("wrong-client", token, val) {
+	if IsValidInternalServiceRequest("wrong-client", token, val, false) {
 		t.Error("wrong client ID should always be rejected")
 	}
 
-	// Also test with nil validator
-	if IsValidInternalServiceRequest("wrong-client", TokenFallback, nil) {
+	// Also test with nil validator (both fallback values)
+	if IsValidInternalServiceRequest("wrong-client", TokenFallback, nil, true) {
 		t.Error("wrong client ID should be rejected in community mode too")
+	}
+	if IsValidInternalServiceRequest("wrong-client", TokenFallback, nil, false) {
+		t.Error("wrong client ID should be rejected in strict mode too")
 	}
 }
 
@@ -344,7 +364,7 @@ func TestIsValidRequest_ExpiredHMACToken(t *testing.T) {
 	valClock := newMockClock(time.Unix(1700000360, 0))
 	val := NewTokenValidator(testSecret, valClock, DefaultClockSkew)
 
-	if IsValidInternalServiceRequest(ClientID, token, val) {
+	if IsValidInternalServiceRequest(ClientID, token, val, false) {
 		t.Error("expired HMAC token should be rejected")
 	}
 }
@@ -355,7 +375,7 @@ func TestIsValidRequest_WrongLegacySecret(t *testing.T) {
 	val := NewTokenValidator(testSecret, clock, DefaultClockSkew)
 
 	// Wrong plain secret
-	if IsValidInternalServiceRequest(ClientID, "wrong-secret", val) {
+	if IsValidInternalServiceRequest(ClientID, "wrong-secret", val, false) {
 		t.Error("wrong legacy secret should be rejected")
 	}
 }


### PR DESCRIPTION
chore(release): v7.2.0

Added:

  - AXONFLOW_MAP_MAX_TIMEOUT_SECONDS orchestrator env.
    MAP plans chain several LLM calls end-to-end; the orchestrator's
    planExecutionTimeout previously scaled 30s/step with a hardcoded
    300s cap, so operators running long plans had to rebuild the
    binary to tune the budget. The new env knob reads the cap at
    startup, clamps to 60..1800 seconds, and falls back to the 300s
    default on unset or unparsable input. The effective value is
    logged once at boot when non-default; clamp-bound adjustments log
    a warning that the value was pinned to the floor/ceiling. Works
    alongside the new AlbIdleTimeoutSeconds CFN parameter - the
    orchestrator cap must be <= the ALB idle timeout or long plans
    get cut at the front door before the orchestrator finishes.

  - AlbIdleTimeoutSeconds CloudFormation parameter on
    infrastructure/cloudformation/community-saas-ecs.yaml. Previously
    the ALB's idle_timeout.timeout_seconds was a hardcoded "300"
    inside the LoadBalancerAttributes list, so tuning required
    editing the template. The parameter defaults to 300, accepts
    60..1800, and wires through via !Ref. update-stack applies as a
    non-disruptive attribute change; ECS tasks are not recycled.
    Keep this value >= AXONFLOW_MAP_MAX_TIMEOUT_SECONDS on the
    orchestrator or you will see a 504 mid-stream on the caller's
    side even though the orchestrator is still working.

Fixed:

  - Agent now proxies /api/v1/euaiact/* to the orchestrator.
    The single-entry-point mux listed /rbi, /sebi, and /masfeat
    alongside the rest of the compliance family but omitted
    /euaiact, so every EU AI Act call that landed on the front-door
    ALB returned "404 page not found". Direct orchestrator hits
    returned "400 X-Org-ID or X-Tenant-ID header required",
    confirming the route was registered on the orchestrator side all
    along - only the agent layer was missing. Added the prefix to
    both r.PathPrefix(...).HandlerFunc(orchAuth) and IsProxiedPath.
    Unit test now covers all four compliance prefixes so the next
    new regional module can't be registered partway through the
    stack again.

  - Canonical /api/v1/policy-overrides alias on the agent. The agent
    previously only exposed the tenant override list under
    /api/v1/static-policies/overrides; callers expecting the
    canonical path (matching the naming pattern policy-categories /
    static-policies / dynamic-policies) hit 404. Added the alias
    under the auth-protected subrouter; same HandleListOverrides
    handler services both paths.

  - Agent /health response includes tier. The validated license tier
    (Community / Evaluation / Professional / Enterprise / starting)
    is captured at license-validation time into an atomic.Value and
    surfaced on both the readiness-aware and legacy health handlers.
    Operators querying "curl /health | jq .tier" (including the
    post-start check in scripts/setup-e2e-testing.sh) previously got
    "unknown" because the field was not in the response.

  - Front-door ALB idle timeout 60s -> 300s; orchestrator plan
    budget capped to match. MAP plans chain multiple LLM calls
    (~15s each); a typical 5-step plan routinely ran past the
    default 60s ALB idle timeout, the ALB killed the connection, and
    the caller saw "HTTP 504 Gateway Time-out" mid-stream even
    though the orchestrator was still working. Aligned the
    end-to-end chain so no link is shorter than the plan budget:
    infrastructure/cloudformation/community-saas-ecs.yaml sets
    idle_timeout.timeout_seconds = 300 on the front-door ALB
    (non-disruptive attribute change; update-stack applies without
    ECS task churn); platform/orchestrator/run.go:
    planExecutionTimeout now scales 30s/step, minimum 60s, capped at
    the value of AXONFLOW_MAP_MAX_TIMEOUT_SECONDS (default 300s).
    SDK note: the TypeScript SDK's default mapTimeout is 120s;
    clients that want the full 300s budget on the server need to
    raise mapTimeout on their client config to match.

  - Orchestrator ValidPolicyTypes accepts context_aware. Three
    seeded system policies (Tenant Isolation, Debug Mode
    Restriction, Sensitive Data Control) ship with
    policy_type=context_aware. The orchestrator's allowlist of
    valid types missed it, so every PUT /api/v1/policies/{id} that
    touched one of those policies returned 400 - same blocker for
    any Community deployment that needed to override the policy.

  - POST /api/v1/policies/{id}/overrides accepts require_approval
    (HITL). The override validator's allow-list was hand-written as
    {block, redact, warn, log}, silently dropping the HITL action
    even though the agent's override repository and the HITL queue
    accepted it end-to-end. Standardised on a single canonical
    source in platform/shared/policy/types.go: ValidActionTypes
    (8 actions accepted by policy authoring - alert, block, log,
    modify_risk, redact, require_approval, route, warn) and
    ValidOverrideActions (5 actions accepted by the override
    endpoint - block, require_approval, redact, warn, log). Every
    caller resolves against the shared lists.

  - Cross-tenant fail-closed enforcement on read + action endpoints.
    /api/v1/audit/search, /audit/tenant/{id},
    /decisions/{id}/explain, /evidence/summary, /evidence/export,
    /policies/simulate, /policies/impact-report, /cost/estimate, and
    /plans/{id}/cost previously fell back to an empty-string tenant
    when neither X-Tenant-ID nor a context-stored tenant_id was set.
    The SQL then ran with WHERE tenant_id = '' (zero rows in the
    happy case, but the moment a downstream query stopped filtering
    the request would have leaked every other tenant's data, and
    in the meantime the empty tenant was burning daily quota slots
    for everyone). New shared resolveTenantOrFail helper returns 401
    with code: TENANT_REQUIRED when neither source provides a scope.
    /decisions/{id}/explain additionally moves the tenant filter
    into the SELECT clause (was post-fetch, failing open on NULL
    user_email); cross-tenant requests now return 404 not 403 so the
    response shape does not leak whether the decision_id exists in
    another tenant.

  - Legacy V1 HMAC license format removed from active code and
    deploy scripts. The V2 Ed25519 format has been the only accepted
    key for months; stale HMAC references in
    scripts/multi-tenant/deploy-client.sh (fetching the wrong
    secret), .github/workflows/deploy-platform.yml (pre-flight check
    on a variable the binary ignores), docker-compose.test.yml,
    scripts/utilities/secrets-manager-utils.sh,
    scripts/deployment/deploy-cloudformation.sh, and
    docker-compose.enterprise.yml would have produced confusing
    failures in a clean shell. The rejection-path code that returns
    "V1 license format no longer supported" is kept so an old key
    ever surfacing gets a clear error, not silent acceptance.
    Technical docs that still treated V1 as a live format now carry
    a deprecation banner pointing readers at the V2 keygen
    invocation.
