### PR TITLE
fix(capabilities): recommend Java SDK 5.5.0 on /health

### DIFF
--- a/platform/agent/capabilities.go
+++ b/platform/agent/capabilities.go
@@ -48,7 +48,7 @@ func getSDKCompatibility() SDKCompatInfo {
 			"python":     "6.4.0",
 			"typescript": "5.4.0",
 			"go":         "5.4.0",
-			"java":       "5.4.0",
+			"java":       "5.5.0",
 		},
 	}
 }

--- a/platform/orchestrator/capabilities.go
+++ b/platform/orchestrator/capabilities.go
@@ -64,7 +64,7 @@ func getSDKCompatibility() SDKCompatInfo {
 			"python":     "6.4.0",
 			"typescript": "5.4.0",
 			"go":         "5.4.0",
-			"java":       "5.4.0",
+			"java":       "5.5.0",
 		},
 	}
 }


### PR DESCRIPTION
fix(capabilities): recommend Java SDK 5.5.0 on /health

The agent /health response now advertises Java SDK 5.5.0 as the
recommended version. Java 5.5.0 shipped to Maven Central on 2026-04-20
with additive mapTimeout on AxonFlowConfig.builder(), bringing Java
to parity with the TypeScript / Python / Go SDKs.