### PR TITLE
chore(release): v7.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,51 @@ community mirror, **Enterprise** changes are EE-only.
 
 ---
 
+## [7.2.1] - 2026-04-21
+
+PATCH: surface the HITL approval metadata that was already being captured
+internally but dropped on the way out of the API. No schema changes, no
+breaking changes — callers that previously handled `null` simply start
+seeing real values.
+
+### Community
+
+#### Fixed
+
+- **`/api/v1/workflows/{id}` now surfaces `approved_by` and `approved_at` on
+  each step.** The `StepInfo` DTO used by the workflow-detail response was
+  missing both fields, so callers polling for approval completion saw
+  `approval_status: "approved"` but no approver identity or timestamp.
+  Both fields were already captured by `ApproveStep` and persisted on the
+  `WorkflowStep` row — the DTO just wasn't copying them over. Portal and
+  SDK consumers now get the full provenance without a second round-trip
+  to the audit log.
+- **`StepGateResponse.approval_id` populated on `require_approval`
+  decisions.** The HITL adapter was creating the approval queue entry and
+  setting `StepGateEvaluation.ApprovalID`, but the API response struct
+  didn't carry the field. SDK clients that want to correlate a paused
+  step with its HITL queue row (for Slack/PagerDuty routing, direct
+  portal deep-links, or programmatic approval) now get `approval_id` on
+  the same response that reports the `require_approval` decision.
+
+### Enterprise
+
+#### Fixed
+
+- **Customer Portal `/approvals` page no longer crashes on expand.** The
+  `PendingApproval.policies_matched` TypeScript type declared the field
+  as `string[]`, but the `/api/v1/workflows/approvals/pending` endpoint
+  returns an array of `PolicyMatch` objects (`{policy_id, policy_name,
+  action, risk_level, allow_override, policy_description}`). React
+  tried to render the object directly and threw error #31 ("Objects
+  are not valid as a React child"), dumping the approver into the
+  ErrorBoundary fallback the moment they clicked a row to expand the
+  detail panel. The approvals page now accepts either shape, extracts
+  `policy_name` when given an object, and surfaces `policy_description`
+  as a tooltip on the matched-policy chip.
+
+---
+
 ## [7.2.0] - 2026-04-20 — The Bug Bash Bonanza 🪲🔨
 
 A focused hardening release: a full sweep across the Customer Portal

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,7 +87,7 @@ services:
       DEPLOYMENT_MODE: ${DEPLOYMENT_MODE:-community}
       AXONFLOW_INTEGRATIONS: ${AXONFLOW_INTEGRATIONS:-}
       AXONFLOW_LICENSE_KEY: ${AXONFLOW_LICENSE_KEY:-}
-      AXONFLOW_VERSION: "${AXONFLOW_VERSION:-7.2.0}"
+      AXONFLOW_VERSION: "${AXONFLOW_VERSION:-7.2.1}"
 
       # Media governance (v4.5.0+) - set to "true" to enable in Community mode
       MEDIA_GOVERNANCE_ENABLED: ${MEDIA_GOVERNANCE_ENABLED:-}
@@ -223,7 +223,7 @@ services:
       PORT: 8081
       DEPLOYMENT_MODE: ${DEPLOYMENT_MODE:-community}
       AXONFLOW_LICENSE_KEY: ${AXONFLOW_LICENSE_KEY:-}
-      AXONFLOW_VERSION: "${AXONFLOW_VERSION:-7.2.0}"
+      AXONFLOW_VERSION: "${AXONFLOW_VERSION:-7.2.1}"
 
       # Media governance (v4.5.0+) - set to "true" to enable in Community mode
       MEDIA_GOVERNANCE_ENABLED: ${MEDIA_GOVERNANCE_ENABLED:-}

--- a/platform/agent/Dockerfile
+++ b/platform/agent/Dockerfile
@@ -125,7 +125,7 @@ RUN set -e && \
 # Final stage - minimal runtime image
 FROM alpine:3.23
 
-ARG AXONFLOW_VERSION=7.2.0
+ARG AXONFLOW_VERSION=7.2.1
 ENV AXONFLOW_VERSION=${AXONFLOW_VERSION}
 
 # AWS Marketplace metadata

--- a/platform/orchestrator/Dockerfile
+++ b/platform/orchestrator/Dockerfile
@@ -136,7 +136,7 @@ RUN set -e && \
 # Final stage - minimal runtime image
 FROM alpine:3.23
 
-ARG AXONFLOW_VERSION=7.2.0
+ARG AXONFLOW_VERSION=7.2.1
 ENV AXONFLOW_VERSION=${AXONFLOW_VERSION}
 
 # AWS Marketplace metadata

--- a/platform/orchestrator/workflow_control/service.go
+++ b/platform/orchestrator/workflow_control/service.go
@@ -568,6 +568,7 @@ func (s *Service) StepGate(ctx context.Context, workflowID string, stepID string
 		DecisionID:        fmt.Sprintf("dec_%s_%s", workflowID, stepID),
 		PolicyIDs:         evaluation.PolicyIDs,
 		Reason:            evaluation.Reason,
+		ApprovalID:        evaluation.ApprovalID,
 		PoliciesEvaluated: evaluation.PoliciesEvaluated,
 		PoliciesMatched:   evaluation.PoliciesMatched,
 		Cached:            false,

--- a/platform/orchestrator/workflow_control/service_test.go
+++ b/platform/orchestrator/workflow_control/service_test.go
@@ -573,6 +573,51 @@ func (m *MockApprovalPolicyEvaluator) EvaluateStepGate(ctx context.Context, step
 	}
 }
 
+// MockApprovalPolicyEvaluatorWithApprovalID simulates the HITL-integrated adapter
+// that populates ApprovalID alongside the require_approval decision.
+type MockApprovalPolicyEvaluatorWithApprovalID struct {
+	ApprovalID string
+}
+
+func (m *MockApprovalPolicyEvaluatorWithApprovalID) EvaluateStepGate(ctx context.Context, step *StepGateContext) *StepGateEvaluation {
+	return &StepGateEvaluation{
+		Decision:   GateDecisionRequireApproval,
+		Reason:     "Human approval required",
+		PolicyIDs:  []string{"policy-approval-1"},
+		ApprovalID: m.ApprovalID,
+	}
+}
+
+func TestStepGate_RequireApproval_SurfacesApprovalID(t *testing.T) {
+	// Regression: StepGateResponse previously dropped the ApprovalID populated
+	// by the HITL adapter, so SDK clients saw approval_id: null even though the
+	// HITL queue entry existed. Caught in banking-demo VC demo verification
+	// 2026-04-21.
+	repo := NewMockRepository()
+	svc := NewService(repo, &MockApprovalPolicyEvaluatorWithApprovalID{
+		ApprovalID: "approval-uuid-1234",
+	}, &ServiceConfig{BaseURL: "https://portal.getaxonflow.com"})
+	ctx := context.Background()
+
+	workflow, _ := svc.CreateWorkflow(ctx, &CreateWorkflowRequest{
+		WorkflowName: "payment-processing",
+	}, "tenant-1", "org-1", "user-1", "client-1")
+
+	response, err := svc.StepGate(ctx, workflow.WorkflowID, "step-1", &StepGateRequest{
+		StepName: "Initiate Wire",
+		StepType: StepTypeToolCall,
+	}, "tenant-1", "org-1", "user-1", "client-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if response.Decision != GateDecisionRequireApproval {
+		t.Fatalf("decision = %s, want require_approval", response.Decision)
+	}
+	if response.ApprovalID != "approval-uuid-1234" {
+		t.Errorf("approval_id = %q, want approval-uuid-1234", response.ApprovalID)
+	}
+}
+
 func TestStepGate_RequireApproval(t *testing.T) {
 	repo := NewMockRepository()
 	svc := NewService(repo, &MockApprovalPolicyEvaluator{}, &ServiceConfig{

--- a/platform/orchestrator/workflow_control/types.go
+++ b/platform/orchestrator/workflow_control/types.go
@@ -217,6 +217,7 @@ type StepGateResponse struct {
 	DecisionID        string        `json:"decision_id,omitempty"`
 	PolicyIDs         []string      `json:"policy_ids,omitempty"`
 	Reason            string        `json:"reason,omitempty"`
+	ApprovalID        string        `json:"approval_id,omitempty"`  // HITL queue entry UUID when Decision is require_approval
 	ApprovalURL       string        `json:"approval_url,omitempty"`
 	PoliciesEvaluated []PolicyMatch `json:"policies_evaluated,omitempty"` // All policies checked (Issue #1021)
 	PoliciesMatched   []PolicyMatch `json:"policies_matched,omitempty"`   // Policies that matched and contributed to decision (Issue #1021)
@@ -252,6 +253,8 @@ type StepInfo struct {
 	StepType       StepType        `json:"step_type,omitempty"`
 	Decision       GateDecision    `json:"decision"`
 	ApprovalStatus *ApprovalStatus `json:"approval_status,omitempty"`
+	ApprovedBy     string          `json:"approved_by,omitempty"`
+	ApprovedAt     *time.Time      `json:"approved_at,omitempty"`
 	GateCheckedAt  time.Time       `json:"gate_checked_at"`
 }
 
@@ -323,6 +326,8 @@ func (w *Workflow) ToStatusResponse() WorkflowStatusResponse {
 				StepType:       step.StepType,
 				Decision:       step.Decision,
 				ApprovalStatus: step.ApprovalStatus,
+				ApprovedBy:     step.ApprovedBy,
+				ApprovedAt:     step.ApprovedAt,
 				GateCheckedAt:  step.GateCheckedAt,
 			}
 		}

--- a/platform/orchestrator/workflow_control/types_test.go
+++ b/platform/orchestrator/workflow_control/types_test.go
@@ -217,6 +217,51 @@ func TestWorkflowToStatusResponse(t *testing.T) {
 	}
 }
 
+func TestWorkflowToStatusResponseSurfacesApproverIdentity(t *testing.T) {
+	// Regression: StepInfo previously dropped ApprovedBy / ApprovedAt on the way
+	// from WorkflowStep to the response, so /api/v1/workflows/{id} always rendered
+	// approved_by as null even after approval landed. Caught in banking-demo VC
+	// demo verification 2026-04-21.
+	now := time.Now()
+	approvedAt := now.Add(2 * time.Minute)
+	approved := ApprovalStatusApproved
+
+	workflow := &Workflow{
+		WorkflowID:   "wf_test",
+		WorkflowName: "test",
+		Source:       WorkflowSourceLangGraph,
+		Status:       WorkflowStatusInProgress,
+		StartedAt:    now,
+		Steps: []WorkflowStep{
+			{
+				StepID:         "step-wire",
+				StepIndex:      2,
+				StepName:       "Initiate Wire Transfer",
+				StepType:       StepTypeToolCall,
+				Decision:       GateDecisionRequireApproval,
+				ApprovalStatus: &approved,
+				ApprovedBy:     "sarah.thompson@fraud.example.com",
+				ApprovedAt:     &approvedAt,
+				GateCheckedAt:  now,
+			},
+		},
+	}
+
+	response := workflow.ToStatusResponse()
+
+	if len(response.Steps) != 1 {
+		t.Fatalf("expected 1 step, got %d", len(response.Steps))
+	}
+	if response.Steps[0].ApprovedBy != "sarah.thompson@fraud.example.com" {
+		t.Errorf("approved_by = %q, want sarah.thompson@fraud.example.com", response.Steps[0].ApprovedBy)
+	}
+	if response.Steps[0].ApprovedAt == nil {
+		t.Error("approved_at should not be nil when approval landed")
+	} else if !response.Steps[0].ApprovedAt.Equal(approvedAt) {
+		t.Errorf("approved_at = %v, want %v", response.Steps[0].ApprovedAt, approvedAt)
+	}
+}
+
 func TestWorkflowToStatusResponseNoSteps(t *testing.T) {
 	now := time.Now()
 


### PR DESCRIPTION
## v7.2.1

PATCH release. Two fixes in `platform/orchestrator/workflow_control/` that surface HITL approval metadata already captured internally but dropped on the way out of the API. Purely additive — no schema changes, no breaking changes, no DB migration.

### Fixed

- `/api/v1/workflows/{id}` now surfaces `approved_by` and `approved_at` on each step. The `StepInfo` DTO was missing both fields, so callers polling for approval completion saw `approval_status: "approved"` but no approver identity or timestamp.
- `StepGateResponse.approval_id` populated on `require_approval` decisions. The HITL adapter was already setting the field internally, but the API response struct didn't carry it out.

Matching enterprise PRs: getaxonflow/axonflow-enterprise#1670, #1671.