### PR TITLE
chore(sync): v7.3.0 — retry_context and idempotency_key on WCP step gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,99 @@ community mirror, **Enterprise** changes are EE-only.
 
 ---
 
+## [7.3.0] - 2026-04-21 — Retry Semantics & Idempotency
+
+MINOR: first-class retry and idempotency surfaces on the Workflow Control
+Plane. The `cached: bool` signal every gate response has been returning is
+now a deprecated alias — responses carry a `retry_context` block that
+answers "how many gate calls?", "did any prior attempt complete?", and
+"what was the prior decision?" unambiguously. A new caller-supplied
+`idempotency_key` on gate + complete anchors a workflow step to a
+business-level identity (payment intent, invoice, claim reference), with
+strict match validation between the two endpoints.
+
+No breaking changes. Purely additive.
+
+### Community
+
+#### Added
+
+- **`retry_context` on every `StepGateResponse`** — always present, including
+  on the first gate call (where counters are 1/0 and
+  `prior_completion_status` is `"none"`). Fields: `gate_count`,
+  `completion_count`, `prior_completion_status` (enum `none` / `completed` /
+  `gated_not_completed`), `prior_output_available`, `prior_output`,
+  `prior_completion_at`, `first_attempt_at`, `last_attempt_at`,
+  `last_decision`, `idempotency_key`. Counter bookkeeping is atomic inside
+  the repository UPSERT; a separate cached-hit update keeps counters
+  accurate across idempotent retries without re-evaluating policy.
+- **`?include_prior_output=true` query param on `/gate`** — opt-in inclusion
+  of the prior `/complete` payload in `retry_context.prior_output`. Default
+  is `false` (null) because output may be large and/or contain sensitive
+  data. When the opt-in is set AND a prior completion exists, the full
+  output is returned so agents can safely short-circuit re-execution.
+- **Caller-supplied `idempotency_key` on `/gate` and `/complete`** —
+  optional opaque string up to 255 chars. Recorded on the first gate call
+  that sets it; immutable for the step's lifetime. Surfaced on every
+  subsequent `retry_context.idempotency_key`. Audit log records the key
+  on every `step_gate` and `step_completed` event.
+- **`HTTP 409 IDEMPOTENCY_KEY_MISMATCH`** returned when `/complete` (or a
+  subsequent `/gate`) passes a different key than the one recorded on the
+  first gate, or when one side supplies a key and the other omits it.
+  Response envelope includes `expected_idempotency_key` and
+  `received_idempotency_key` so SDKs can build typed errors.
+- **`cached` and `decision_source` fields remain on every response** so
+  existing SDK versions continue working unchanged. Both are marked
+  deprecated in the wire docs; `retry_context.gate_count > 1` replaces
+  `cached: true` and `retry_context.prior_completion_status` replaces the
+  string-typed `decision_source`.
+
+#### Changed
+
+- **`MarkStepCompleted` HTTP handler** now reads tenant identity from
+  `X-Tenant-ID` consistently with `StepGate` rather than from
+  `X-Client-ID`. A real multi-tenant caller setting the tenant header now
+  works on both endpoints; previously the complete path rejected the
+  request as "workflow not found" because the isolation check compared
+  against the wrong attribute. No behavior change for callers using
+  empty headers.
+
+### Evaluation
+
+#### Added
+
+- **Retry-aware dynamic policy conditions** — the policy engine now
+  resolves seven new `step.*` fields: `step.gate_count`,
+  `step.completion_count`, `step.prior_completion_status` (enum `none` /
+  `completed` / `gated_not_completed`), `step.prior_output_available`,
+  `step.last_decision`, `step.first_attempt_age_seconds`, and
+  `step.idempotency_key`. Policy authors can write rules like
+  "retry on un-completed payment requires approval", "more than three
+  attempts = block", or "rapid retry within 30 seconds escalates severity"
+  without custom code. These fields are added to `ValidPolicyFields` so
+  the create/update policy APIs accept them.
+- **Tier-gated create:** attempting to author a dynamic policy with any
+  `step.*` condition on a Community license is rejected at create time
+  with `FEATURE_REQUIRES_EVALUATION_LICENSE`. Evaluation and Enterprise
+  tiers accept. Enforcement sits in `PolicyService.validateTierForCreate`
+  before the tenant policy-count check, so the rejection fires cleanly
+  without a DB roundtrip.
+- **UX note for policy authors:** retry-aware policies only fire when
+  callers pass `retry_policy: "reevaluate"` on subsequent `/gate` calls.
+  Default-idempotent retries hit the cache and bypass the policy engine,
+  consistent with the existing cache semantics. Documented in the
+  bundled Evaluation-tier example.
+
+### Enterprise
+
+No Enterprise-exclusive additions in this release. Cross-workflow
+idempotency lookup, windowed operators like `idempotency_key_seen_within`,
+retry-pattern correlation across workflows, and compliance-grade
+audit/reporting for duplicate prevention are on the roadmap for a
+later release.
+
+---
+
 ## [7.2.1] - 2026-04-21
 
 PATCH: surface the HITL approval metadata that was already being captured

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,7 +87,7 @@ services:
       DEPLOYMENT_MODE: ${DEPLOYMENT_MODE:-community}
       AXONFLOW_INTEGRATIONS: ${AXONFLOW_INTEGRATIONS:-}
       AXONFLOW_LICENSE_KEY: ${AXONFLOW_LICENSE_KEY:-}
-      AXONFLOW_VERSION: "${AXONFLOW_VERSION:-7.2.1}"
+      AXONFLOW_VERSION: "${AXONFLOW_VERSION:-7.3.0}"
 
       # Media governance (v4.5.0+) - set to "true" to enable in Community mode
       MEDIA_GOVERNANCE_ENABLED: ${MEDIA_GOVERNANCE_ENABLED:-}
@@ -168,7 +168,7 @@ services:
       AXONFLOW_INTERNAL_SERVICE_SECRET: ${AXONFLOW_INTERNAL_SERVICE_SECRET:-}
 
       # Misc
-      ORG_ID: local-dev-org
+      ORG_ID: ${ORG_ID:-local-dev-org}
       ENVIRONMENT: development
       LOG_LEVEL: debug
       GOOGLE_MODEL: ${GOOGLE_MODEL:-}
@@ -223,7 +223,7 @@ services:
       PORT: 8081
       DEPLOYMENT_MODE: ${DEPLOYMENT_MODE:-community}
       AXONFLOW_LICENSE_KEY: ${AXONFLOW_LICENSE_KEY:-}
-      AXONFLOW_VERSION: "${AXONFLOW_VERSION:-7.2.1}"
+      AXONFLOW_VERSION: "${AXONFLOW_VERSION:-7.3.0}"
 
       # Media governance (v4.5.0+) - set to "true" to enable in Community mode
       MEDIA_GOVERNANCE_ENABLED: ${MEDIA_GOVERNANCE_ENABLED:-}
@@ -265,7 +265,7 @@ services:
       PROVIDER_WEIGHTS: ${PROVIDER_WEIGHTS:-}
 
       # Misc
-      ORG_ID: local-dev-org
+      ORG_ID: ${ORG_ID:-local-dev-org}
       LOG_LEVEL: debug
     ports:
       - "8081:8081"

--- a/docs/api/orchestrator-api.yaml
+++ b/docs/api/orchestrator-api.yaml
@@ -3648,6 +3648,13 @@ paths:
         Returns a decision (allow/block/require_approval) based on policy evaluation.
 
         Call this BEFORE executing each step in your external orchestrator.
+
+        The response always includes a `retry_context` block (Issue #1673 Phase 1)
+        carrying first-class retry state: gate count, prior completion status,
+        first/last attempt timestamps, last decision, and the idempotency_key.
+        Callers that need to unambiguously detect retries or uncertain-territory
+        scenarios should prefer `retry_context` over the deprecated `cached`
+        boolean.
       operationId: checkStepGate
       parameters:
         - name: workflow_id
@@ -3664,6 +3671,18 @@ paths:
           schema:
             type: string
           example: "step-1"
+        - name: include_prior_output
+          in: query
+          required: false
+          description: |
+            Opt-in (Issue #1673 Phase 1) — when `true` and a prior /complete
+            landed for this step, `retry_context.prior_output` is populated
+            with the stored output so the agent can short-circuit re-execution.
+            Default `false` because prior output may be large or sensitive.
+          schema:
+            type: boolean
+            default: false
+          example: true
       requestBody:
         required: true
         content:
@@ -3705,8 +3724,32 @@ paths:
                     step_id: "step-1"
                     reason: "Human approval required for deployment steps"
                     approval_url: "https://portal.axonflow.com/approvals/abc123"
+        '400':
+          description: |
+            Bad request — missing step_type, invalid retry_policy, or
+            idempotency_key exceeds 255 characters.
         '404':
           $ref: '#/components/responses/NotFound'
+        '409':
+          description: |
+            `IDEMPOTENCY_KEY_MISMATCH` (Issue #1673 Phase 2) — the supplied
+            `idempotency_key` does not match the one recorded on the step's
+            earlier /gate call. `expected_idempotency_key` and
+            `received_idempotency_key` are always present, empty string when
+            one side is absent.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIErrorResponse'
+              example:
+                error:
+                  code: "IDEMPOTENCY_KEY_MISMATCH"
+                  message: "idempotency_key does not match the key recorded on gate"
+                  details:
+                    workflow_id: "wf_41231a72"
+                    step_id: "step-1"
+                    expected_idempotency_key: "payment:wire:invoice-7721"
+                    received_idempotency_key: "payment:wire:invoice-9999"
 
   /api/v1/workflows/{workflow_id}/steps/{step_id}/complete:
     post:
@@ -3742,8 +3785,19 @@ paths:
       responses:
         '204':
           description: Step marked completed
+        '400':
+          description: idempotency_key exceeds 255 characters
         '404':
           $ref: '#/components/responses/NotFound'
+        '409':
+          description: |
+            `IDEMPOTENCY_KEY_MISMATCH` (Issue #1673 Phase 2) — the supplied
+            `idempotency_key` does not match the one recorded on the step's
+            earlier /gate call.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIErrorResponse'
 
   /api/v1/workflows/{workflow_id}/complete:
     post:
@@ -7304,6 +7358,103 @@ components:
           enum: [idempotent, reevaluate]
           default: idempotent
           example: "idempotent"
+        idempotency_key:
+          type: string
+          maxLength: 255
+          description: |
+            Optional caller-supplied opaque business-level key (Issue #1673 Phase 2).
+            Recorded on the first /gate call that sets it; immutable for the step's
+            lifetime. Subsequent /gate and /complete calls MUST pass the same key
+            or receive 409 IDEMPOTENCY_KEY_MISMATCH. Use business-meaningful values
+            like `payment:wire:invoice-7721`, not request IDs.
+          example: "payment:wire:invoice-7721"
+
+    RetryContext:
+      type: object
+      description: |
+        First-class retry and execution state (Issue #1673 Phase 1). Always
+        present on every `StepGateResponse`, including the first gate call.
+        Replaces the ambiguous `cached: bool` signal with unambiguous state
+        the agent and policy engine can reason about.
+      required:
+        - gate_count
+        - completion_count
+        - prior_completion_status
+        - prior_output_available
+        - prior_output
+        - prior_completion_at
+        - first_attempt_at
+        - last_attempt_at
+        - last_decision
+        - idempotency_key
+      properties:
+        gate_count:
+          type: integer
+          minimum: 1
+          description: |
+            Number of /gate calls for this (workflow_id, step_id), including
+            the current call. First call returns 1.
+          example: 2
+        completion_count:
+          type: integer
+          minimum: 0
+          description: |
+            Number of /complete calls for this (workflow_id, step_id). Normally
+            0 on first gate, 1 after the step completes.
+          example: 1
+        prior_completion_status:
+          type: string
+          enum: [none, completed, gated_not_completed]
+          description: |
+            "none" on first gate call. "completed" when a prior /gate + /complete
+            both landed. "gated_not_completed" when a prior /gate landed but no
+            /complete followed — uncertain territory the agent needs to reconcile
+            against the downstream system before re-executing.
+          example: "completed"
+        prior_output_available:
+          type: boolean
+          description: |
+            True iff prior_completion_status == "completed". Mirrors whether
+            prior_output *could* be returned if include_prior_output=true.
+          example: true
+        prior_output:
+          type: object
+          nullable: true
+          additionalProperties: true
+          description: |
+            Always present in the schema. Populated only when the caller set
+            ?include_prior_output=true AND prior_output_available is true.
+            Otherwise null.
+        prior_completion_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: Timestamp of the prior /complete call, if any.
+        first_attempt_at:
+          type: string
+          format: date-time
+          description: |
+            Timestamp of the first /gate call for this step. On the first call,
+            equals last_attempt_at.
+        last_attempt_at:
+          type: string
+          format: date-time
+          description: Timestamp of this /gate call.
+        last_decision:
+          type: string
+          enum: [allow, block, require_approval]
+          description: |
+            Decision of the immediately prior /gate call. On the first call
+            (gate_count == 1), equals the current decision (first-call
+            invariant).
+          example: "allow"
+        idempotency_key:
+          type: string
+          description: |
+            The caller-supplied business-level key recorded on this step
+            (Issue #1673 Phase 2). Always present in the schema — empty
+            string `""` if the caller never supplied one.
+          example: "payment:wire:invoice-7721"
 
     StepGateResponse:
       type: object
@@ -7342,18 +7493,27 @@ components:
             $ref: '#/components/schemas/PolicyMatch'
         cached:
           type: boolean
+          deprecated: true
           description: |
-            Whether this response was served from a prior decision rather than
-            a fresh policy evaluation. True when retry_policy is "idempotent"
-            (the default) and the step was previously evaluated.
+            **Deprecated (Issue #1673).** Whether this response was served from
+            a prior decision rather than a fresh policy evaluation. Use
+            `retry_context.gate_count > 1` instead — `cached` conflates
+            first-call-no vs many-retries-yes into a single bit. Kept
+            populated on every response for back-compat; removal planned
+            for a future major version.
           example: false
         decision_source:
           type: string
+          deprecated: true
           description: |
-            How the decision was produced: "fresh" (policy evaluator ran for
-            this request) or "cached" (returned from prior evaluation in DB).
+            **Deprecated (Issue #1673).** "fresh" or "cached". Use
+            `retry_context.prior_completion_status` for the distinction
+            agents and policies actually need. Kept populated on every
+            response for back-compat; removal planned for a future major.
           enum: [fresh, cached]
           example: "fresh"
+        retry_context:
+          $ref: '#/components/schemas/RetryContext'
 
     MarkStepCompletedRequest:
       type: object
@@ -7375,6 +7535,57 @@ components:
           format: double
           description: Actual cost in USD for the step (overrides gate-time estimate)
           example: 0.0023
+        idempotency_key:
+          type: string
+          maxLength: 255
+          description: |
+            Optional caller-supplied key (Issue #1673 Phase 2). Must match the
+            key recorded on the step's earlier /gate call. Mismatch returns
+            409 IDEMPOTENCY_KEY_MISMATCH.
+          example: "payment:wire:invoice-7721"
+
+    APIErrorDetails:
+      type: object
+      description: Structured error details used by typed SDK exceptions.
+      properties:
+        workflow_id:
+          type: string
+        step_id:
+          type: string
+        expected_idempotency_key:
+          type: string
+          description: |
+            The key recorded on the step's /gate call. Empty string when the
+            gate call had no key but the /complete call supplied one.
+        received_idempotency_key:
+          type: string
+          description: |
+            The key the caller just passed. Empty string when the /complete
+            call omitted a key that the /gate call had set.
+
+    APIError:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: string
+          description: Machine-readable error code (e.g. IDEMPOTENCY_KEY_MISMATCH).
+        message:
+          type: string
+          description: Human-readable error description.
+        details:
+          $ref: '#/components/schemas/APIErrorDetails'
+
+    APIErrorResponse:
+      type: object
+      description: Structured error response envelope used by WCP endpoints.
+      required:
+        - error
+      properties:
+        error:
+          $ref: '#/components/schemas/APIError'
 
     Checkpoint:
       type: object

--- a/examples/wcp-retry-idempotency/README.md
+++ b/examples/wcp-retry-idempotency/README.md
@@ -1,0 +1,164 @@
+# WCP retry_context + idempotency_key examples
+
+Hardened end-to-end validators for the Workflow Control Plane's retry-aware
+surface:
+
+- `retry_context` on every `StepGateResponse` — unambiguous retry state
+  (counters, prior-completion enum, timestamps, last decision) replacing
+  the ambiguous `cached: bool` signal.
+- Caller-supplied `idempotency_key` on `/gate` + `/complete` — business-level
+  key with strict match validation (`HTTP 409 IDEMPOTENCY_KEY_MISMATCH` on
+  conflict).
+- `step.*` condition fields for the dynamic policy engine — `gate_count`,
+  `completion_count`, `prior_completion_status`, `prior_output_available`,
+  `last_decision`, `first_attempt_age_seconds`, `idempotency_key`.
+
+Every example **asserts actual behaviour** — counter values, enum strings,
+error envelope fields, recovered payloads — and exits non-zero on any
+mismatch. They are release-gate tests, not smoke demos.
+
+The public API contract these examples target is documented in the
+`/api/v1/workflows/.../gate` and `/api/v1/workflows/.../complete` paths
+of `docs/api/orchestrator-api.yaml`.
+
+---
+
+## Layout
+
+```
+examples/wcp-retry-idempotency/
+├── README.md                      ← you are here
+├── community/                     ← Community-tier primitives (any tier)
+│   ├── http/        raw HTTP (no SDK dependency)
+│   ├── go/          Go SDK
+│   ├── typescript/  TypeScript SDK
+│   ├── python/      Python SDK (3.10+)
+│   └── java/        Java SDK
+└── evaluation/                    ← Evaluation-tier retry-aware policy
+    ├── http/        authors a retry-aware policy + verifies it fires
+    ├── go/          same flow via Go SDK
+    ├── typescript/  same flow via TypeScript SDK
+    ├── python/      same flow via Python SDK
+    └── java/        same flow via Java SDK
+```
+
+---
+
+## Community-tier examples
+
+What each exercises (identical across all 5 languages):
+
+1. **First-gate invariants** — `gate_count == 1`, `completion_count == 0`,
+   `prior_completion_status == "none"`, `first_attempt_at == last_attempt_at`,
+   `last_decision == decision` (first-call invariant).
+2. **Re-gate post-complete** — after `/complete`, a subsequent `/gate`
+   returns `gate_count == 2`, `completion_count == 1`,
+   `prior_completion_status == "completed"`, `prior_output_available == true`.
+3. **Gated-not-completed** — gate without complete, then re-gate → the
+   "uncertain territory" state: `prior_completion_status ==
+   "gated_not_completed"`, `completion_count == 0`. This is the signal an
+   agent needs to reconcile with the downstream system before re-executing.
+4. **`?include_prior_output=true`** — opt-in populates
+   `retry_context.prior_output` with the payload passed to `/complete`.
+5. **idempotency_key round-trip** — key supplied on gate echoes on every
+   subsequent `retry_context.idempotency_key`; key on complete must match
+   or return 409.
+6. **409 IDEMPOTENCY_KEY_MISMATCH** — typed error surfaced in each SDK
+   with `expected_idempotency_key`, `received_idempotency_key`,
+   `workflow_id`, `step_id` all populated.
+
+### Running any community example
+
+```bash
+# From the repo root, boot a stack (community, evaluation, or enterprise):
+./scripts/setup-e2e-testing.sh community
+source /tmp/axonflow-e2e-env.sh
+export AXONFLOW_BASE_URL=http://localhost:8080
+
+# HTTP (no SDK):
+cd examples/wcp-retry-idempotency/community/http && go run .
+
+# Go SDK:
+cd ../go && go run .
+
+# TypeScript SDK:
+cd ../typescript && npm install && npx ts-node index.ts
+
+# Python SDK (requires Python 3.10+):
+cd ../python && python3.11 -m venv .venv && source .venv/bin/activate && \
+  pip install axonflow && python main.py
+
+# Java SDK:
+cd ../java && mvn -q compile exec:java \
+  -Dexec.mainClass="com.getaxonflow.examples.WcpRetryIdempotency"
+```
+
+Each example prints ✔ per assertion block and ends with
+`All assertions passed ✔`. Non-zero exit on failure.
+
+---
+
+## Evaluation-tier example
+
+> ⚠️ **Evaluation or Enterprise license required.**
+>
+> Policies that reference `step.*` retry-aware condition fields require
+> the Evaluation tier or higher. On a Community license, `POST
+> /api/v1/policies` returns `HTTP 403 FEATURE_REQUIRES_EVALUATION_LICENSE`
+> with a link to get a free Evaluation license. Same gate applies on the
+> update and import paths. Boot the stack with
+> `./scripts/setup-e2e-testing.sh evaluation` (or `enterprise`) before
+> running these examples.
+
+Each example walks the same three-gate story:
+
+1. **First gate (default `retry_policy`)** — decision `allow`,
+   `gate_count == 1` (policy's `gate_count > 1` condition does NOT match).
+2. **Second gate (default `retry_policy`)** — decision `allow`,
+   **cached**. Cache short-circuits the policy engine; retry-aware
+   conditions do **not** fire even though `gate_count == 2` and
+   `prior_completion_status == "gated_not_completed"`. This assertion
+   locks the current cache semantics — if a future change makes
+   retry-aware policies fire on cached retries, this line fails and
+   prompts a deliberate update.
+3. **Third gate (`retry_policy: "reevaluate"`)** — forces fresh policy
+   evaluation; all three conditions now match, policy fires, decision
+   becomes `require_approval`.
+
+**Important for policy authors:** retry-aware dynamic policies only
+fire when the caller opts into reevaluation via `retry_policy:
+"reevaluate"`. Default-idempotent retries hit the cache and bypass the
+policy engine. If your intent is "every retry reconsiders the
+decision", pass `reevaluate` on every gate call after the first.
+
+### Running
+
+```bash
+./scripts/setup-e2e-testing.sh evaluation   # or enterprise
+source /tmp/axonflow-e2e-env.sh
+export AXONFLOW_BASE_URL=http://localhost:8080
+
+# HTTP (no SDK):
+cd examples/wcp-retry-idempotency/evaluation/http && go run .
+
+# Go / TypeScript / Python / Java — same pattern as community/, but under evaluation/:
+cd ../go        && go run .
+cd ../typescript && npm install && npx ts-node index.ts
+cd ../python    && python3.11 -m venv .venv && source .venv/bin/activate && \
+  pip install axonflow && python main.py
+cd ../java      && mvn -q compile exec:java \
+  -Dexec.mainClass="com.getaxonflow.examples.EvalRetryAware"
+```
+
+Each example authors its policy at setup and tears it down in a
+defer/finally block, so re-runs are clean.
+
+---
+
+## Related
+
+- API reference: [`docs/api/orchestrator-api.yaml`](../../docs/api/orchestrator-api.yaml)
+- CHANGELOG: the `[7.3.0]` entry describes the full surface area and
+  the edition split (Community primitives / Evaluation retry-aware
+  policy conditions / Enterprise cross-workflow features in a future
+  release).

--- a/examples/wcp-retry-idempotency/community/go/go.mod
+++ b/examples/wcp-retry-idempotency/community/go/go.mod
@@ -1,0 +1,15 @@
+module github.com/getaxonflow/axonflow-enterprise/examples/wcp-retry-idempotency/community/go
+
+go 1.23
+
+// Phase 1 + Phase 2 of Issue #1673 land in Go SDK v5.6.0.
+// Update this require line and delete the `replace` below once v5.6.0
+// publishes to the Go module proxy.
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.5.0
+
+// Temporary local replace — resolves to the sibling SDK worktree where
+// feat/1673-retry-context-and-idempotency-key is checked out. Remove
+// when SDK v5.6.0 publishes. The path assumes a sibling layout:
+//   ~/Development/axonflow-enterprise-1673/examples/...  (this file)
+//   ~/Development/axonflow-sdk-go-1673/                  (SDK worktree)
+replace github.com/getaxonflow/axonflow-sdk-go/v5 => ../../../../../axonflow-sdk-go-1673

--- a/examples/wcp-retry-idempotency/community/go/main.go
+++ b/examples/wcp-retry-idempotency/community/go/main.go
@@ -1,0 +1,192 @@
+// Copyright 2026 AxonFlow
+// SPDX-License-Identifier: BUSL-1.1
+//
+// Go SDK example for Issue #1673 Phase 1 (retry_context) + Phase 2
+// (idempotency_key). Exercises the full feature set end-to-end through the
+// SDK against a running enterprise stack.
+//
+// Usage:
+//   source /tmp/axonflow-e2e-env.sh
+//   export AXONFLOW_BASE_URL=http://localhost:8080
+//   go run main.go
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	axonflow "github.com/getaxonflow/axonflow-sdk-go/v5"
+)
+
+func main() {
+	endpoint := envOrDefault("AXONFLOW_BASE_URL", "http://localhost:8080")
+	clientID := mustEnv("AXONFLOW_CLIENT_ID")
+	clientSecret := mustEnv("AXONFLOW_CLIENT_SECRET")
+
+	client := axonflow.NewClient(axonflow.AxonFlowConfig{
+		Endpoint:     endpoint,
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+	})
+
+	banner("Act 1 — retry_context (Go SDK)")
+	act1(client)
+
+	banner("Act 2 — idempotency_key (Go SDK)")
+	act2(client)
+
+	banner("All assertions passed ✔")
+}
+
+func act1(c *axonflow.AxonFlowClient) {
+	wf, err := c.CreateWorkflow(axonflow.CreateWorkflowRequest{
+		WorkflowName: "go-sdk-retry-context",
+	})
+	must(err, "create workflow")
+	fmt.Printf("workflow: %s\n", wf.WorkflowID)
+
+	// 1) First gate — first-call invariants
+	resp, err := c.StepGate(wf.WorkflowID, "step-1", axonflow.StepGateRequest{
+		StepName: "first-step",
+		StepType: axonflow.StepTypeToolCall,
+	})
+	must(err, "first gate")
+	assertEqInt("first gate_count", 1, resp.RetryContext.GateCount)
+	assertEqInt("first completion_count", 0, resp.RetryContext.CompletionCount)
+	assertEqStr("first prior_completion_status", "none", string(resp.RetryContext.PriorCompletionStatus))
+	assertTrue("first !PriorOutputAvailable", !resp.RetryContext.PriorOutputAvailable)
+	assertEqStr("first last_decision (first-call invariant)", string(resp.Decision), string(resp.RetryContext.LastDecision))
+	assertTrue("first FirstAttemptAt == LastAttemptAt", resp.RetryContext.FirstAttemptAt.Equal(resp.RetryContext.LastAttemptAt))
+	fmt.Println("  first gate invariants ✔")
+
+	// 2) Complete, then re-gate (cached path)
+	out := map[string]interface{}{"transfer_id": "TXN-go-1", "amount": 500.0}
+	must(c.MarkStepCompleted(wf.WorkflowID, "step-1", &axonflow.MarkStepCompletedRequest{Output: out}), "complete")
+	resp, err = c.StepGate(wf.WorkflowID, "step-1", axonflow.StepGateRequest{StepType: axonflow.StepTypeToolCall})
+	must(err, "re-gate post-complete")
+	assertEqInt("re-gate post-complete gate_count", 2, resp.RetryContext.GateCount)
+	assertEqInt("re-gate post-complete completion_count", 1, resp.RetryContext.CompletionCount)
+	assertEqStr("re-gate post-complete prior_completion_status", "completed", string(resp.RetryContext.PriorCompletionStatus))
+	assertTrue("re-gate post-complete PriorOutputAvailable", resp.RetryContext.PriorOutputAvailable)
+	assertTrue("re-gate post-complete PriorOutput omitted by default", resp.RetryContext.PriorOutput == nil)
+	assertTrue("re-gate post-complete Cached==true", resp.Cached)
+	fmt.Println("  re-gate post-complete ✔")
+
+	// 3) Gate on step-2 without completion (agent crash simulation)
+	_, err = c.StepGate(wf.WorkflowID, "step-2", axonflow.StepGateRequest{
+		StepName: "second-step", StepType: axonflow.StepTypeToolCall,
+	})
+	must(err, "step-2 first gate")
+	resp, err = c.StepGate(wf.WorkflowID, "step-2", axonflow.StepGateRequest{StepType: axonflow.StepTypeToolCall})
+	must(err, "step-2 re-gate")
+	assertEqStr("gated_not_completed status", "gated_not_completed", string(resp.RetryContext.PriorCompletionStatus))
+	assertEqInt("gated_not_completed completion_count", 0, resp.RetryContext.CompletionCount)
+	fmt.Println("  gated_not_completed ✔")
+
+	// 4) include_prior_output=true recovers the payload
+	resp, err = c.StepGateWithOptions(wf.WorkflowID, "step-1",
+		axonflow.StepGateRequest{StepType: axonflow.StepTypeToolCall},
+		axonflow.StepGateOptions{IncludePriorOutput: true},
+	)
+	must(err, "re-gate with include_prior_output")
+	assertTrue("PriorOutput populated", resp.RetryContext.PriorOutput != nil)
+	assertEqStr("PriorOutput[transfer_id]", "TXN-go-1", fmt.Sprint(resp.RetryContext.PriorOutput["transfer_id"]))
+	fmt.Println("  prior_output recovery ✔")
+}
+
+func act2(c *axonflow.AxonFlowClient) {
+	wf, err := c.CreateWorkflow(axonflow.CreateWorkflowRequest{
+		WorkflowName: "go-sdk-idempotency-key",
+	})
+	must(err, "create workflow")
+	fmt.Printf("workflow: %s\n", wf.WorkflowID)
+
+	originalKey := "payment:wire:go-sdk-invoice-1"
+
+	// 5) Gate with key — retry_context.idempotency_key echoes
+	resp, err := c.StepGate(wf.WorkflowID, "step-1", axonflow.StepGateRequest{
+		StepName: "wire", StepType: axonflow.StepTypeToolCall,
+		IdempotencyKey: originalKey,
+	})
+	must(err, "gate 1 with key")
+	assertEqStr("retry_context.idempotency_key echo", originalKey, resp.RetryContext.IdempotencyKey)
+	fmt.Println("  key round-trip ✔")
+
+	// 6) Re-gate with different key → IdempotencyKeyMismatchError
+	_, err = c.StepGate(wf.WorkflowID, "step-1", axonflow.StepGateRequest{
+		StepType: axonflow.StepTypeToolCall, IdempotencyKey: "payment:wire:different-2",
+	})
+	if err == nil {
+		fail("expected IdempotencyKeyMismatchError on gate with different key")
+	}
+	var mismatch *axonflow.IdempotencyKeyMismatchError
+	if !errors.As(err, &mismatch) {
+		fail(fmt.Sprintf("expected *IdempotencyKeyMismatchError, got %T: %v", err, err))
+	}
+	assertEqStr("mismatch expected_key", originalKey, mismatch.ExpectedIdempotencyKey)
+	assertEqStr("mismatch received_key", "payment:wire:different-2", mismatch.ReceivedIdempotencyKey)
+	assertTrue("mismatch workflow_id populated", strings.HasPrefix(mismatch.WorkflowID, "wf_"))
+	assertEqStr("mismatch step_id", "step-1", mismatch.StepID)
+	fmt.Println("  typed 409 error ✔")
+
+	// 7) Complete with matching key → success
+	must(c.MarkStepCompleted(wf.WorkflowID, "step-1", &axonflow.MarkStepCompletedRequest{
+		Output:         map[string]interface{}{"transfer_id": "TXN-K1"},
+		IdempotencyKey: originalKey,
+	}), "complete with matching key")
+	fmt.Println("  complete with matching key ✔")
+}
+
+// --- helpers ---
+
+func envOrDefault(k, d string) string {
+	if v := os.Getenv(k); v != "" {
+		return v
+	}
+	return d
+}
+
+func mustEnv(k string) string {
+	v := os.Getenv(k)
+	if v == "" {
+		fail("missing env: " + k)
+	}
+	return v
+}
+
+func must(err error, label string) {
+	if err != nil {
+		fail(label + ": " + err.Error())
+	}
+}
+
+func assertTrue(label string, cond bool) {
+	if !cond {
+		fail("assertion failed: " + label)
+	}
+}
+
+func assertEqStr(label, want, got string) {
+	if want != got {
+		fail(fmt.Sprintf("%s: want %q, got %q", label, want, got))
+	}
+}
+
+func assertEqInt(label string, want, got int) {
+	if want != got {
+		fail(fmt.Sprintf("%s: want %d, got %d", label, want, got))
+	}
+}
+
+func fail(msg string) {
+	fmt.Fprintln(os.Stderr, "FAIL: "+msg)
+	os.Exit(1)
+}
+
+func banner(s string) {
+	fmt.Println()
+	fmt.Println("━━━", s, "━━━")
+}

--- a/examples/wcp-retry-idempotency/community/http/go.mod
+++ b/examples/wcp-retry-idempotency/community/http/go.mod
@@ -1,0 +1,3 @@
+module github.com/getaxonflow/axonflow-enterprise/ee/examples/workflows/wcp-retry-idempotency/go
+
+go 1.23

--- a/examples/wcp-retry-idempotency/community/http/main.go
+++ b/examples/wcp-retry-idempotency/community/http/main.go
@@ -1,0 +1,366 @@
+// Copyright 2026 AxonFlow
+// SPDX-License-Identifier: BUSL-1.1
+//
+// WCP retry_context + idempotency_key demo (Issue #1673 Phase 1 + Phase 2)
+//
+// Demonstrates the two new primitives together, using raw HTTP so the wire
+// shape is obvious. Every assertion is checked — the example exits 1 on any
+// contract deviation.
+//
+// The story:
+//
+//   Act 1 — retry_context exposes first-class state
+//     1. Create a workflow, call /gate on step-1. Assert retry_context has
+//        gate_count=1, completion_count=0, prior_completion_status=none,
+//        last_decision=decision (first-call invariant).
+//     2. Call /complete for step-1. Then re-gate step-1. Assert
+//        gate_count=2, completion_count=1, prior_completion_status=completed,
+//        prior_output_available=true.
+//     3. On a DIFFERENT step, call /gate only (simulating agent crash between
+//        gate and complete). Re-gate. Assert prior_completion_status=
+//        gated_not_completed — the state an agent sees when it must reconcile
+//        with the downstream system before re-executing.
+//     4. Re-gate with ?include_prior_output=true on the completed step and
+//        assert prior_output is populated with the payload from /complete.
+//
+//   Act 2 — idempotency_key as a first-class business-level key
+//     5. Create a new workflow, gate step-1 with idempotency_key="payment:K1".
+//        Assert retry_context.idempotency_key echoes back.
+//     6. Re-gate step-1 with a DIFFERENT key "payment:K2" and assert the
+//        server returns 409 IDEMPOTENCY_KEY_MISMATCH with expected/received
+//        keys on the error envelope.
+//     7. /complete step-1 with the matching original key and assert success.
+//
+// Usage:
+//
+//   # Boot enterprise stack via the E2E setup script
+//   ./scripts/setup-e2e-testing.sh
+//   # Then (the script exports these into your shell):
+//   export AXONFLOW_BASE_URL=http://localhost:8080
+//   export AXONFLOW_CLIENT_ID=demo-org
+//   export AXONFLOW_CLIENT_SECRET="<license key from setup-e2e-testing.sh>"
+//   go run main.go
+//
+// Auth: HTTP Basic with client_id + client_secret, the same scheme the
+// AxonFlow SDKs use. The agent validates Basic credentials against the
+// license database, then injects X-Tenant-ID / X-Org-ID / X-User-ID when
+// proxying to the orchestrator.
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"time"
+)
+
+// --- wire types mirror platform/orchestrator/workflow_control/types.go ---
+
+type stepGateRequest struct {
+	StepName       string      `json:"step_name,omitempty"`
+	StepType       string      `json:"step_type"`
+	StepInput      interface{} `json:"step_input,omitempty"`
+	ToolContext    interface{} `json:"tool_context,omitempty"`
+	RetryPolicy    string      `json:"retry_policy,omitempty"`
+	IdempotencyKey string      `json:"idempotency_key,omitempty"`
+}
+
+type retryContext struct {
+	GateCount             int                    `json:"gate_count"`
+	CompletionCount       int                    `json:"completion_count"`
+	PriorCompletionStatus string                 `json:"prior_completion_status"`
+	PriorOutputAvailable  bool                   `json:"prior_output_available"`
+	PriorOutput           map[string]interface{} `json:"prior_output"`
+	PriorCompletionAt     *time.Time             `json:"prior_completion_at"`
+	FirstAttemptAt        time.Time              `json:"first_attempt_at"`
+	LastAttemptAt         time.Time              `json:"last_attempt_at"`
+	LastDecision          string                 `json:"last_decision"`
+	IdempotencyKey        string                 `json:"idempotency_key,omitempty"`
+}
+
+type stepGateResponse struct {
+	Decision       string       `json:"decision"`
+	StepID         string       `json:"step_id"`
+	Reason         string       `json:"reason"`
+	Cached         bool         `json:"cached"`
+	DecisionSource string       `json:"decision_source"`
+	RetryContext   retryContext `json:"retry_context"`
+}
+
+type stepCompleteRequest struct {
+	Output         map[string]interface{} `json:"output,omitempty"`
+	IdempotencyKey string                 `json:"idempotency_key,omitempty"`
+}
+
+type apiErrorResponse struct {
+	Error struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+		Details struct {
+			WorkflowID             string `json:"workflow_id"`
+			StepID                 string `json:"step_id"`
+			ExpectedIdempotencyKey string `json:"expected_idempotency_key"`
+			ReceivedIdempotencyKey string `json:"received_idempotency_key"`
+		} `json:"details"`
+	} `json:"error"`
+}
+
+// --- demo ---
+
+func main() {
+	baseURL := envOrDie("AXONFLOW_BASE_URL", "http://localhost:8080")
+	clientID := envOrDie("AXONFLOW_CLIENT_ID")
+	clientSecret := envOrDie("AXONFLOW_CLIENT_SECRET")
+
+	c := &client{
+		baseURL:      baseURL,
+		clientID:     clientID,
+		clientSecret: clientSecret,
+		http:         &http.Client{Timeout: 10 * time.Second},
+	}
+
+	banner("Act 1 — retry_context")
+	act1(c)
+
+	banner("Act 2 — idempotency_key")
+	act2(c)
+
+	banner("All assertions passed ✔")
+}
+
+func act1(c *client) {
+	wfID := c.createWorkflow("retry-context-demo")
+	fmt.Printf("workflow: %s\n", wfID)
+
+	// 1. First gate on step-1
+	resp := c.gate(wfID, "step-1", stepGateRequest{StepType: "tool_call", StepName: "first-step"}, false)
+	assertRetryContext("first gate", resp.RetryContext, expect{
+		gateCount:             1,
+		completionCount:       0,
+		priorCompletionStatus: "none",
+		lastDecision:          resp.Decision, // first-call invariant
+	})
+	assert(!resp.Cached, "first gate: want cached=false")
+
+	// 2. Complete step-1, then re-gate
+	c.complete(wfID, "step-1", stepCompleteRequest{Output: map[string]interface{}{
+		"transfer_id": "TXN-retry-demo-1",
+		"amount":      500,
+	}})
+	resp = c.gate(wfID, "step-1", stepGateRequest{StepType: "tool_call"}, false)
+	assertRetryContext("re-gate post-complete", resp.RetryContext, expect{
+		gateCount:             2,
+		completionCount:       1,
+		priorCompletionStatus: "completed",
+		priorOutputAvailable:  true,
+	})
+	assert(resp.Cached, "re-gate post-complete: want cached=true")
+	assert(resp.RetryContext.PriorOutput == nil,
+		"re-gate without include_prior_output: PriorOutput must be nil")
+
+	// 3. Gate on step-2 WITHOUT complete — simulate agent crash
+	c.gate(wfID, "step-2", stepGateRequest{StepType: "tool_call", StepName: "second-step"}, false)
+	resp = c.gate(wfID, "step-2", stepGateRequest{StepType: "tool_call"}, false)
+	assertRetryContext("re-gate without complete", resp.RetryContext, expect{
+		gateCount:             2,
+		completionCount:       0,
+		priorCompletionStatus: "gated_not_completed",
+	})
+
+	// 4. Re-gate step-1 with include_prior_output=true
+	resp = c.gate(wfID, "step-1", stepGateRequest{StepType: "tool_call"}, true)
+	assert(resp.RetryContext.PriorOutput != nil,
+		"include_prior_output=true: prior_output must be populated")
+	assertEqual("prior_output.transfer_id", "TXN-retry-demo-1",
+		fmt.Sprint(resp.RetryContext.PriorOutput["transfer_id"]))
+	fmt.Println("  prior_output payload recovered across retry ✔")
+}
+
+func act2(c *client) {
+	wfID := c.createWorkflow("idempotency-key-demo")
+	fmt.Printf("workflow: %s\n", wfID)
+
+	originalKey := "payment:wire:invoice-1"
+
+	// 5. First gate with key — echoed back
+	resp := c.gate(wfID, "step-1",
+		stepGateRequest{StepType: "tool_call", StepName: "wire", IdempotencyKey: originalKey}, false)
+	assertEqual("gate 1 retry_context.idempotency_key", originalKey, resp.RetryContext.IdempotencyKey)
+
+	// 6. Re-gate with different key → 409
+	code, body := c.gateRaw(wfID, "step-1",
+		stepGateRequest{StepType: "tool_call", IdempotencyKey: "payment:wire:invoice-2"}, false)
+	assertEqual("mismatch status", "409", fmt.Sprintf("%d", code))
+	var errEnv apiErrorResponse
+	if err := json.Unmarshal(body, &errEnv); err != nil {
+		fail("mismatch body unmarshal: " + err.Error())
+	}
+	assertEqual("mismatch error.code", "IDEMPOTENCY_KEY_MISMATCH", errEnv.Error.Code)
+	assertEqual("mismatch expected_key", originalKey, errEnv.Error.Details.ExpectedIdempotencyKey)
+	assertEqual("mismatch received_key", "payment:wire:invoice-2", errEnv.Error.Details.ReceivedIdempotencyKey)
+	assertEqual("mismatch workflow_id", wfID, errEnv.Error.Details.WorkflowID)
+	assertEqual("mismatch step_id", "step-1", errEnv.Error.Details.StepID)
+	fmt.Println("  409 envelope shape verified ✔")
+
+	// 7. Complete with matching key
+	c.complete(wfID, "step-1", stepCompleteRequest{
+		Output:         map[string]interface{}{"transfer_id": "TXN-K1"},
+		IdempotencyKey: originalKey,
+	})
+	fmt.Println("  complete with matching key succeeded ✔")
+}
+
+// --- http helper ---
+
+type client struct {
+	baseURL      string
+	clientID     string
+	clientSecret string
+	http         *http.Client
+}
+
+// authHeaders applies Basic auth + Content-Type on a prepared request.
+// This matches what the AxonFlow SDKs do internally (see
+// axonflow-sdk-go's http.Request.SetBasicAuth usage).
+func (c *client) authHeaders(req *http.Request) {
+	req.Header.Set("Content-Type", "application/json")
+	req.SetBasicAuth(c.clientID, c.clientSecret)
+}
+
+func (c *client) createWorkflow(name string) string {
+	body, _ := json.Marshal(map[string]string{"workflow_name": name})
+	req, _ := http.NewRequest(http.MethodPost, c.baseURL+"/api/v1/workflows", bytes.NewReader(body))
+	c.authHeaders(req)
+	resp, err := c.http.Do(req)
+	if err != nil {
+		fail("createWorkflow: " + err.Error())
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		raw, _ := io.ReadAll(resp.Body)
+		fail(fmt.Sprintf("createWorkflow status=%d body=%s", resp.StatusCode, string(raw)))
+	}
+	var wf struct {
+		WorkflowID string `json:"workflow_id"`
+	}
+	_ = json.NewDecoder(resp.Body).Decode(&wf)
+	if wf.WorkflowID == "" {
+		fail("createWorkflow: empty workflow_id")
+	}
+	return wf.WorkflowID
+}
+
+func (c *client) gate(wfID, stepID string, req stepGateRequest, includePriorOutput bool) *stepGateResponse {
+	code, body := c.gateRaw(wfID, stepID, req, includePriorOutput)
+	if code != http.StatusOK {
+		fail(fmt.Sprintf("gate status=%d body=%s", code, string(body)))
+	}
+	var resp stepGateResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		fail("gate unmarshal: " + err.Error())
+	}
+	return &resp
+}
+
+func (c *client) gateRaw(wfID, stepID string, req stepGateRequest, includePriorOutput bool) (int, []byte) {
+	body, _ := json.Marshal(req)
+	u := fmt.Sprintf("%s/api/v1/workflows/%s/steps/%s/gate",
+		c.baseURL, url.PathEscape(wfID), url.PathEscape(stepID))
+	if includePriorOutput {
+		u += "?include_prior_output=true"
+	}
+	httpReq, _ := http.NewRequest(http.MethodPost, u, bytes.NewReader(body))
+	c.authHeaders(httpReq)
+	resp, err := c.http.Do(httpReq)
+	if err != nil {
+		fail("gate: " + err.Error())
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, raw
+}
+
+func (c *client) complete(wfID, stepID string, req stepCompleteRequest) {
+	body, _ := json.Marshal(req)
+	u := fmt.Sprintf("%s/api/v1/workflows/%s/steps/%s/complete",
+		c.baseURL, url.PathEscape(wfID), url.PathEscape(stepID))
+	httpReq, _ := http.NewRequest(http.MethodPost, u, bytes.NewReader(body))
+	c.authHeaders(httpReq)
+	resp, err := c.http.Do(httpReq)
+	if err != nil {
+		fail("complete: " + err.Error())
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		raw, _ := io.ReadAll(resp.Body)
+		fail(fmt.Sprintf("complete status=%d body=%s", resp.StatusCode, string(raw)))
+	}
+}
+
+// --- tiny assertion helpers ---
+
+type expect struct {
+	gateCount             int
+	completionCount       int
+	priorCompletionStatus string
+	priorOutputAvailable  bool
+	lastDecision          string
+}
+
+func assertRetryContext(label string, rc retryContext, want expect) {
+	if rc.GateCount != want.gateCount {
+		fail(fmt.Sprintf("%s: gate_count want %d, got %d", label, want.gateCount, rc.GateCount))
+	}
+	if rc.CompletionCount != want.completionCount {
+		fail(fmt.Sprintf("%s: completion_count want %d, got %d", label, want.completionCount, rc.CompletionCount))
+	}
+	if rc.PriorCompletionStatus != want.priorCompletionStatus {
+		fail(fmt.Sprintf("%s: prior_completion_status want %q, got %q", label, want.priorCompletionStatus, rc.PriorCompletionStatus))
+	}
+	if want.priorOutputAvailable != rc.PriorOutputAvailable {
+		fail(fmt.Sprintf("%s: prior_output_available want %v, got %v", label, want.priorOutputAvailable, rc.PriorOutputAvailable))
+	}
+	if want.lastDecision != "" && rc.LastDecision != want.lastDecision {
+		fail(fmt.Sprintf("%s: last_decision want %q, got %q", label, want.lastDecision, rc.LastDecision))
+	}
+	fmt.Printf("  %s: gate_count=%d completion_count=%d status=%s ✔\n",
+		label, rc.GateCount, rc.CompletionCount, rc.PriorCompletionStatus)
+}
+
+func assert(cond bool, msg string) {
+	if !cond {
+		fail(msg)
+	}
+}
+
+func assertEqual(label, want, got string) {
+	if want != got {
+		fail(fmt.Sprintf("%s: want %q, got %q", label, want, got))
+	}
+}
+
+func fail(msg string) {
+	fmt.Fprintln(os.Stderr, "FAIL: "+msg)
+	os.Exit(1)
+}
+
+func banner(s string) {
+	fmt.Println()
+	fmt.Println("━━━", s, "━━━")
+}
+
+func envOrDie(key string, optionalDefault ...string) string {
+	v := os.Getenv(key)
+	if v != "" {
+		return v
+	}
+	if len(optionalDefault) > 0 {
+		return optionalDefault[0]
+	}
+	fail("missing required env var: " + key)
+	return "" // unreachable
+}

--- a/examples/wcp-retry-idempotency/community/java/pom.xml
+++ b/examples/wcp-retry-idempotency/community/java/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.getaxonflow.examples</groupId>
+    <artifactId>wcp-retry-idempotency</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>WCP retry_context + idempotency_key E2E Example</name>
+    <description>
+        E2E validation of #1673 Phase 1 + Phase 2 through the Java SDK.
+    </description>
+
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <!-- Pin Jackson to 2.18.6 to override the SDK 5.5.0 transitive 2.17.0,
+             which is vulnerable to GHSA-72hv-8253-57qq (jackson-core async parser DoS).
+             Drop this pin once the Java SDK ships a release that bumps Jackson. -->
+        <jackson.version>2.18.6</jackson.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${jackson.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.getaxonflow</groupId>
+            <artifactId>axonflow-sdk</artifactId>
+            <version>5.5.0</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <mainClass>com.getaxonflow.examples.WcpRetryIdempotency</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/wcp-retry-idempotency/community/java/src/main/java/com/getaxonflow/examples/WcpRetryIdempotency.java
+++ b/examples/wcp-retry-idempotency/community/java/src/main/java/com/getaxonflow/examples/WcpRetryIdempotency.java
@@ -1,0 +1,233 @@
+// Copyright 2026 AxonFlow
+// SPDX-License-Identifier: Apache-2.0
+//
+// WCP retry_context + idempotency_key E2E example (Issue #1673 Phase 1 + 2).
+//
+// Exercises the new Java SDK surface end-to-end against a running v7.3.0
+// enterprise stack. Every assertion fails the process with System.exit(1).
+//
+// Run from this directory:
+//   mvn install -DskipTests=true       # from the SDK root, first time only
+//   source /tmp/axonflow-e2e-env.sh
+//   export AXONFLOW_BASE_URL=http://localhost:8080
+//   mvn -q compile exec:java
+package com.getaxonflow.examples;
+
+import com.getaxonflow.sdk.AxonFlow;
+import com.getaxonflow.sdk.AxonFlowConfig;
+import com.getaxonflow.sdk.exceptions.IdempotencyKeyMismatchException;
+import com.getaxonflow.sdk.types.workflow.WorkflowTypes;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class WcpRetryIdempotency {
+
+    public static void main(String[] args) {
+        String endpoint = envOrDefault("AXONFLOW_BASE_URL", "http://localhost:8080");
+        String clientId = mustEnv("AXONFLOW_CLIENT_ID");
+        String clientSecret = mustEnv("AXONFLOW_CLIENT_SECRET");
+
+        AxonFlow client = AxonFlow.create(
+                AxonFlowConfig.builder()
+                        .endpoint(endpoint)
+                        .clientId(clientId)
+                        .clientSecret(clientSecret)
+                        .build());
+
+        banner("Act 1 — retry_context (Java SDK)");
+        act1(client);
+
+        banner("Act 2 — idempotency_key (Java SDK)");
+        act2(client);
+
+        banner("All assertions passed ✔");
+    }
+
+    private static void act1(AxonFlow client) {
+        WorkflowTypes.CreateWorkflowResponse wf = client.createWorkflow(
+                WorkflowTypes.CreateWorkflowRequest.builder()
+                        .workflowName("java-sdk-retry-context")
+                        .build());
+        System.out.println("workflow: " + wf.getWorkflowId());
+
+        // 1) First gate — first-call invariants
+        WorkflowTypes.StepGateResponse first = client.stepGate(
+                wf.getWorkflowId(),
+                "step-1",
+                WorkflowTypes.StepGateRequest.builder()
+                        .stepName("first-step")
+                        .stepType(WorkflowTypes.StepType.TOOL_CALL)
+                        .build());
+        WorkflowTypes.RetryContext rc = first.getRetryContext();
+        assertTrue("retry_context not null", rc != null);
+        assertEqInt("first gate_count", 1, rc.getGateCount());
+        assertEqInt("first completion_count", 0, rc.getCompletionCount());
+        assertEqStr("first prior_completion_status",
+                WorkflowTypes.PriorCompletionStatus.NONE.name(),
+                rc.getPriorCompletionStatus().name());
+        assertTrue("first !prior_output_available", !rc.isPriorOutputAvailable());
+        assertEqStr("first last_decision (first-call invariant)",
+                first.getDecision().name(), rc.getLastDecision().name());
+        assertTrue("first FirstAttemptAt == LastAttemptAt",
+                rc.getFirstAttemptAt().equals(rc.getLastAttemptAt()));
+        System.out.println("  first gate invariants ✔");
+
+        // 2) Complete, then re-gate
+        Map<String, Object> output = new HashMap<>();
+        output.put("transfer_id", "TXN-java-1");
+        output.put("amount", 500);
+        client.markStepCompleted(
+                wf.getWorkflowId(),
+                "step-1",
+                WorkflowTypes.MarkStepCompletedRequest.builder().output(output).build());
+        WorkflowTypes.StepGateResponse reGate = client.stepGate(
+                wf.getWorkflowId(),
+                "step-1",
+                WorkflowTypes.StepGateRequest.builder()
+                        .stepType(WorkflowTypes.StepType.TOOL_CALL)
+                        .build());
+        assertEqInt("re-gate post-complete gate_count", 2,
+                reGate.getRetryContext().getGateCount());
+        assertEqInt("re-gate post-complete completion_count", 1,
+                reGate.getRetryContext().getCompletionCount());
+        assertEqStr("re-gate post-complete prior_completion_status",
+                WorkflowTypes.PriorCompletionStatus.COMPLETED.name(),
+                reGate.getRetryContext().getPriorCompletionStatus().name());
+        assertTrue("re-gate post-complete prior_output_available",
+                reGate.getRetryContext().isPriorOutputAvailable());
+        assertTrue("re-gate post-complete prior_output omitted by default",
+                reGate.getRetryContext().getPriorOutput() == null);
+        assertTrue("re-gate post-complete cached==true", reGate.isCached());
+        System.out.println("  re-gate post-complete ✔");
+
+        // 3) Gate on step-2 without completion (agent-crash simulation)
+        client.stepGate(
+                wf.getWorkflowId(),
+                "step-2",
+                WorkflowTypes.StepGateRequest.builder()
+                        .stepName("second-step")
+                        .stepType(WorkflowTypes.StepType.TOOL_CALL)
+                        .build());
+        WorkflowTypes.StepGateResponse reGate2 = client.stepGate(
+                wf.getWorkflowId(),
+                "step-2",
+                WorkflowTypes.StepGateRequest.builder()
+                        .stepType(WorkflowTypes.StepType.TOOL_CALL)
+                        .build());
+        assertEqStr("gated_not_completed status",
+                WorkflowTypes.PriorCompletionStatus.GATED_NOT_COMPLETED.name(),
+                reGate2.getRetryContext().getPriorCompletionStatus().name());
+        assertEqInt("gated_not_completed completion_count", 0,
+                reGate2.getRetryContext().getCompletionCount());
+        System.out.println("  gated_not_completed ✔");
+
+        // 4) include_prior_output=true recovers the payload
+        WorkflowTypes.StepGateResponse withPrior = client.stepGate(
+                wf.getWorkflowId(),
+                "step-1",
+                WorkflowTypes.StepGateRequest.builder()
+                        .stepType(WorkflowTypes.StepType.TOOL_CALL)
+                        .build(),
+                WorkflowTypes.StepGateOptions.includePriorOutput());
+        assertTrue("prior_output populated",
+                withPrior.getRetryContext().getPriorOutput() != null);
+        assertEqStr("prior_output[transfer_id]", "TXN-java-1",
+                String.valueOf(withPrior.getRetryContext().getPriorOutput().get("transfer_id")));
+        System.out.println("  prior_output recovery ✔");
+    }
+
+    private static void act2(AxonFlow client) {
+        WorkflowTypes.CreateWorkflowResponse wf = client.createWorkflow(
+                WorkflowTypes.CreateWorkflowRequest.builder()
+                        .workflowName("java-sdk-idempotency-key")
+                        .build());
+        System.out.println("workflow: " + wf.getWorkflowId());
+
+        String originalKey = "payment:wire:java-sdk-invoice-1";
+
+        // 5) Gate with key — retry_context.idempotency_key echoes
+        WorkflowTypes.StepGateResponse first = client.stepGate(
+                wf.getWorkflowId(),
+                "step-1",
+                WorkflowTypes.StepGateRequest.builder()
+                        .stepName("wire")
+                        .stepType(WorkflowTypes.StepType.TOOL_CALL)
+                        .idempotencyKey(originalKey)
+                        .build());
+        assertEqStr("retry_context.idempotency_key echo",
+                originalKey, first.getRetryContext().getIdempotencyKey());
+        System.out.println("  key round-trip ✔");
+
+        // 6) Re-gate with different key → IdempotencyKeyMismatchException
+        try {
+            client.stepGate(
+                    wf.getWorkflowId(),
+                    "step-1",
+                    WorkflowTypes.StepGateRequest.builder()
+                            .stepType(WorkflowTypes.StepType.TOOL_CALL)
+                            .idempotencyKey("payment:wire:different-2")
+                            .build());
+            fail("expected IdempotencyKeyMismatchException on gate with different key");
+        } catch (IdempotencyKeyMismatchException e) {
+            assertEqStr("mismatch expected_key", originalKey, e.getExpectedIdempotencyKey());
+            assertEqStr("mismatch received_key", "payment:wire:different-2",
+                    e.getReceivedIdempotencyKey());
+            assertTrue("mismatch workflow_id populated",
+                    e.getWorkflowId() != null && e.getWorkflowId().startsWith("wf_"));
+            assertEqStr("mismatch step_id", "step-1", e.getStepId());
+        }
+        System.out.println("  typed 409 error ✔");
+
+        // 7) Complete with matching key
+        Map<String, Object> output = new HashMap<>();
+        output.put("transfer_id", "TXN-K1");
+        client.markStepCompleted(
+                wf.getWorkflowId(),
+                "step-1",
+                WorkflowTypes.MarkStepCompletedRequest.builder()
+                        .output(output)
+                        .idempotencyKey(originalKey)
+                        .build());
+        System.out.println("  complete with matching key ✔");
+    }
+
+    // --- helpers ---
+
+    private static String envOrDefault(String name, String fallback) {
+        String v = System.getenv(name);
+        return v == null || v.isEmpty() ? fallback : v;
+    }
+
+    private static String mustEnv(String name) {
+        String v = System.getenv(name);
+        if (v == null || v.isEmpty()) {
+            fail("missing env: " + name);
+        }
+        return v;
+    }
+
+    private static void assertTrue(String label, boolean cond) {
+        if (!cond) fail("assertion failed: " + label);
+    }
+
+    private static void assertEqStr(String label, String want, String got) {
+        if (want == null ? got != null : !want.equals(got)) {
+            fail(label + ": want \"" + want + "\", got \"" + got + "\"");
+        }
+    }
+
+    private static void assertEqInt(String label, int want, int got) {
+        if (want != got) fail(label + ": want " + want + ", got " + got);
+    }
+
+    private static void fail(String msg) {
+        System.err.println("FAIL: " + msg);
+        System.exit(1);
+    }
+
+    private static void banner(String s) {
+        System.out.println();
+        System.out.println("━━━ " + s + " ━━━");
+    }
+}

--- a/examples/wcp-retry-idempotency/community/python/main.py
+++ b/examples/wcp-retry-idempotency/community/python/main.py
@@ -1,0 +1,210 @@
+"""WCP retry_context + idempotency_key E2E example (Issue #1673 Phase 1 + 2).
+
+Exercises the new SDK surface end-to-end against a running v7.3.0 enterprise
+stack. Every assertion fails the process on mismatch.
+
+Run:
+    source /tmp/axonflow-e2e-env.sh
+    export AXONFLOW_BASE_URL=http://localhost:8080
+    python examples/wcp_retry_idempotency.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+
+from axonflow import AxonFlow
+from axonflow.exceptions import IdempotencyKeyMismatchError
+from axonflow.workflow import (
+    CreateWorkflowRequest,
+    MarkStepCompletedRequest,
+    StepGateRequest,
+    StepType,
+)
+
+
+def must_env(name: str) -> str:
+    v = os.environ.get(name)
+    if not v:
+        print(f"missing env: {name}", file=sys.stderr)
+        sys.exit(1)
+    return v
+
+
+def banner(msg: str) -> None:
+    print()
+    print("━━━", msg, "━━━")
+
+
+def fail(msg: str) -> None:
+    print(f"FAIL: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def assert_eq(label: str, want: object, got: object) -> None:
+    if want != got:
+        fail(f"{label}: want {want!r}, got {got!r}")
+
+
+def assert_true(label: str, cond: bool) -> None:
+    if not cond:
+        fail(f"assertion failed: {label}")
+
+
+async def act1(client: AxonFlow) -> None:
+    wf = await client.create_workflow(CreateWorkflowRequest(workflow_name="py-sdk-retry-context"))
+    print(f"workflow: {wf.workflow_id}")
+
+    # 1) First gate — first-call invariants
+    first = await client.step_gate(
+        wf.workflow_id,
+        "step-1",
+        StepGateRequest(step_name="first-step", step_type=StepType.TOOL_CALL),
+    )
+    rc = first.retry_context
+    assert rc is not None, "retry_context missing on first gate"
+    assert_eq("first gate_count", 1, rc.gate_count)
+    assert_eq("first completion_count", 0, rc.completion_count)
+    assert_eq("first prior_completion_status", "none", rc.prior_completion_status)
+    assert_true("first !prior_output_available", not rc.prior_output_available)
+    assert_eq(
+        "first last_decision (first-call invariant)",
+        first.decision.value,
+        rc.last_decision.value if hasattr(rc.last_decision, "value") else rc.last_decision,
+    )
+    assert_eq("first FirstAttemptAt == LastAttemptAt", rc.first_attempt_at, rc.last_attempt_at)
+    print("  first gate invariants ✔")
+
+    # 2) Complete, then re-gate
+    await client.mark_step_completed(
+        wf.workflow_id,
+        "step-1",
+        MarkStepCompletedRequest(output={"transfer_id": "TXN-py-1", "amount": 500}),
+    )
+    re_gate = await client.step_gate(
+        wf.workflow_id,
+        "step-1",
+        StepGateRequest(step_type=StepType.TOOL_CALL),
+    )
+    rc = re_gate.retry_context
+    assert rc is not None
+    assert_eq("re-gate post-complete gate_count", 2, rc.gate_count)
+    assert_eq("re-gate post-complete completion_count", 1, rc.completion_count)
+    assert_eq(
+        "re-gate post-complete prior_completion_status", "completed", rc.prior_completion_status
+    )
+    assert_true("re-gate post-complete prior_output_available", rc.prior_output_available)
+    assert_true("re-gate post-complete prior_output omitted by default", rc.prior_output is None)
+    assert_true("re-gate post-complete cached==True", re_gate.cached is True)
+    print("  re-gate post-complete ✔")
+
+    # 3) Gate on step-2 without completion (agent-crash simulation)
+    await client.step_gate(
+        wf.workflow_id,
+        "step-2",
+        StepGateRequest(step_name="second-step", step_type=StepType.TOOL_CALL),
+    )
+    re_gate2 = await client.step_gate(
+        wf.workflow_id,
+        "step-2",
+        StepGateRequest(step_type=StepType.TOOL_CALL),
+    )
+    assert re_gate2.retry_context is not None
+    assert_eq(
+        "gated_not_completed status",
+        "gated_not_completed",
+        re_gate2.retry_context.prior_completion_status,
+    )
+    assert_eq("gated_not_completed completion_count", 0, re_gate2.retry_context.completion_count)
+    print("  gated_not_completed ✔")
+
+    # 4) include_prior_output=True recovers the payload
+    with_prior = await client.step_gate(
+        wf.workflow_id,
+        "step-1",
+        StepGateRequest(step_type=StepType.TOOL_CALL),
+        include_prior_output=True,
+    )
+    assert with_prior.retry_context is not None
+    assert_true("prior_output populated", with_prior.retry_context.prior_output is not None)
+    assert_eq(
+        "prior_output[transfer_id]",
+        "TXN-py-1",
+        with_prior.retry_context.prior_output["transfer_id"],
+    )
+    print("  prior_output recovery ✔")
+
+
+async def act2(client: AxonFlow) -> None:
+    wf = await client.create_workflow(CreateWorkflowRequest(workflow_name="py-sdk-idempotency-key"))
+    print(f"workflow: {wf.workflow_id}")
+
+    original_key = "payment:wire:py-sdk-invoice-1"
+
+    # 5) Gate with key — retry_context.idempotency_key echoes
+    first = await client.step_gate(
+        wf.workflow_id,
+        "step-1",
+        StepGateRequest(
+            step_name="wire", step_type=StepType.TOOL_CALL, idempotency_key=original_key
+        ),
+    )
+    assert first.retry_context is not None
+    assert_eq(
+        "retry_context.idempotency_key echo", original_key, first.retry_context.idempotency_key
+    )
+    print("  key round-trip ✔")
+
+    # 6) Re-gate with different key → IdempotencyKeyMismatchError
+    try:
+        await client.step_gate(
+            wf.workflow_id,
+            "step-1",
+            StepGateRequest(
+                step_type=StepType.TOOL_CALL, idempotency_key="payment:wire:different-2"
+            ),
+        )
+        fail("expected IdempotencyKeyMismatchError on gate with different key")
+    except IdempotencyKeyMismatchError as err:
+        assert_eq("mismatch expected_key", original_key, err.expected_idempotency_key)
+        assert_eq("mismatch received_key", "payment:wire:different-2", err.received_idempotency_key)
+        assert_true("mismatch workflow_id populated", err.workflow_id.startswith("wf_"))
+        assert_eq("mismatch step_id", "step-1", err.step_id)
+    print("  typed 409 error ✔")
+
+    # 7) Complete with matching key
+    await client.mark_step_completed(
+        wf.workflow_id,
+        "step-1",
+        MarkStepCompletedRequest(output={"transfer_id": "TXN-K1"}, idempotency_key=original_key),
+    )
+    print("  complete with matching key ✔")
+
+
+async def main() -> None:
+    endpoint = os.environ.get("AXONFLOW_BASE_URL", "http://localhost:8080")
+    client_id = must_env("AXONFLOW_CLIENT_ID")
+    client_secret = must_env("AXONFLOW_CLIENT_SECRET")
+
+    client = AxonFlow(
+        endpoint=endpoint,
+        client_id=client_id,
+        client_secret=client_secret,
+    )
+
+    try:
+        banner("Act 1 — retry_context (Python SDK)")
+        await act1(client)
+
+        banner("Act 2 — idempotency_key (Python SDK)")
+        await act2(client)
+
+        banner("All assertions passed ✔")
+    finally:
+        await client.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/wcp-retry-idempotency/community/typescript/index.ts
+++ b/examples/wcp-retry-idempotency/community/typescript/index.ts
@@ -1,0 +1,157 @@
+/**
+ * WCP retry_context + idempotency_key E2E example (Issue #1673 Phase 1 + 2).
+ *
+ * Exercises the new SDK surface end-to-end against a running v7.3.0
+ * enterprise stack.
+ *
+ * Run:
+ *   source /tmp/axonflow-e2e-env.sh
+ *   export AXONFLOW_BASE_URL=http://localhost:8080
+ *   npx ts-node index.ts
+ */
+
+import {
+  AxonFlow,
+  IdempotencyKeyMismatchError,
+  type StepGateRequest,
+} from '@axonflow/sdk';
+
+function mustEnv(k: string): string {
+  const v = process.env[k];
+  if (!v) {
+    console.error(`missing env: ${k}`);
+    process.exit(1);
+  }
+  return v;
+}
+
+function banner(s: string): void {
+  console.log('');
+  console.log('━━━', s, '━━━');
+}
+
+function fail(msg: string): never {
+  console.error('FAIL:', msg);
+  process.exit(1);
+}
+
+function assertEqStr(label: string, want: string, got: string): void {
+  if (want !== got) fail(`${label}: want "${want}", got "${got}"`);
+}
+
+function assertEqInt(label: string, want: number, got: number): void {
+  if (want !== got) fail(`${label}: want ${want}, got ${got}`);
+}
+
+function assertTrue(label: string, cond: boolean): void {
+  if (!cond) fail(`assertion failed: ${label}`);
+}
+
+async function main(): Promise<void> {
+  const endpoint = process.env.AXONFLOW_BASE_URL || 'http://localhost:8080';
+  const clientId = mustEnv('AXONFLOW_CLIENT_ID');
+  const clientSecret = mustEnv('AXONFLOW_CLIENT_SECRET');
+
+  const client = new AxonFlow({ clientId, clientSecret, endpoint });
+
+  banner('Act 1 — retry_context (TypeScript SDK)');
+  await act1(client);
+
+  banner('Act 2 — idempotency_key (TypeScript SDK)');
+  await act2(client);
+
+  banner('All assertions passed ✔');
+}
+
+async function act1(client: AxonFlow): Promise<void> {
+  const wf = await client.createWorkflow({ workflow_name: 'ts-sdk-retry-context' });
+  console.log(`workflow: ${wf.workflow_id}`);
+
+  // 1) First gate — first-call invariants
+  const req: StepGateRequest = { step_name: 'first-step', step_type: 'tool_call' as const };
+  const first = await client.stepGate(wf.workflow_id, 'step-1', req);
+  assertEqInt('first gate_count', 1, first.retry_context.gate_count);
+  assertEqInt('first completion_count', 0, first.retry_context.completion_count);
+  assertEqStr('first prior_completion_status', 'none', first.retry_context.prior_completion_status);
+  assertTrue('first !prior_output_available', !first.retry_context.prior_output_available);
+  assertEqStr('first last_decision (first-call invariant)', first.decision, first.retry_context.last_decision);
+  assertEqStr('first FirstAttemptAt == LastAttemptAt', first.retry_context.first_attempt_at ?? '', first.retry_context.last_attempt_at ?? '');
+  console.log('  first gate invariants ✔');
+
+  // 2) Complete, then re-gate
+  await client.markStepCompleted(wf.workflow_id, 'step-1', {
+    output: { transfer_id: 'TXN-ts-1', amount: 500 },
+  });
+  const reGate = await client.stepGate(wf.workflow_id, 'step-1', { step_type: 'tool_call' as const });
+  assertEqInt('re-gate post-complete gate_count', 2, reGate.retry_context.gate_count);
+  assertEqInt('re-gate post-complete completion_count', 1, reGate.retry_context.completion_count);
+  assertEqStr('re-gate post-complete prior_completion_status', 'completed', reGate.retry_context.prior_completion_status);
+  assertTrue('re-gate post-complete prior_output_available', reGate.retry_context.prior_output_available);
+  assertTrue('re-gate post-complete prior_output omitted by default', reGate.retry_context.prior_output === null || reGate.retry_context.prior_output === undefined);
+  assertTrue('re-gate post-complete cached==true', reGate.cached);
+  console.log('  re-gate post-complete ✔');
+
+  // 3) Gate on step-2 without completion (agent-crash simulation)
+  await client.stepGate(wf.workflow_id, 'step-2', { step_name: 'second-step', step_type: 'tool_call' as const });
+  const reGate2 = await client.stepGate(wf.workflow_id, 'step-2', { step_type: 'tool_call' as const });
+  assertEqStr('gated_not_completed status', 'gated_not_completed', reGate2.retry_context.prior_completion_status);
+  assertEqInt('gated_not_completed completion_count', 0, reGate2.retry_context.completion_count);
+  console.log('  gated_not_completed ✔');
+
+  // 4) include_prior_output=true recovers the payload
+  const withPrior = await client.stepGate(
+    wf.workflow_id,
+    'step-1',
+    { step_type: 'tool_call' as const },
+    { includePriorOutput: true }
+  );
+  assertTrue('prior_output populated', !!withPrior.retry_context.prior_output);
+  assertEqStr('prior_output.transfer_id', 'TXN-ts-1', String(withPrior.retry_context.prior_output!.transfer_id));
+  console.log('  prior_output recovery ✔');
+}
+
+async function act2(client: AxonFlow): Promise<void> {
+  const wf = await client.createWorkflow({ workflow_name: 'ts-sdk-idempotency-key' });
+  console.log(`workflow: ${wf.workflow_id}`);
+
+  const originalKey = 'payment:wire:ts-sdk-invoice-1';
+
+  // 5) Gate with key — echoes back
+  const first = await client.stepGate(wf.workflow_id, 'step-1', {
+    step_name: 'wire',
+    step_type: 'tool_call' as const,
+    idempotency_key: originalKey,
+  });
+  assertEqStr('retry_context.idempotency_key echo', originalKey, first.retry_context.idempotency_key);
+  console.log('  key round-trip ✔');
+
+  // 6) Re-gate with different key → IdempotencyKeyMismatchError
+  try {
+    await client.stepGate(wf.workflow_id, 'step-1', {
+      step_type: 'tool_call' as const,
+      idempotency_key: 'payment:wire:different-2',
+    });
+    fail('expected IdempotencyKeyMismatchError on gate with different key');
+  } catch (err) {
+    if (!(err instanceof IdempotencyKeyMismatchError)) {
+      fail(`expected IdempotencyKeyMismatchError, got ${(err as Error).constructor?.name}: ${(err as Error).message}`);
+    }
+    assertEqStr('mismatch expected_key', originalKey, err.expectedIdempotencyKey);
+    assertEqStr('mismatch received_key', 'payment:wire:different-2', err.receivedIdempotencyKey);
+    assertTrue('mismatch workflow_id', err.workflowId.startsWith('wf_'));
+    assertEqStr('mismatch step_id', 'step-1', err.stepId);
+  }
+  console.log('  typed 409 error ✔');
+
+  // 7) Complete with matching key
+  await client.markStepCompleted(wf.workflow_id, 'step-1', {
+    output: { transfer_id: 'TXN-K1' },
+    idempotency_key: originalKey,
+  });
+  console.log('  complete with matching key ✔');
+}
+
+main().catch((err) => {
+  console.error('UNEXPECTED ERROR:', err);
+  process.exit(1);
+});

--- a/examples/wcp-retry-idempotency/community/typescript/package.json
+++ b/examples/wcp-retry-idempotency/community/typescript/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "wcp-retry-idempotency-community",
+  "version": "0.0.0",
+  "private": true,
+  "type": "commonjs",
+  "description": "E2E validation for retry_context + idempotency_key (#1673 P1+P2, Community tier) via the TypeScript SDK",
+  "scripts": {
+    "start": "ts-node index.ts"
+  },
+  "dependencies": {
+    "@axonflow/sdk": "file:../../../../../axonflow-sdk-typescript-1673"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "ts-node": "^10.9.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/examples/wcp-retry-idempotency/community/typescript/tsconfig.json
+++ b/examples/wcp-retry-idempotency/community/typescript/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true
+  },
+  "ts-node": {
+    "transpileOnly": true
+  }
+}

--- a/examples/wcp-retry-idempotency/evaluation/go/go.mod
+++ b/examples/wcp-retry-idempotency/evaluation/go/go.mod
@@ -1,0 +1,8 @@
+module github.com/getaxonflow/axonflow-enterprise/examples/wcp-retry-idempotency/evaluation/go
+
+go 1.23
+
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.5.0
+
+// Temporary local replace — remove when SDK v5.6.0 publishes.
+replace github.com/getaxonflow/axonflow-sdk-go/v5 => ../../../../../axonflow-sdk-go-1673

--- a/examples/wcp-retry-idempotency/evaluation/go/main.go
+++ b/examples/wcp-retry-idempotency/evaluation/go/main.go
@@ -1,0 +1,171 @@
+// Copyright 2026 AxonFlow
+// SPDX-License-Identifier: BUSL-1.1
+//
+// Evaluation-tier example (Go SDK variant) for Issue #1673 retry-aware
+// dynamic policy. See ../http/main.go for the rationale; this program does
+// the same thing through the axonflow-sdk-go client, with the policy
+// created via a raw HTTP call (the Go SDK does not expose a
+// createPolicy helper).
+//
+// ⚠️ Evaluation or Enterprise license required — dynamic policy creation
+// has tier limits; Community licenses may hit the policy-count cap.
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"time"
+
+	axonflow "github.com/getaxonflow/axonflow-sdk-go/v5"
+)
+
+const policyName = "Retry on gated-not-completed wire requires approval"
+
+type policyCreateResp struct {
+	Policy struct {
+		ID string `json:"id"`
+	} `json:"policy"`
+}
+
+func createRetryAwarePolicy(baseURL, clientID, clientSecret string) string {
+	body := map[string]interface{}{
+		"name":        policyName,
+		"description": "Human verification required before re-executing a wire when the prior attempt never completed.",
+		"type":        "context_aware",
+		"priority":    100,
+		"enabled":     true,
+		"conditions": []map[string]interface{}{
+			{"field": "step.gate_count", "operator": "greater_than", "value": 1},
+			{"field": "step.prior_completion_status", "operator": "equals", "value": "gated_not_completed"},
+			{"field": "context.tool_name", "operator": "equals", "value": "core_banking_transfer"},
+		},
+		"actions": []map[string]interface{}{
+			{
+				"type": "require_approval",
+				"config": map[string]string{
+					"reason":   "Retry on un-completed wire — verify with bank before re-execution",
+					"severity": "high",
+				},
+			},
+		},
+	}
+	raw, _ := json.Marshal(body)
+	req, _ := http.NewRequest("POST", baseURL+"/api/v1/policies", bytes.NewReader(raw))
+	req.Header.Set("Content-Type", "application/json")
+	req.SetBasicAuth(clientID, clientSecret)
+	resp, err := (&http.Client{Timeout: 10 * time.Second}).Do(req)
+	if err != nil {
+		fail("create policy: " + err.Error())
+	}
+	defer resp.Body.Close()
+	data, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		fail(fmt.Sprintf("create policy: status=%d body=%s", resp.StatusCode, data))
+	}
+	var pr policyCreateResp
+	_ = json.Unmarshal(data, &pr)
+	if pr.Policy.ID == "" {
+		fail(fmt.Sprintf("create policy: empty policy.id in response, body=%s", data))
+	}
+	return pr.Policy.ID
+}
+
+func deletePolicy(baseURL, clientID, clientSecret, policyID string) {
+	req, _ := http.NewRequest("DELETE", baseURL+"/api/v1/policies/"+url.PathEscape(policyID), nil)
+	req.SetBasicAuth(clientID, clientSecret)
+	resp, _ := (&http.Client{Timeout: 5 * time.Second}).Do(req)
+	if resp != nil {
+		resp.Body.Close()
+	}
+}
+
+func main() {
+	baseURL := envOrDefault("AXONFLOW_BASE_URL", "http://localhost:8080")
+	clientID := mustEnv("AXONFLOW_CLIENT_ID")
+	clientSecret := mustEnv("AXONFLOW_CLIENT_SECRET")
+
+	banner("Retry-aware policy (Go SDK, Evaluation tier)")
+
+	policyID := createRetryAwarePolicy(baseURL, clientID, clientSecret)
+	fmt.Printf("  policy created: %s\n", policyID)
+	defer deletePolicy(baseURL, clientID, clientSecret, policyID)
+
+	client := axonflow.NewClient(axonflow.AxonFlowConfig{
+		Endpoint: baseURL, ClientID: clientID, ClientSecret: clientSecret,
+	})
+
+	wf, err := client.CreateWorkflow(axonflow.CreateWorkflowRequest{
+		WorkflowName: "eval-retry-aware-go",
+	})
+	must(err, "create workflow")
+	fmt.Printf("  workflow: %s\n", wf.WorkflowID)
+
+	toolCtx := &axonflow.ToolContext{
+		ToolName: "core_banking_transfer", ToolType: "api",
+	}
+	req := axonflow.StepGateRequest{
+		StepName: "Initiate Wire", StepType: axonflow.StepTypeToolCall,
+		StepInput:   map[string]interface{}{"amount_eur": 750, "to_account": "1234"},
+		ToolContext: toolCtx,
+	}
+
+	// 1) First gate — allow.
+	first, err := client.StepGate(wf.WorkflowID, "step-1", req)
+	must(err, "first gate")
+	if first.Decision != axonflow.GateDecisionAllow {
+		fail(fmt.Sprintf("first gate: want allow, got %s", first.Decision))
+	}
+	fmt.Println("  first gate: allow (gate_count=1, policy doesn't fire) ✔")
+
+	// 2) Second gate, default retry_policy — cached allow, policy bypassed.
+	cached, err := client.StepGate(wf.WorkflowID, "step-1", req)
+	must(err, "cached gate")
+	if !cached.Cached {
+		fail("second gate should be cached")
+	}
+	if cached.Decision != axonflow.GateDecisionAllow {
+		fail(fmt.Sprintf("second gate: want allow (cache bypasses policy), got %s", cached.Decision))
+	}
+	fmt.Println("  second gate cached: still allow (cache bypasses policy) ✔")
+
+	// 3) Reevaluate — retry-aware policy fires.
+	reevaluate := req
+	reevaluate.RetryPolicy = axonflow.RetryPolicyReevaluate
+	third, err := client.StepGate(wf.WorkflowID, "step-1", reevaluate)
+	must(err, "reevaluate gate")
+	if third.Cached {
+		fail("reevaluate gate should not be cached")
+	}
+	if third.Decision != axonflow.GateDecisionRequireApproval {
+		fail(fmt.Sprintf("reevaluate gate: want require_approval (retry-aware policy), got %s (%s)", third.Decision, third.Reason))
+	}
+	fmt.Println("  third gate (reevaluate): require_approval (policy FIRED) ✔")
+
+	banner("Evaluation-tier Go SDK demo passed ✔")
+}
+
+func envOrDefault(k, d string) string {
+	if v := os.Getenv(k); v != "" {
+		return v
+	}
+	return d
+}
+func mustEnv(k string) string {
+	v := os.Getenv(k)
+	if v == "" {
+		fail("missing env: " + k)
+	}
+	return v
+}
+func must(err error, label string) {
+	if err != nil {
+		fail(label + ": " + err.Error())
+	}
+}
+func fail(msg string) { fmt.Fprintln(os.Stderr, "FAIL: "+msg); os.Exit(1) }
+func banner(s string) { fmt.Println(); fmt.Println("━━━", s, "━━━") }

--- a/examples/wcp-retry-idempotency/evaluation/http/go.mod
+++ b/examples/wcp-retry-idempotency/evaluation/http/go.mod
@@ -1,0 +1,3 @@
+module github.com/getaxonflow/axonflow-enterprise/examples/wcp-retry-idempotency/evaluation/http
+
+go 1.23

--- a/examples/wcp-retry-idempotency/evaluation/http/main.go
+++ b/examples/wcp-retry-idempotency/evaluation/http/main.go
@@ -1,0 +1,280 @@
+// Copyright 2026 AxonFlow
+// SPDX-License-Identifier: BUSL-1.1
+//
+// Evaluation-tier example for Issue #1673: retry-aware policy authoring.
+//
+// Exercises the policy engine side of retry_context — the Community-tier
+// primitives (counters, status, idempotency_key) are always visible; what
+// the Evaluation tier unlocks is the ability to write policy conditions
+// against them:
+//
+//   step.gate_count                 (int)
+//   step.completion_count           (int)
+//   step.prior_completion_status    ("none" | "completed" | "gated_not_completed")
+//   step.prior_output_available     (bool)
+//   step.last_decision              ("allow" | "block" | "require_approval")
+//   step.first_attempt_age_seconds  (int)
+//   step.idempotency_key            (string, equals/regex)
+//
+// The demo creates a dynamic policy —
+//     "if step.gate_count > 1 AND step.prior_completion_status ==
+//      'gated_not_completed' AND tool_name == 'core_banking_transfer',
+//      then require_approval"
+// — that only fires on the uncertain-territory retry case. We then:
+//   1. Verify first gate: policy does NOT fire (gate_count == 1).
+//   2. Skip /complete (simulate agent crash between gate and complete).
+//   3. Re-gate same step: policy NOW fires, returns require_approval.
+//
+// ⚠️ EVALUATION OR ENTERPRISE LICENSE REQUIRED
+// Dynamic-policy authoring is gated at the Evaluation tier and above.
+// On Community, this example will fail on policy creation with a
+// tier-denial error. Use `./scripts/setup-e2e-testing.sh evaluation`
+// or `enterprise` to boot a stack that accepts this flow.
+//
+// Usage:
+//   ./scripts/setup-e2e-testing.sh enterprise
+//   source /tmp/axonflow-e2e-env.sh
+//   export AXONFLOW_BASE_URL=http://localhost:8080
+//   cd examples/wcp-retry-idempotency/evaluation/http
+//   go run main.go
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"time"
+)
+
+type client struct {
+	baseURL      string
+	clientID     string
+	clientSecret string
+	http         *http.Client
+}
+
+func (c *client) auth(req *http.Request) {
+	req.Header.Set("Content-Type", "application/json")
+	req.SetBasicAuth(c.clientID, c.clientSecret)
+}
+
+func (c *client) do(method, path string, body interface{}) (int, []byte) {
+	var rdr io.Reader
+	if body != nil {
+		b, _ := json.Marshal(body)
+		rdr = bytes.NewReader(b)
+	}
+	req, _ := http.NewRequest(method, c.baseURL+path, rdr)
+	c.auth(req)
+	resp, err := c.http.Do(req)
+	if err != nil {
+		fail(method + " " + path + ": " + err.Error())
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, raw
+}
+
+// createRetryAwarePolicy authors a dynamic policy that require_approval's
+// ANY retry on a core_banking_transfer step where no prior /complete landed.
+// Returns the policy_id so we can delete it at teardown.
+func createRetryAwarePolicy(c *client) string {
+	body := map[string]interface{}{
+		"name":        "Retry on gated-not-completed wire requires approval",
+		"description": "Human verification required before re-executing a wire when the prior attempt never completed.",
+		"type":        "context_aware",
+		"priority":    100,
+		"enabled":     true,
+		"conditions": []map[string]interface{}{
+			{"field": "step.gate_count", "operator": "greater_than", "value": 1},
+			{"field": "step.prior_completion_status", "operator": "equals", "value": "gated_not_completed"},
+			{"field": "context.tool_name", "operator": "equals", "value": "core_banking_transfer"},
+		},
+		"actions": []map[string]interface{}{
+			{
+				"type": "require_approval",
+				"config": map[string]string{
+					"reason":   "Retry on un-completed wire — verify with bank before re-execution",
+					"severity": "high",
+				},
+			},
+		},
+	}
+	code, raw := c.do("POST", "/api/v1/policies", body)
+	if code != http.StatusCreated && code != http.StatusOK {
+		fail(fmt.Sprintf("create policy: status=%d body=%s", code, raw))
+	}
+	var resp struct {
+		Policy struct {
+			ID string `json:"id"`
+		} `json:"policy"`
+	}
+	_ = json.Unmarshal(raw, &resp)
+	if resp.Policy.ID == "" {
+		fail(fmt.Sprintf("create policy: empty policy.id in response, body=%s", raw))
+	}
+	fmt.Printf("  policy created: %s\n", resp.Policy.ID)
+	return resp.Policy.ID
+}
+
+func deletePolicy(c *client, policyID string) {
+	c.do("DELETE", "/api/v1/policies/"+url.PathEscape(policyID), nil)
+}
+
+func createWorkflow(c *client, name string) string {
+	code, raw := c.do("POST", "/api/v1/workflows", map[string]string{"workflow_name": name})
+	if code != http.StatusOK && code != http.StatusCreated {
+		fail(fmt.Sprintf("create workflow: status=%d body=%s", code, raw))
+	}
+	var resp struct {
+		WorkflowID string `json:"workflow_id"`
+	}
+	_ = json.Unmarshal(raw, &resp)
+	return resp.WorkflowID
+}
+
+type gateResponse struct {
+	Decision       string `json:"decision"`
+	Reason         string `json:"reason"`
+	Cached         bool   `json:"cached"`
+	DecisionSource string `json:"decision_source"`
+	RetryContext   struct {
+		GateCount             int    `json:"gate_count"`
+		CompletionCount       int    `json:"completion_count"`
+		PriorCompletionStatus string `json:"prior_completion_status"`
+		LastDecision          string `json:"last_decision"`
+	} `json:"retry_context"`
+}
+
+// gate sends a /gate call. retryPolicy is the value for the `retry_policy`
+// request field — empty string means server default ("idempotent"). Callers
+// that want retry-aware policies to fire MUST pass "reevaluate" on retries,
+// otherwise the server returns the cached decision without running the
+// policy engine.
+func gate(c *client, wfID, stepID, retryPolicy string) *gateResponse {
+	body := map[string]interface{}{
+		"step_name": "Initiate Wire",
+		"step_type": "tool_call",
+		"step_input": map[string]interface{}{
+			"amount_eur":  750,
+			"to_account":  "1234",
+			"description": "retry-aware-policy demo",
+		},
+		"tool_context": map[string]string{
+			"tool_name": "core_banking_transfer",
+			"tool_type": "api",
+		},
+	}
+	if retryPolicy != "" {
+		body["retry_policy"] = retryPolicy
+	}
+	code, raw := c.do("POST", "/api/v1/workflows/"+url.PathEscape(wfID)+"/steps/"+url.PathEscape(stepID)+"/gate", body)
+	if code != http.StatusOK {
+		fail(fmt.Sprintf("gate %s/%s: status=%d body=%s", wfID, stepID, code, raw))
+	}
+	var g gateResponse
+	if err := json.Unmarshal(raw, &g); err != nil {
+		fail("gate unmarshal: " + err.Error())
+	}
+	return &g
+}
+
+func main() {
+	baseURL := envOrDefault("AXONFLOW_BASE_URL", "http://localhost:8080")
+	c := &client{
+		baseURL:      baseURL,
+		clientID:     mustEnv("AXONFLOW_CLIENT_ID"),
+		clientSecret: mustEnv("AXONFLOW_CLIENT_SECRET"),
+		http:         &http.Client{Timeout: 10 * time.Second},
+	}
+
+	banner("Retry-aware policy (Evaluation tier)")
+
+	// Setup: author the retry-aware policy. Clean up at the end even if
+	// assertions fail partway — leaving a stray policy around breaks later
+	// runs.
+	policyID := createRetryAwarePolicy(c)
+	defer deletePolicy(c, policyID)
+
+	wfID := createWorkflow(c, "retry-aware-policy-demo")
+	fmt.Printf("  workflow: %s\n", wfID)
+
+	// 1. First gate — policy does NOT fire because step.gate_count == 1.
+	//    Uses default retry_policy (idempotent); policy engine runs because
+	//    there's no cached decision yet.
+	resp := gate(c, wfID, "step-1", "")
+	if resp.Decision != "allow" {
+		fail(fmt.Sprintf("first gate: want allow (gate_count=1, policy shouldn't fire), got %s (%s)", resp.Decision, resp.Reason))
+	}
+	if resp.RetryContext.GateCount != 1 {
+		fail(fmt.Sprintf("first gate: gate_count want 1, got %d", resp.RetryContext.GateCount))
+	}
+	fmt.Println("  first gate: allow (gate_count=1, policy doesn't fire) ✔")
+
+	// 2. Demonstrate the cache-bypass pitfall: default retry_policy on retry
+	//    returns the cached decision without consulting the policy engine,
+	//    so retry-aware conditions DO NOT fire even if their conditions
+	//    would match. This assertion locks the current semantics — if a
+	//    future change makes retry-aware policies fire on cached retries,
+	//    this line will fail and prompt a deliberate update.
+	cached := gate(c, wfID, "step-1", "")
+	if !cached.Cached {
+		fail("second gate should be cached under default retry_policy")
+	}
+	if cached.Decision != "allow" {
+		fail(fmt.Sprintf("second gate (cached): want allow (cached bypasses policy), got %s (%s)", cached.Decision, cached.Reason))
+	}
+	if cached.RetryContext.GateCount != 2 {
+		fail(fmt.Sprintf("second gate: gate_count want 2, got %d", cached.RetryContext.GateCount))
+	}
+	fmt.Println("  second gate cached: still allow (cache bypasses policy) ✔")
+
+	// 3. Reevaluate — NO /complete, so prior_completion_status is
+	//    gated_not_completed. With retry_policy=reevaluate the policy
+	//    engine runs fresh and the retry-aware condition fires.
+	resp = gate(c, wfID, "step-1", "reevaluate")
+	if resp.Cached {
+		fail("third gate should not be cached (retry_policy=reevaluate)")
+	}
+	if resp.RetryContext.GateCount != 3 {
+		fail(fmt.Sprintf("third gate: gate_count want 3, got %d", resp.RetryContext.GateCount))
+	}
+	if resp.RetryContext.PriorCompletionStatus != "gated_not_completed" {
+		fail(fmt.Sprintf("third gate: prior_completion_status want gated_not_completed, got %s", resp.RetryContext.PriorCompletionStatus))
+	}
+	if resp.Decision != "require_approval" {
+		fail(fmt.Sprintf("third gate: want require_approval (retry-aware policy fires on reevaluate), got %s (%s)", resp.Decision, resp.Reason))
+	}
+	fmt.Println("  third gate (reevaluate): require_approval (retry-aware policy FIRED) ✔")
+
+	banner("Evaluation-tier policy demo passed ✔")
+}
+
+func envOrDefault(k, d string) string {
+	if v := os.Getenv(k); v != "" {
+		return v
+	}
+	return d
+}
+
+func mustEnv(k string) string {
+	v := os.Getenv(k)
+	if v == "" {
+		fail("missing env: " + k)
+	}
+	return v
+}
+
+func fail(msg string) {
+	fmt.Fprintln(os.Stderr, "FAIL: "+msg)
+	os.Exit(1)
+}
+
+func banner(s string) {
+	fmt.Println()
+	fmt.Println("━━━", s, "━━━")
+}

--- a/examples/wcp-retry-idempotency/evaluation/java/pom.xml
+++ b/examples/wcp-retry-idempotency/evaluation/java/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.getaxonflow.examples</groupId>
+    <artifactId>wcp-retry-idempotency-evaluation</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>WCP retry-aware policy demo (Java SDK, Evaluation tier)</name>
+
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <!-- Pin Jackson to 2.18.6 to override the SDK 5.5.0 transitive 2.17.0,
+             which is vulnerable to GHSA-72hv-8253-57qq (jackson-core async parser DoS).
+             Drop this pin once the Java SDK ships a release that bumps Jackson. -->
+        <jackson.version>2.18.6</jackson.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${jackson.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.getaxonflow</groupId>
+            <artifactId>axonflow-sdk</artifactId>
+            <version>5.5.0</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <mainClass>com.getaxonflow.examples.EvalRetryAware</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/wcp-retry-idempotency/evaluation/java/src/main/java/com/getaxonflow/examples/EvalRetryAware.java
+++ b/examples/wcp-retry-idempotency/evaluation/java/src/main/java/com/getaxonflow/examples/EvalRetryAware.java
@@ -1,0 +1,165 @@
+// Copyright 2026 AxonFlow
+// SPDX-License-Identifier: Apache-2.0
+//
+// Evaluation-tier retry-aware policy demo (Java SDK).
+//
+// Creates a dynamic policy via raw HTTP (the Java SDK doesn't expose a
+// createPolicy helper), then uses the SDK's stepGate to prove the
+// retry-aware condition fires on retry_policy=reevaluate.
+//
+// ⚠️ Evaluation or Enterprise license required.
+package com.getaxonflow.examples;
+
+import com.getaxonflow.sdk.AxonFlow;
+import com.getaxonflow.sdk.AxonFlowConfig;
+import com.getaxonflow.sdk.types.workflow.WorkflowTypes;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class EvalRetryAware {
+
+    private static final String POLICY_JSON = "{"
+            + "\"name\":\"Retry on gated-not-completed wire requires approval (Java)\","
+            + "\"description\":\"Human verification required before re-executing a wire when the prior attempt never completed.\","
+            + "\"type\":\"context_aware\","
+            + "\"priority\":100,"
+            + "\"enabled\":true,"
+            + "\"conditions\":["
+            + "  {\"field\":\"step.gate_count\",\"operator\":\"greater_than\",\"value\":1},"
+            + "  {\"field\":\"step.prior_completion_status\",\"operator\":\"equals\",\"value\":\"gated_not_completed\"},"
+            + "  {\"field\":\"context.tool_name\",\"operator\":\"equals\",\"value\":\"core_banking_transfer\"}"
+            + "],"
+            + "\"actions\":[{"
+            + "  \"type\":\"require_approval\","
+            + "  \"config\":{\"reason\":\"Retry on un-completed wire — verify with bank before re-execution\",\"severity\":\"high\"}"
+            + "}]"
+            + "}";
+
+    public static void main(String[] args) throws Exception {
+        String endpoint = envOrDefault("AXONFLOW_BASE_URL", "http://localhost:8080");
+        String clientId = mustEnv("AXONFLOW_CLIENT_ID");
+        String clientSecret = mustEnv("AXONFLOW_CLIENT_SECRET");
+
+        banner("Retry-aware policy (Java SDK, Evaluation tier)");
+
+        HttpClient http = HttpClient.newHttpClient();
+        String auth = "Basic " + Base64.getEncoder().encodeToString(
+                (clientId + ":" + clientSecret).getBytes(StandardCharsets.UTF_8));
+
+        String policyId = createRetryAwarePolicy(http, endpoint, auth);
+        System.out.println("  policy created: " + policyId);
+
+        try {
+            AxonFlow client = AxonFlow.create(
+                    AxonFlowConfig.builder()
+                            .endpoint(endpoint)
+                            .clientId(clientId)
+                            .clientSecret(clientSecret)
+                            .build());
+
+            WorkflowTypes.CreateWorkflowResponse wf = client.createWorkflow(
+                    WorkflowTypes.CreateWorkflowRequest.builder()
+                            .workflowName("eval-retry-aware-java")
+                            .build());
+            System.out.println("  workflow: " + wf.getWorkflowId());
+
+            Map<String, Object> stepInput = new HashMap<>();
+            stepInput.put("amount_eur", 750);
+            stepInput.put("to_account", "1234");
+
+            WorkflowTypes.ToolContext toolCtx = WorkflowTypes.ToolContext.builder("core_banking_transfer")
+                    .toolType("api")
+                    .build();
+
+            // 1) First gate — allow
+            WorkflowTypes.StepGateRequest baseReq = WorkflowTypes.StepGateRequest.builder()
+                    .stepName("Initiate Wire")
+                    .stepType(WorkflowTypes.StepType.TOOL_CALL)
+                    .stepInput(stepInput)
+                    .toolContext(toolCtx)
+                    .build();
+            WorkflowTypes.StepGateResponse first = client.stepGate(wf.getWorkflowId(), "step-1", baseReq);
+            if (first.getDecision() != WorkflowTypes.GateDecision.ALLOW) {
+                fail("first gate: want allow, got " + first.getDecision());
+            }
+            System.out.println("  first gate: allow (gate_count=1, policy doesn't fire) ✔");
+
+            // 2) Cached retry — still allow
+            WorkflowTypes.StepGateResponse cached = client.stepGate(wf.getWorkflowId(), "step-1", baseReq);
+            if (!cached.isCached()) fail("second gate should be cached");
+            if (cached.getDecision() != WorkflowTypes.GateDecision.ALLOW) {
+                fail("cached gate: want allow, got " + cached.getDecision());
+            }
+            System.out.println("  second gate cached: still allow (cache bypasses policy) ✔");
+
+            // 3) Reevaluate — retry-aware policy fires
+            WorkflowTypes.StepGateRequest reevalReq = WorkflowTypes.StepGateRequest.builder()
+                    .stepName("Initiate Wire")
+                    .stepType(WorkflowTypes.StepType.TOOL_CALL)
+                    .stepInput(stepInput)
+                    .toolContext(toolCtx)
+                    .retryPolicy("reevaluate")
+                    .build();
+            WorkflowTypes.StepGateResponse third = client.stepGate(wf.getWorkflowId(), "step-1", reevalReq);
+            if (third.isCached()) fail("reevaluate gate should not be cached");
+            if (third.getDecision() != WorkflowTypes.GateDecision.REQUIRE_APPROVAL) {
+                fail("reevaluate gate: want require_approval, got " + third.getDecision() + " (" + third.getReason() + ")");
+            }
+            System.out.println("  third gate (reevaluate): require_approval (policy FIRED) ✔");
+
+            banner("Evaluation-tier Java SDK demo passed ✔");
+        } finally {
+            deletePolicy(http, endpoint, auth, policyId);
+        }
+    }
+
+    private static String createRetryAwarePolicy(HttpClient http, String endpoint, String auth) throws IOException, InterruptedException {
+        HttpRequest req = HttpRequest.newBuilder(URI.create(endpoint + "/api/v1/policies"))
+                .header("Content-Type", "application/json")
+                .header("Authorization", auth)
+                .POST(HttpRequest.BodyPublishers.ofString(POLICY_JSON))
+                .build();
+        HttpResponse<String> resp = http.send(req, HttpResponse.BodyHandlers.ofString());
+        if (resp.statusCode() != 200 && resp.statusCode() != 201) {
+            fail("create policy: status=" + resp.statusCode() + " body=" + resp.body());
+        }
+        // Minimal JSON extraction: policy.id
+        Matcher m = Pattern.compile("\"id\"\\s*:\\s*\"([^\"]+)\"").matcher(resp.body());
+        if (!m.find()) {
+            fail("create policy: missing policy.id in response, body=" + resp.body());
+        }
+        return m.group(1);
+    }
+
+    private static void deletePolicy(HttpClient http, String endpoint, String auth, String policyId) {
+        try {
+            HttpRequest req = HttpRequest.newBuilder(URI.create(endpoint + "/api/v1/policies/" + policyId))
+                    .header("Authorization", auth)
+                    .DELETE()
+                    .build();
+            http.send(req, HttpResponse.BodyHandlers.discarding());
+        } catch (IOException | InterruptedException ignored) { /* best-effort teardown */ }
+    }
+
+    private static String envOrDefault(String k, String d) {
+        String v = System.getenv(k);
+        return (v == null || v.isEmpty()) ? d : v;
+    }
+    private static String mustEnv(String k) {
+        String v = System.getenv(k);
+        if (v == null || v.isEmpty()) fail("missing env: " + k);
+        return v;
+    }
+    private static void fail(String msg) { System.err.println("FAIL: " + msg); System.exit(1); }
+    private static void banner(String s) { System.out.println(); System.out.println("━━━ " + s + " ━━━"); }
+}

--- a/examples/wcp-retry-idempotency/evaluation/python/main.py
+++ b/examples/wcp-retry-idempotency/evaluation/python/main.py
@@ -1,0 +1,164 @@
+"""Evaluation-tier retry-aware policy demo (Python SDK).
+
+Creates a dynamic policy via the policy REST API (the Python SDK doesn't
+expose a policy-create helper), then uses the SDK's step_gate to prove
+the retry-aware condition fires on retry_policy="reevaluate".
+
+⚠️ Evaluation or Enterprise license required.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import os
+import sys
+import urllib.request
+
+from axonflow import AxonFlow
+from axonflow.workflow import (
+    CreateWorkflowRequest,
+    StepGateRequest,
+    StepType,
+    ToolContext,
+    RetryPolicy,
+)
+
+
+def must_env(k: str) -> str:
+    v = os.environ.get(k)
+    if not v:
+        print(f"missing env: {k}", file=sys.stderr)
+        sys.exit(1)
+    return v
+
+
+def fail(msg: str) -> None:
+    print(f"FAIL: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def banner(s: str) -> None:
+    print()
+    print("━━━", s, "━━━")
+
+
+def _auth_header(client_id: str, client_secret: str) -> str:
+    raw = f"{client_id}:{client_secret}".encode()
+    return "Basic " + base64.b64encode(raw).decode()
+
+
+def create_retry_aware_policy(base_url: str, client_id: str, client_secret: str) -> str:
+    body = json.dumps({
+        "name": "Retry on gated-not-completed wire requires approval (Python)",
+        "description": "Human verification required before re-executing a wire when the prior attempt never completed.",
+        "type": "context_aware",
+        "priority": 100,
+        "enabled": True,
+        "conditions": [
+            {"field": "step.gate_count", "operator": "greater_than", "value": 1},
+            {"field": "step.prior_completion_status", "operator": "equals", "value": "gated_not_completed"},
+            {"field": "context.tool_name", "operator": "equals", "value": "core_banking_transfer"},
+        ],
+        "actions": [{
+            "type": "require_approval",
+            "config": {
+                "reason": "Retry on un-completed wire — verify with bank before re-execution",
+                "severity": "high",
+            },
+        }],
+    }).encode()
+
+    req = urllib.request.Request(
+        f"{base_url}/api/v1/policies",
+        data=body,
+        method="POST",
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": _auth_header(client_id, client_secret),
+        },
+    )
+    try:
+        with urllib.request.urlopen(req) as resp:
+            payload = json.loads(resp.read().decode())
+    except urllib.error.HTTPError as e:
+        fail(f"create policy: HTTP {e.code} body={e.read().decode()}")
+
+    pid = payload.get("policy", {}).get("id", "")
+    if not pid:
+        fail(f"create policy: missing policy.id in response, body={payload}")
+    return pid
+
+
+def delete_policy(base_url: str, client_id: str, client_secret: str, policy_id: str) -> None:
+    req = urllib.request.Request(
+        f"{base_url}/api/v1/policies/{policy_id}",
+        method="DELETE",
+        headers={"Authorization": _auth_header(client_id, client_secret)},
+    )
+    try:
+        urllib.request.urlopen(req).close()
+    except urllib.error.URLError:
+        pass  # best-effort teardown
+
+
+async def main() -> None:
+    endpoint = os.environ.get("AXONFLOW_BASE_URL", "http://localhost:8080")
+    client_id = must_env("AXONFLOW_CLIENT_ID")
+    client_secret = must_env("AXONFLOW_CLIENT_SECRET")
+
+    banner("Retry-aware policy (Python SDK, Evaluation tier)")
+
+    policy_id = create_retry_aware_policy(endpoint, client_id, client_secret)
+    print(f"  policy created: {policy_id}")
+
+    client = AxonFlow(endpoint=endpoint, client_id=client_id, client_secret=client_secret)
+    try:
+        wf = await client.create_workflow(CreateWorkflowRequest(workflow_name="eval-retry-aware-py"))
+        print(f"  workflow: {wf.workflow_id}")
+
+        base_req = StepGateRequest(
+            step_name="Initiate Wire",
+            step_type=StepType.TOOL_CALL,
+            step_input={"amount_eur": 750, "to_account": "1234"},
+            tool_context=ToolContext(tool_name="core_banking_transfer", tool_type="api"),
+        )
+
+        # 1) First gate — allow
+        first = await client.step_gate(wf.workflow_id, "step-1", base_req)
+        if first.decision.value != "allow":
+            fail(f"first gate: want allow, got {first.decision}")
+        print("  first gate: allow (gate_count=1, policy doesn't fire) ✔")
+
+        # 2) Cached retry — allow, policy bypassed
+        cached = await client.step_gate(wf.workflow_id, "step-1", base_req)
+        if not cached.cached:
+            fail("second gate should be cached")
+        if cached.decision.value != "allow":
+            fail(f"cached gate: want allow, got {cached.decision}")
+        print("  second gate cached: still allow (cache bypasses policy) ✔")
+
+        # 3) Reevaluate — retry-aware policy fires
+        reeval_req = StepGateRequest(
+            step_name="Initiate Wire",
+            step_type=StepType.TOOL_CALL,
+            step_input={"amount_eur": 750, "to_account": "1234"},
+            tool_context=ToolContext(tool_name="core_banking_transfer", tool_type="api"),
+            retry_policy=RetryPolicy.REEVALUATE,
+        )
+        third = await client.step_gate(wf.workflow_id, "step-1", reeval_req)
+        if third.cached:
+            fail("reevaluate gate should not be cached")
+        if third.decision.value != "require_approval":
+            fail(f"reevaluate gate: want require_approval, got {third.decision} ({third.reason})")
+        print("  third gate (reevaluate): require_approval (policy FIRED) ✔")
+
+        banner("Evaluation-tier Python SDK demo passed ✔")
+    finally:
+        delete_policy(endpoint, client_id, client_secret, policy_id)
+        await client.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/wcp-retry-idempotency/evaluation/typescript/index.ts
+++ b/examples/wcp-retry-idempotency/evaluation/typescript/index.ts
@@ -1,0 +1,111 @@
+/**
+ * Evaluation-tier example (TypeScript SDK variant) for Issue #1673
+ * retry-aware dynamic policy. See ../http/main.go for rationale; this does
+ * the same thing through @axonflow/sdk, with policy creation via raw fetch
+ * (the SDK doesn't expose a createPolicy helper).
+ *
+ * ⚠️ Evaluation or Enterprise license required.
+ */
+
+import { AxonFlow } from '@axonflow/sdk';
+
+function mustEnv(k: string): string {
+  const v = process.env[k];
+  if (!v) { console.error(`missing env: ${k}`); process.exit(1); }
+  return v;
+}
+
+function fail(msg: string): never { console.error(`FAIL: ${msg}`); process.exit(1); }
+function banner(s: string): void { console.log(''); console.log('━━━', s, '━━━'); }
+
+async function createRetryAwarePolicy(baseURL: string, clientId: string, clientSecret: string): Promise<string> {
+  const authHeader = 'Basic ' + Buffer.from(`${clientId}:${clientSecret}`).toString('base64');
+  const body = {
+    name: 'Retry on gated-not-completed wire requires approval (TS)',
+    description: 'Human verification required before re-executing a wire when the prior attempt never completed.',
+    type: 'context_aware',
+    priority: 100,
+    enabled: true,
+    conditions: [
+      { field: 'step.gate_count', operator: 'greater_than', value: 1 },
+      { field: 'step.prior_completion_status', operator: 'equals', value: 'gated_not_completed' },
+      { field: 'context.tool_name', operator: 'equals', value: 'core_banking_transfer' },
+    ],
+    actions: [{
+      type: 'require_approval',
+      config: { reason: 'Retry on un-completed wire — verify with bank before re-execution', severity: 'high' },
+    }],
+  };
+  const res = await fetch(`${baseURL}/api/v1/policies`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: authHeader },
+    body: JSON.stringify(body),
+  });
+  const text = await res.text();
+  if (res.status !== 200 && res.status !== 201) {
+    fail(`create policy: status=${res.status} body=${text}`);
+  }
+  const parsed = JSON.parse(text) as { policy?: { id?: string } };
+  const id = parsed.policy?.id;
+  if (!id) fail(`create policy: missing policy.id in response, body=${text}`);
+  return id;
+}
+
+async function deletePolicy(baseURL: string, clientId: string, clientSecret: string, policyId: string): Promise<void> {
+  const authHeader = 'Basic ' + Buffer.from(`${clientId}:${clientSecret}`).toString('base64');
+  try {
+    await fetch(`${baseURL}/api/v1/policies/${encodeURIComponent(policyId)}`, {
+      method: 'DELETE',
+      headers: { Authorization: authHeader },
+    });
+  } catch { /* best-effort teardown */ }
+}
+
+async function main(): Promise<void> {
+  const endpoint = process.env.AXONFLOW_BASE_URL || 'http://localhost:8080';
+  const clientId = mustEnv('AXONFLOW_CLIENT_ID');
+  const clientSecret = mustEnv('AXONFLOW_CLIENT_SECRET');
+
+  banner('Retry-aware policy (TypeScript SDK, Evaluation tier)');
+
+  const policyId = await createRetryAwarePolicy(endpoint, clientId, clientSecret);
+  console.log(`  policy created: ${policyId}`);
+
+  try {
+    const client = new AxonFlow({ clientId, clientSecret, endpoint });
+    const wf = await client.createWorkflow({ workflow_name: 'eval-retry-aware-ts' });
+    console.log(`  workflow: ${wf.workflow_id}`);
+
+    const baseReq = {
+      step_name: 'Initiate Wire',
+      step_type: 'tool_call' as const,
+      step_input: { amount_eur: 750, to_account: '1234' },
+      tool_context: { tool_name: 'core_banking_transfer', tool_type: 'api' },
+    };
+
+    // 1) First gate — allow
+    const first = await client.stepGate(wf.workflow_id, 'step-1', baseReq);
+    if (first.decision !== 'allow') fail(`first gate: want allow, got ${first.decision}`);
+    console.log('  first gate: allow (gate_count=1, policy doesn\'t fire) ✔');
+
+    // 2) Cached retry — allow, policy bypassed
+    const cached = await client.stepGate(wf.workflow_id, 'step-1', baseReq);
+    if (!cached.cached) fail('second gate should be cached');
+    if (cached.decision !== 'allow') fail(`cached gate: want allow, got ${cached.decision}`);
+    console.log('  second gate cached: still allow (cache bypasses policy) ✔');
+
+    // 3) Reevaluate — retry-aware policy fires
+    const third = await client.stepGate(wf.workflow_id, 'step-1', { ...baseReq, retry_policy: 'reevaluate' });
+    if (third.cached) fail('reevaluate gate should not be cached');
+    if (third.decision !== 'require_approval') {
+      fail(`reevaluate gate: want require_approval, got ${third.decision} (${third.reason})`);
+    }
+    console.log('  third gate (reevaluate): require_approval (policy FIRED) ✔');
+
+    banner('Evaluation-tier TypeScript SDK demo passed ✔');
+  } finally {
+    await deletePolicy(endpoint, clientId, clientSecret, policyId);
+  }
+}
+
+main().catch((err) => { console.error('UNEXPECTED:', err); process.exit(1); });

--- a/examples/wcp-retry-idempotency/evaluation/typescript/package.json
+++ b/examples/wcp-retry-idempotency/evaluation/typescript/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "wcp-retry-idempotency-evaluation",
+  "version": "0.0.0",
+  "private": true,
+  "type": "commonjs",
+  "dependencies": {
+    "@axonflow/sdk": "file:../../../../../axonflow-sdk-typescript-1673"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "ts-node": "^10.9.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/examples/wcp-retry-idempotency/evaluation/typescript/tsconfig.json
+++ b/examples/wcp-retry-idempotency/evaluation/typescript/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "ts-node": { "transpileOnly": true }
+}

--- a/migrations/core/071_wcp_retry_context_counters.sql
+++ b/migrations/core/071_wcp_retry_context_counters.sql
@@ -1,0 +1,56 @@
+-- Copyright 2026 AxonFlow
+-- SPDX-License-Identifier: BUSL-1.1
+--
+-- Migration 071: WCP retry_context counters (Issue #1673 Phase 1)
+--
+-- Adds gate_count, completion_count, and last_decision columns to
+-- workflow_steps so StepGateResponse can return a first-class retry_context
+-- block on every gate response. Replaces the ambiguous `cached: bool` flag
+-- with unambiguous execution state (how many times /gate has been called,
+-- whether a prior /complete has landed, what the prior decision was).
+--
+-- See technical-docs/WCP_RETRY_IDEMPOTENCY_WIRE_CONTRACT.md for the full
+-- response shape SDK work is built against.
+--
+-- Additive; all new columns have defaults. Existing rows are backfilled so
+-- retry_context.gate_count >= 1 on any legacy row (a row exists ⇒ a gate
+-- happened at least once) and completion_count reflects step_completed_at.
+
+BEGIN;
+
+ALTER TABLE workflow_steps
+    ADD COLUMN IF NOT EXISTS gate_count INTEGER NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS completion_count INTEGER NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS last_decision VARCHAR(50),
+    ADD COLUMN IF NOT EXISTS first_attempt_at TIMESTAMP WITH TIME ZONE;
+
+-- Backfill legacy rows. A row in workflow_steps implies at least one gate
+-- call happened (rows are created by AddStep which is called from StepGate).
+-- If step_completed_at is set, /complete was called exactly once (pre-#1673
+-- semantics didn't allow re-complete). last_decision equals the current
+-- decision for legacy rows: we have no history of prior gate calls, and the
+-- contract says last_decision on first-call == current decision.
+-- first_attempt_at backfills to gate_checked_at since that was both the
+-- first and only gate event for legacy rows.
+UPDATE workflow_steps
+SET gate_count = 1,
+    completion_count = CASE WHEN step_completed_at IS NOT NULL THEN 1 ELSE 0 END,
+    last_decision = decision,
+    first_attempt_at = gate_checked_at
+WHERE gate_count = 0;
+
+COMMENT ON COLUMN workflow_steps.gate_count IS
+    'Number of /gate calls for this (workflow_id, step_id). Incremented on every gate call. Surfaced in StepGateResponse.retry_context.gate_count (Issue #1673).';
+COMMENT ON COLUMN workflow_steps.completion_count IS
+    'Number of /complete calls. Normally 0 or 1. Surfaced in StepGateResponse.retry_context.completion_count (Issue #1673).';
+COMMENT ON COLUMN workflow_steps.last_decision IS
+    'Decision of the prior gate call. On the first call, equals the current decision. Surfaced in StepGateResponse.retry_context.last_decision (Issue #1673).';
+COMMENT ON COLUMN workflow_steps.first_attempt_at IS
+    'Timestamp of the first /gate call for this step. gate_checked_at is overwritten on each gate call (= last_attempt_at); this column preserves the original. Surfaced in StepGateResponse.retry_context.first_attempt_at (Issue #1673).';
+
+DO $$
+BEGIN
+    RAISE NOTICE 'Migration 071: Added gate_count, completion_count, last_decision, first_attempt_at to workflow_steps for Issue #1673 Phase 1';
+END $$;
+
+COMMIT;

--- a/migrations/core/071_wcp_retry_context_counters_down.sql
+++ b/migrations/core/071_wcp_retry_context_counters_down.sql
@@ -1,0 +1,11 @@
+-- Down migration for 071_wcp_retry_context_counters.sql
+
+BEGIN;
+
+ALTER TABLE workflow_steps
+    DROP COLUMN IF EXISTS first_attempt_at,
+    DROP COLUMN IF EXISTS last_decision,
+    DROP COLUMN IF EXISTS completion_count,
+    DROP COLUMN IF EXISTS gate_count;
+
+COMMIT;

--- a/migrations/core/072_wcp_idempotency_key.sql
+++ b/migrations/core/072_wcp_idempotency_key.sql
@@ -1,0 +1,40 @@
+-- Copyright 2026 AxonFlow
+-- SPDX-License-Identifier: BUSL-1.1
+--
+-- Migration 072: WCP caller-supplied idempotency_key (Issue #1673 Phase 2)
+--
+-- Adds an optional caller-supplied idempotency_key on workflow_steps so the
+-- caller can anchor a gate/complete pair to a business-level key (e.g.
+-- "payment:wire:acct4471:invoice-7721"). The key is validated for match
+-- between /gate and /complete; mismatch returns HTTP 409
+-- IDEMPOTENCY_KEY_MISMATCH.
+--
+-- Phase 2 is purely same-workflow: the key is recorded and policy-reachable
+-- via step.idempotency_key. Cross-workflow lookup (Phase 3, issue #1672)
+-- builds on this column but is explicitly out of scope here.
+--
+-- Additive; column is nullable since existing rows and callers that don't
+-- supply a key continue to work unchanged.
+
+BEGIN;
+
+ALTER TABLE workflow_steps
+    ADD COLUMN IF NOT EXISTS idempotency_key VARCHAR(255);
+
+-- Index for audit queries filtering by idempotency_key. Partial (non-null
+-- only) since most legacy rows won't have a key; keeps the index lean.
+-- Phase 3 will likely add a composite (tenant_id, tool_name, idempotency_key)
+-- index for cross-workflow lookup; that's a separate migration.
+CREATE INDEX IF NOT EXISTS idx_workflow_steps_idempotency_key
+    ON workflow_steps(idempotency_key)
+    WHERE idempotency_key IS NOT NULL;
+
+COMMENT ON COLUMN workflow_steps.idempotency_key IS
+    'Caller-supplied opaque business-level key (Issue #1673 Phase 2). Recorded on the first /gate call that sets it; subsequent /gate and /complete calls must pass the same key or receive 409 IDEMPOTENCY_KEY_MISMATCH. Max 255 chars. Null when the caller did not supply one.';
+
+DO $$
+BEGIN
+    RAISE NOTICE 'Migration 072: Added idempotency_key to workflow_steps for Issue #1673 Phase 2';
+END $$;
+
+COMMIT;

--- a/migrations/core/072_wcp_idempotency_key_down.sql
+++ b/migrations/core/072_wcp_idempotency_key_down.sql
@@ -1,0 +1,10 @@
+-- Down migration for 072_wcp_idempotency_key.sql
+
+BEGIN;
+
+DROP INDEX IF EXISTS idx_workflow_steps_idempotency_key;
+
+ALTER TABLE workflow_steps
+    DROP COLUMN IF EXISTS idempotency_key;
+
+COMMIT;

--- a/platform/agent/Dockerfile
+++ b/platform/agent/Dockerfile
@@ -125,7 +125,7 @@ RUN set -e && \
 # Final stage - minimal runtime image
 FROM alpine:3.23
 
-ARG AXONFLOW_VERSION=7.2.1
+ARG AXONFLOW_VERSION=7.3.0
 ENV AXONFLOW_VERSION=${AXONFLOW_VERSION}
 
 # AWS Marketplace metadata

--- a/platform/orchestrator/Dockerfile
+++ b/platform/orchestrator/Dockerfile
@@ -136,7 +136,7 @@ RUN set -e && \
 # Final stage - minimal runtime image
 FROM alpine:3.23
 
-ARG AXONFLOW_VERSION=7.2.1
+ARG AXONFLOW_VERSION=7.3.0
 ENV AXONFLOW_VERSION=${AXONFLOW_VERSION}
 
 # AWS Marketplace metadata

--- a/platform/orchestrator/dynamic_policy_engine.go
+++ b/platform/orchestrator/dynamic_policy_engine.go
@@ -424,6 +424,22 @@ func (e *DynamicPolicyEngine) getFieldValue(field string, req OrchestratorReques
 			return req.Context[key]
 		}
 		return nil
+	case "step":
+		// Retry-aware step fields (Issue #1673 Phase 1 + 2). Populated by
+		// WCPPolicyAdapter.convertToOrchestratorRequest as "step.gate_count",
+		// "step.completion_count", "step.prior_completion_status",
+		// "step.prior_output_available", "step.last_decision",
+		// "step.first_attempt_age_seconds", and "step.idempotency_key".
+		//
+		// Note: policy semantics for step.last_decision differ from the
+		// response-side first-call invariant — it is empty on the first
+		// gate call so policies can distinguish "no prior call" from
+		// "prior allow" without a separate step.gate_count check.
+		if len(parts) > 1 && req.Context != nil {
+			key := strings.Join(parts, ".")
+			return req.Context[key]
+		}
+		return nil
 	case "media":
 		// Media governance fields — resolved from context["media_analysis"]
 		// These are populated by the media analysis pipeline before policy evaluation.

--- a/platform/orchestrator/policy_api_service.go
+++ b/platform/orchestrator/policy_api_service.go
@@ -163,6 +163,19 @@ func (s *PolicyService) UpdatePolicy(ctx context.Context, tenantID, policyID str
 		return nil, err
 	}
 
+	// Issue #1673: retry-aware step.* conditions require Evaluation tier on
+	// every mutation path, not just create. Without this check a Community
+	// tenant could create a benign policy, then PATCH its conditions to
+	// retry-aware fields. UpdatePolicyRequest.Conditions is optional — if
+	// nil the caller isn't changing conditions and there's nothing to
+	// re-gate. Runs BEFORE validateTierForModify so a quick reject path
+	// doesn't roundtrip to the DB just to return a tier error.
+	if len(req.Conditions) > 0 {
+		if err := s.validateRetryAwareTier(req.Conditions); err != nil {
+			return nil, err
+		}
+	}
+
 	// Tier validation: system tier policies cannot be modified (except system media policies)
 	if err := s.validateTierForModify(ctx, tenantID, policyID); err != nil {
 		return nil, err
@@ -292,6 +305,13 @@ func (s *PolicyService) ImportPolicies(ctx context.Context, tenantID string, req
 	for i, p := range req.Policies {
 		if err := s.validateCreateRequest(&p); err != nil {
 			return nil, fmt.Errorf("policy %d validation failed: %w", i, err)
+		}
+		// Issue #1673: retry-aware step.* conditions require Evaluation tier
+		// on the import path too, not just direct create. Reject the whole
+		// import if any policy in the batch has retry-aware fields on a
+		// non-Evaluation-or-higher license.
+		if err := s.validateRetryAwareTier(p.Conditions); err != nil {
+			return nil, fmt.Errorf("policy %d: %w", i, err)
 		}
 	}
 
@@ -730,6 +750,15 @@ func (s *PolicyService) validateTierForCreate(ctx context.Context, tenantID stri
 		}
 	}
 
+	// Issue #1673: retry-aware step.* condition fields are an Evaluation-tier
+	// capability per the edition split. Reject at create time so the edition
+	// table maps to enforceable code, not just documentation. Checked BEFORE
+	// the tenant policy-count query so Community users attempting a retry-aware
+	// policy see the right error immediately without the count roundtrip.
+	if err := s.validateRetryAwareTier(req.Conditions); err != nil {
+		return err
+	}
+
 	// Tenant tier: check policy limit for non-paid tiers
 	if tier == TierTenant && !license.IsPaidTier(licenseTier) {
 		count, err := s.repo.CountByTenant(ctx, tenantID)
@@ -751,6 +780,47 @@ func (s *PolicyService) validateTierForCreate(ctx context.Context, tenantID stri
 		}
 	}
 
+	return nil
+}
+
+// firstRetryAwareField returns the first step.* condition field in the
+// given slice, or "" if none. Retry-aware fields (step.gate_count,
+// step.completion_count, step.prior_completion_status, etc.) are the
+// Phase 1 + Phase 2 additions from Issue #1673; policies using any of
+// them require Evaluation tier or higher. Shared by create, update,
+// and import paths so the edition boundary cannot be bypassed via a
+// different entry point.
+func firstRetryAwareField(conditions []PolicyCondition) string {
+	for _, c := range conditions {
+		if strings.HasPrefix(c.Field, "step.") {
+			return c.Field
+		}
+	}
+	return ""
+}
+
+// retryAwareTierError returns the standard TierValidationError for a
+// retry-aware policy condition on a non-Evaluation-or-higher license.
+// Used by every code path that accepts policy conditions (create,
+// update, import) so the error message stays consistent.
+func retryAwareTierError(field string) error {
+	return NewTierValidationError(
+		fmt.Sprintf("Retry-aware policy condition %q requires Evaluation or Enterprise license. "+
+			"Get a free Evaluation license at https://getaxonflow.com/evaluation-license", field),
+		ErrCodeFeatureRequiresEvaluation,
+	)
+}
+
+// validateRetryAwareTier enforces the Evaluation-tier gate for retry-aware
+// step.* condition fields across every policy-mutation entry point. Call
+// this before writing any policy with caller-supplied conditions.
+func (s *PolicyService) validateRetryAwareTier(conditions []PolicyCondition) error {
+	if license.IsEvaluationOrHigher(s.licenseChecker.Tier()) {
+		return nil
+	}
+	if field := firstRetryAwareField(conditions); field != "" {
+		return retryAwareTierError(field)
+	}
 	return nil
 }
 

--- a/platform/orchestrator/policy_api_types.go
+++ b/platform/orchestrator/policy_api_types.go
@@ -256,6 +256,15 @@ var ValidPolicyFields = []string{
 	"media.pii_types",
 	"media.has_extracted_text",
 	"media.extracted_text_length",
+	// Retry-aware step fields for WCP policies (Issue #1673 Phase 1 + 2).
+	// See technical-docs/WCP_RETRY_IDEMPOTENCY_WIRE_CONTRACT.md for semantics.
+	"step.gate_count",
+	"step.completion_count",
+	"step.prior_completion_status",
+	"step.prior_output_available",
+	"step.last_decision",
+	"step.first_attempt_age_seconds",
+	"step.idempotency_key",
 }
 
 // Valid action types — re-exported from platform/shared/policy as the single

--- a/platform/orchestrator/policy_tier_test.go
+++ b/platform/orchestrator/policy_tier_test.go
@@ -424,6 +424,105 @@ func TestPolicyService_CreatePolicy_OrganizationTierRequiresEvaluationOrHigher(t
 	}
 }
 
+// Issue #1673: retry-aware step.* condition fields require Evaluation tier.
+// The edition table in #1673 declares these policies Evaluation-only; this
+// test locks that rule at create time so Community licenses cannot author
+// them within their policy budget.
+func TestPolicyService_CreatePolicy_CommunityRejectsRetryAwareStepFields(t *testing.T) {
+	// Every new step.* field added in Phase 1 + Phase 2 must be rejected.
+	retryAwareFields := []string{
+		"step.gate_count",
+		"step.completion_count",
+		"step.prior_completion_status",
+		"step.prior_output_available",
+		"step.last_decision",
+		"step.first_attempt_age_seconds",
+		"step.idempotency_key",
+	}
+
+	for _, field := range retryAwareFields {
+		t.Run(field, func(t *testing.T) {
+			db, _, err := sqlmock.New()
+			if err != nil {
+				t.Fatalf("failed to create mock: %v", err)
+			}
+			defer db.Close()
+
+			repo := NewPolicyRepository(db)
+			svc := NewPolicyServiceWithLicense(repo, nil, newMockLicenseChecker(license.TierCommunity))
+
+			req := &CreatePolicyRequest{
+				Name:        "Retry-aware policy on Community",
+				Description: "Should be rejected with FEATURE_REQUIRES_EVALUATION_LICENSE",
+				Type:        "context_aware",
+				Tier:        TierTenant,
+				Conditions: []PolicyCondition{
+					{Field: field, Operator: "greater_than", Value: 1},
+				},
+				Actions: []PolicyAction{
+					{Type: "require_approval"},
+				},
+				Priority: 100,
+				Enabled:  true,
+			}
+
+			_, err = svc.CreatePolicy(context.Background(), "tenant-1", req, "user-1")
+			if err == nil {
+				t.Fatalf("field %s: expected error on Community tier", field)
+			}
+			if !IsTierValidationError(err) {
+				t.Errorf("field %s: expected TierValidationError, got %T: %v", field, err, err)
+			} else if tierErr := err.(*TierValidationError); tierErr.Code != ErrCodeFeatureRequiresEvaluation {
+				t.Errorf("field %s: expected code %s, got %s", field, ErrCodeFeatureRequiresEvaluation, tierErr.Code)
+			}
+		})
+	}
+}
+
+// Sanity check: policies NOT using retry-aware fields still succeed on
+// Community within the policy count limit, so this rule doesn't over-reach.
+func TestPolicyService_CreatePolicy_CommunityAcceptsNonRetryAwareFields(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create mock: %v", err)
+	}
+	defer db.Close()
+
+	// CountByTenant returns 0 (below the Community limit) so the create proceeds.
+	mock.ExpectQuery("SELECT COUNT").WillReturnRows(
+		sqlmock.NewRows([]string{"count"}).AddRow(0),
+	)
+	mock.ExpectExec("INSERT INTO dynamic_policies").WillReturnResult(sqlmock.NewResult(1, 1))
+
+	repo := NewPolicyRepository(db)
+	svc := NewPolicyServiceWithLicense(repo, nil, newMockLicenseChecker(license.TierCommunity))
+
+	req := &CreatePolicyRequest{
+		Name:        "Non-retry-aware policy on Community",
+		Description: "Should succeed",
+		Type:        "content",
+		Tier:        TierTenant,
+		Conditions: []PolicyCondition{
+			{Field: "query", Operator: "contains", Value: "secret"},
+		},
+		Actions: []PolicyAction{
+			{Type: "log"},
+		},
+		Priority: 100,
+		Enabled:  true,
+	}
+
+	_, err = svc.CreatePolicy(context.Background(), "tenant-1", req, "user-1")
+	// Allow either success or a non-tier error (e.g. repo mock mismatch) — the
+	// key assertion is that it's NOT a FEATURE_REQUIRES_EVALUATION_LICENSE
+	// rejection, i.e. the retry-aware check did not false-positive.
+	if err != nil && IsTierValidationError(err) {
+		if tierErr := err.(*TierValidationError); tierErr.Code == ErrCodeFeatureRequiresEvaluation {
+			t.Errorf("non-retry-aware policy falsely rejected as retry-aware: %v", err)
+		}
+	}
+}
+
 func TestPolicyService_CreatePolicy_EvaluationTierOrgPolicyLimit(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
@@ -594,6 +693,101 @@ func TestPolicyRepository_CountByTenant(t *testing.T) {
 
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Errorf("Database expectations not met: %v", err)
+	}
+}
+
+// Issue #1673: the tier gate that rejects retry-aware step.* conditions at
+// create time must also fire on the update path. Otherwise a Community
+// tenant can create a benign policy and PATCH its conditions into
+// retry-aware ones, bypassing the edition boundary.
+func TestPolicyService_UpdatePolicy_CommunityRejectsRetryAwareStepFields(t *testing.T) {
+	db, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create mock: %v", err)
+	}
+	defer db.Close()
+
+	repo := NewPolicyRepository(db)
+	svc := NewPolicyServiceWithLicense(repo, nil, newMockLicenseChecker(license.TierCommunity))
+
+	req := &UpdatePolicyRequest{
+		Conditions: []PolicyCondition{
+			{Field: "step.gate_count", Operator: "greater_than", Value: 1},
+		},
+	}
+
+	_, err = svc.UpdatePolicy(context.Background(), "tenant-1", "existing-policy", req, "user-1")
+	if err == nil {
+		t.Fatal("expected retry-aware update to be rejected on Community tier")
+	}
+	if !IsTierValidationError(err) {
+		t.Errorf("expected TierValidationError, got %T: %v", err, err)
+	} else if tierErr := err.(*TierValidationError); tierErr.Code != ErrCodeFeatureRequiresEvaluation {
+		t.Errorf("expected code %s, got %s", ErrCodeFeatureRequiresEvaluation, tierErr.Code)
+	}
+}
+
+// Import is the other mutation entry point that can smuggle retry-aware
+// conditions past the Evaluation boundary. If any policy in the batch
+// references step.*, the whole import must be rejected on Community.
+func TestPolicyService_ImportPolicies_CommunityRejectsRetryAwareStepFields(t *testing.T) {
+	db, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create mock: %v", err)
+	}
+	defer db.Close()
+
+	repo := NewPolicyRepository(db)
+	svc := NewPolicyServiceWithLicense(repo, nil, newMockLicenseChecker(license.TierCommunity))
+
+	req := &ImportPoliciesRequest{
+		Policies: []CreatePolicyRequest{
+			{
+				Name:       "Benign-first",
+				Type:       "content",
+				Tier:       TierTenant,
+				Conditions: []PolicyCondition{{Field: "query", Operator: "contains", Value: "hi"}},
+				Actions:    []PolicyAction{{Type: "log"}},
+				Priority:   1,
+				Enabled:    true,
+			},
+			{
+				// Second policy smuggles a retry-aware condition — whole batch must fail.
+				Name:       "Sneaky-retry-aware",
+				Type:       "context_aware",
+				Tier:       TierTenant,
+				Conditions: []PolicyCondition{{Field: "step.prior_completion_status", Operator: "equals", Value: "gated_not_completed"}},
+				Actions:    []PolicyAction{{Type: "require_approval"}},
+				Priority:   1,
+				Enabled:    true,
+			},
+		},
+		OverwriteMode: "skip",
+	}
+
+	_, err = svc.ImportPolicies(context.Background(), "tenant-1", req, "user-1")
+	if err == nil {
+		t.Fatal("expected retry-aware import to be rejected on Community tier")
+	}
+	// The error is wrapped with "policy N: " prefix; unwrap to the underlying tier error.
+	var tierErr *TierValidationError
+	for cur := err; cur != nil; {
+		if te, ok := cur.(*TierValidationError); ok {
+			tierErr = te
+			break
+		}
+		type wrappedError interface{ Unwrap() error }
+		if w, ok := cur.(wrappedError); ok {
+			cur = w.Unwrap()
+		} else {
+			break
+		}
+	}
+	if tierErr == nil {
+		t.Fatalf("expected wrapped TierValidationError, got %T: %v", err, err)
+	}
+	if tierErr.Code != ErrCodeFeatureRequiresEvaluation {
+		t.Errorf("expected code %s, got %s", ErrCodeFeatureRequiresEvaluation, tierErr.Code)
 	}
 }
 

--- a/platform/orchestrator/wcp_policy_adapter.go
+++ b/platform/orchestrator/wcp_policy_adapter.go
@@ -184,6 +184,28 @@ func (a *WCPPolicyAdapter) convertToOrchestratorRequest(step *workflow_control.S
 		}
 	}
 
+	// Issue #1673 Phase 1: retry-aware condition fields. Policies can match
+	// on `step.gate_count`, `step.completion_count`,
+	// `step.prior_completion_status`, `step.prior_output_available`,
+	// `step.last_decision`, `step.first_attempt_age_seconds`, and
+	// `step.idempotency_key`. Values reflect the projected post-bump state
+	// at evaluation time (so `gate_count > 1` matches on the second call,
+	// not the third). Populated by service.applyRetryContextToGate.
+	contextData["step.gate_count"] = step.GateCount
+	contextData["step.completion_count"] = step.CompletionCount
+	contextData["step.prior_completion_status"] = string(step.PriorCompletionStatus)
+	contextData["step.prior_output_available"] = step.PriorOutputAvailable
+	contextData["step.last_decision"] = string(step.LastDecision)
+	contextData["step.first_attempt_age_seconds"] = step.FirstAttemptAgeSeconds
+	// Phase 2: business-level key for policy-authored equals/regex matching.
+	// Always populate — empty string signals "no key supplied" so policy
+	// authors can govern both the presence and absence of keys:
+	//   step.idempotency_key == ""       → no key supplied
+	//   step.idempotency_key regex "..."  → pattern match against key
+	// Matches the wire contract which surfaces the same empty string on
+	// retry_context.idempotency_key when unset.
+	contextData["step.idempotency_key"] = step.IdempotencyKey
+
 	return OrchestratorRequest{
 		RequestID:   step.WorkflowID + "_" + step.StepID,
 		RequestType: "workflow_step_gate",

--- a/platform/orchestrator/workflow_control/handlers.go
+++ b/platform/orchestrator/workflow_control/handlers.go
@@ -5,10 +5,12 @@ package workflow_control
 
 import (
 	"encoding/json"
+	"errors"
 	"log"
 	"net/http"
 	"strconv"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/gorilla/mux"
 
@@ -258,6 +260,26 @@ func (h *Handler) StepGate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Issue #1673 Phase 2: idempotency_key max-length validation (matches DB
+	// column length). Reject oversized keys early with a clear 400 so callers
+	// don't get a less-helpful DB error downstream.
+	// Rune count, not byte count — Postgres VARCHAR(N) is N characters, not
+	// N bytes, and a 255-char UTF-8 string can exceed 255 bytes with
+	// multi-byte characters. Matches the convention used by CreateWorkflow's
+	// trace_id validation.
+	if utf8.RuneCountInString(req.IdempotencyKey) > 255 {
+		h.writeError(w, http.StatusBadRequest, "BAD_REQUEST",
+			"idempotency_key must be at most 255 characters")
+		return
+	}
+
+	// Issue #1673 Phase 1: include_prior_output is an opt-in query param.
+	// Parse into the request struct so the service layer can pass it through
+	// to buildRetryContext.
+	if r.URL.Query().Get("include_prior_output") == "true" {
+		req.IncludePriorOutput = true
+	}
+
 	// Get tenant/org context
 	tenantID := h.getTenantID(r)
 	orgID := h.getOrgID(r)
@@ -266,6 +288,12 @@ func (h *Handler) StepGate(w http.ResponseWriter, r *http.Request) {
 
 	response, err := h.service.StepGate(r.Context(), workflowID, stepID, &req, tenantID, orgID, userID, clientID)
 	if err != nil {
+		// Issue #1673 Phase 2: 409 IDEMPOTENCY_KEY_MISMATCH
+		var mismatchErr *IdempotencyKeyMismatchError
+		if errors.As(err, &mismatchErr) {
+			h.writeIdempotencyKeyMismatch(w, mismatchErr)
+			return
+		}
 		if strings.Contains(err.Error(), "not found") {
 			h.writeError(w, http.StatusNotFound, "NOT_FOUND", "Workflow not found")
 			return
@@ -315,7 +343,26 @@ func (h *Handler) MarkStepCompleted(w http.ResponseWriter, r *http.Request) {
 		req = &parsed
 	}
 
-	if err := h.service.MarkStepCompleted(r.Context(), workflowID, stepID, req, h.getClientID(r), h.getOrgID(r)); err != nil {
+	// Issue #1673 Phase 2: idempotency_key max-length validation.
+	// Rune count, not byte count — see StepGate for rationale.
+	if req != nil && utf8.RuneCountInString(req.IdempotencyKey) > 255 {
+		h.writeError(w, http.StatusBadRequest, "BAD_REQUEST",
+			"idempotency_key must be at most 255 characters")
+		return
+	}
+
+	// Inconsistency fix (Issue #1673 drive-by): this handler previously passed
+	// getClientID as the service's tenantID parameter, while StepGate passes
+	// getTenantID. That meant a real X-Tenant-ID header worked for gate but
+	// broke complete on the isolation check. Align with StepGate — tenantID
+	// is the proper parameter.
+	if err := h.service.MarkStepCompleted(r.Context(), workflowID, stepID, req, h.getTenantID(r), h.getOrgID(r)); err != nil {
+		// Issue #1673 Phase 2: 409 IDEMPOTENCY_KEY_MISMATCH
+		var mismatchErr *IdempotencyKeyMismatchError
+		if errors.As(err, &mismatchErr) {
+			h.writeIdempotencyKeyMismatch(w, mismatchErr)
+			return
+		}
 		if strings.Contains(err.Error(), "not found") {
 			h.writeError(w, http.StatusNotFound, "NOT_FOUND", "Step not found")
 			return
@@ -326,6 +373,27 @@ func (h *Handler) MarkStepCompleted(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// writeIdempotencyKeyMismatch emits the structured 409 response for
+// *IdempotencyKeyMismatchError (Issue #1673 Phase 2). Wire shape matches
+// technical-docs/WCP_RETRY_IDEMPOTENCY_WIRE_CONTRACT.md §5.
+func (h *Handler) writeIdempotencyKeyMismatch(w http.ResponseWriter, e *IdempotencyKeyMismatchError) {
+	resp := APIErrorResponse{
+		Error: APIError{
+			Code:    ErrorCodeIdempotencyKeyMismatch,
+			Message: "idempotency_key does not match the key recorded on gate",
+			Details: APIErrorDetails{
+				WorkflowID:             e.WorkflowID,
+				StepID:                 e.StepID,
+				ExpectedIdempotencyKey: e.ExpectedKey,
+				ReceivedIdempotencyKey: e.ReceivedKey,
+			},
+		},
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusConflict)
+	_ = json.NewEncoder(w).Encode(resp)
 }
 
 // CompleteWorkflow handles POST /api/v1/workflows/{id}/complete.

--- a/platform/orchestrator/workflow_control/mock_repository.go
+++ b/platform/orchestrator/workflow_control/mock_repository.go
@@ -222,7 +222,16 @@ func (m *MockRepository) List(ctx context.Context, opts ListWorkflowsOptions) ([
 	return result[offset:end], total, nil
 }
 
-// AddStep records a new step
+// AddStep records a new step gate decision. Issue #1673: also maintains
+// gate_count / completion_count / last_decision / first_attempt_at /
+// idempotency_key so tests exercise the same invariants as the Postgres
+// implementation. Semantics:
+//   - First-time insert: gate_count=1, completion_count=0, last_decision=decision,
+//     first_attempt_at=now, idempotency_key=step.IdempotencyKey.
+//   - Re-gate (existing row): gate_count++, last_decision=OLD decision
+//     (snapshot before overwrite), first_attempt_at preserved,
+//     idempotency_key preserved (immutable once set; caller-supplied value
+//     only used when the existing key is nil).
 func (m *MockRepository) AddStep(ctx context.Context, step *WorkflowStep) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -235,20 +244,68 @@ func (m *MockRepository) AddStep(ctx context.Context, step *WorkflowStep) error 
 		m.steps[step.WorkflowID] = make(map[string]*WorkflowStep)
 	}
 
-	step.ID = len(m.steps[step.WorkflowID]) + 1
-	step.GateCheckedAt = time.Now()
+	now := time.Now()
+	step.GateCheckedAt = now
 
-	m.steps[step.WorkflowID][step.StepID] = step
+	existing := m.steps[step.WorkflowID][step.StepID]
+	if existing == nil {
+		// First-call insert
+		step.ID = len(m.steps[step.WorkflowID]) + 1
+		step.GateCount = 1
+		step.CompletionCount = 0
+		step.LastDecision = step.Decision
+		first := now
+		step.FirstAttemptAt = &first
+		// step.IdempotencyKey already set by caller; keep as-is
+		m.steps[step.WorkflowID][step.StepID] = step
+	} else {
+		// Re-gate UPSERT: preserve immutable fields, bump counter, snapshot OLD decision
+		step.ID = existing.ID
+		step.GateCount = existing.GateCount + 1
+		step.CompletionCount = existing.CompletionCount
+		step.LastDecision = existing.Decision // OLD decision becomes last_decision
+		step.FirstAttemptAt = existing.FirstAttemptAt
+		// idempotency_key is immutable once set: keep existing, else take new
+		if existing.IdempotencyKey != nil {
+			step.IdempotencyKey = existing.IdempotencyKey
+		}
+		m.steps[step.WorkflowID][step.StepID] = step
+	}
 
 	// Update workflow's current step index
 	if workflow, ok := m.workflows[step.WorkflowID]; ok {
 		if step.StepIndex > workflow.CurrentStepIndex {
 			workflow.CurrentStepIndex = step.StepIndex
-			workflow.UpdatedAt = time.Now()
+			workflow.UpdatedAt = now
 		}
 	}
 
 	return nil
+}
+
+// BumpGateCountCached increments gate_count and snapshots last_decision without
+// changing decision. Used by the cached-hit path of StepGate (Issue #1673).
+func (m *MockRepository) BumpGateCountCached(ctx context.Context, workflowID, stepID string) (*WorkflowStep, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	steps, ok := m.steps[workflowID]
+	if !ok {
+		return nil, fmt.Errorf("step not found: %s/%s", workflowID, stepID)
+	}
+	step, ok := steps[stepID]
+	if !ok {
+		return nil, fmt.Errorf("step not found: %s/%s", workflowID, stepID)
+	}
+
+	step.GateCount++
+	// last_decision = decision snapshots the current (cached) decision so the
+	// NEXT call's retry_context.last_decision reflects this call's outcome.
+	step.LastDecision = step.Decision
+	step.GateCheckedAt = time.Now()
+
+	copy := *step
+	return &copy, nil
 }
 
 // GetStep retrieves a specific step
@@ -301,7 +358,9 @@ func (m *MockRepository) UpdateStepApproval(ctx context.Context, workflowID, ste
 	return fmt.Errorf("step not found: %s/%s", workflowID, stepID)
 }
 
-// MarkStepCompleted marks a step as completed, optionally applying post-execution metrics
+// MarkStepCompleted marks a step as completed, optionally applying post-execution metrics.
+// Issue #1673: also increments completion_count so retry_context on subsequent
+// gate calls reflects that a prior /complete landed.
 func (m *MockRepository) MarkStepCompleted(ctx context.Context, workflowID, stepID string, req *StepCompleteRequest) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -310,6 +369,7 @@ func (m *MockRepository) MarkStepCompleted(ctx context.Context, workflowID, step
 		if step, ok := steps[stepID]; ok {
 			now := time.Now()
 			step.StepCompletedAt = &now
+			step.CompletionCount++
 			if req != nil {
 				if req.TokensIn != nil {
 					step.TokensIn = req.TokensIn

--- a/platform/orchestrator/workflow_control/repository.go
+++ b/platform/orchestrator/workflow_control/repository.go
@@ -32,6 +32,10 @@ type Repository interface {
 	// GetStepDecision retrieves a step's cached decision for idempotent retry support (#1414).
 	// Returns nil (not error) if the step has not been evaluated yet.
 	GetStepDecision(ctx context.Context, workflowID, stepID string) (*WorkflowStep, error)
+	// BumpGateCountCached is called by the cached-hit path of StepGate to
+	// increment gate_count and snapshot last_decision without changing the
+	// stored decision (Issue #1673 Phase 1). Returns the updated row.
+	BumpGateCountCached(ctx context.Context, workflowID, stepID string) (*WorkflowStep, error)
 	UpdateStepApproval(ctx context.Context, workflowID, stepID string, status ApprovalStatus, approvedBy string, comment string) error
 	MarkStepCompleted(ctx context.Context, workflowID, stepID string, req *StepCompleteRequest) error
 	GetStepsForWorkflow(ctx context.Context, workflowID string) ([]WorkflowStep, error)
@@ -429,7 +433,24 @@ func (r *PostgresRepository) List(ctx context.Context, opts ListWorkflowsOptions
 	return workflows, total, nil
 }
 
-// AddStep records a new step gate decision
+// AddStep records a new step gate decision and atomically maintains the
+// retry_context counters (Issue #1673 Phase 1).
+//
+// On fresh insert: gate_count = 1, completion_count = 0, last_decision = decision
+// (first-call invariant), first_attempt_at = now, idempotency_key = caller value
+// or NULL.
+//
+// On ON CONFLICT (a re-gate on an existing step, usually when retry_policy =
+// reevaluate): gate_count = existing + 1, last_decision = existing.decision
+// (snapshot OLD before overwrite), decision = NEW decision,
+// first_attempt_at preserved, idempotency_key preserved (immutable once set).
+//
+// RETURNING populates step.ID, step.GateCount, step.CompletionCount,
+// step.LastDecision, step.FirstAttemptAt, step.IdempotencyKey so callers can
+// build retry_context without a follow-up read.
+//
+// Idempotency-key validation (mismatch ⇒ 409) lives in the service layer —
+// repository only enforces immutability via COALESCE.
 func (r *PostgresRepository) AddStep(ctx context.Context, step *WorkflowStep) error {
 	now := time.Now()
 	step.GateCheckedAt = now
@@ -447,19 +468,38 @@ func (r *PostgresRepository) AddStep(ctx context.Context, step *WorkflowStep) er
 		stepInput = json.RawMessage("{}")
 	}
 
+	// idempotency_key: convert pointer to sql.NullString so nil maps to SQL NULL.
+	var idempotencyKey sql.NullString
+	if step.IdempotencyKey != nil && *step.IdempotencyKey != "" {
+		idempotencyKey = sql.NullString{String: *step.IdempotencyKey, Valid: true}
+	}
+
 	query := `
 		INSERT INTO workflow_steps (
 			workflow_id, step_id, step_index, step_name, step_type,
 			decision, decision_reason, policies_evaluated, policies_matched,
 			approval_status, step_input, model, provider,
-			tokens_in, tokens_out, cost_usd, gate_checked_at
-		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
+			tokens_in, tokens_out, cost_usd, gate_checked_at,
+			gate_count, completion_count, last_decision, first_attempt_at,
+			idempotency_key
+		) VALUES (
+			$1, $2, $3, $4, $5,
+			$6, $7, $8, $9,
+			$10, $11, $12, $13,
+			$14, $15, $16, $17,
+			1, 0, $6, $17,
+			$18
+		)
 		ON CONFLICT (workflow_id, step_id) DO UPDATE SET
 			step_name = EXCLUDED.step_name,
 			step_type = EXCLUDED.step_type,
 			step_input = EXCLUDED.step_input,
 			model = EXCLUDED.model,
 			provider = EXCLUDED.provider,
+			-- Snapshot OLD decision as last_decision BEFORE we overwrite decision.
+			-- This is the value the next gate response will report as
+			-- retry_context.last_decision (= "decision of the prior gate call").
+			last_decision = workflow_steps.decision,
 			decision = EXCLUDED.decision,
 			decision_reason = EXCLUDED.decision_reason,
 			policies_evaluated = EXCLUDED.policies_evaluated,
@@ -468,9 +508,18 @@ func (r *PostgresRepository) AddStep(ctx context.Context, step *WorkflowStep) er
 			tokens_in = EXCLUDED.tokens_in,
 			tokens_out = EXCLUDED.tokens_out,
 			cost_usd = EXCLUDED.cost_usd,
-			gate_checked_at = EXCLUDED.gate_checked_at
-		RETURNING id
+			gate_checked_at = EXCLUDED.gate_checked_at,
+			gate_count = workflow_steps.gate_count + 1,
+			-- completion_count is preserved (this is a gate, not a complete).
+			-- first_attempt_at is preserved (it's the *first* gate, not the latest).
+			-- idempotency_key is immutable once set: keep existing, else take new.
+			idempotency_key = COALESCE(workflow_steps.idempotency_key, EXCLUDED.idempotency_key)
+		RETURNING id, gate_count, completion_count, last_decision, first_attempt_at, idempotency_key
 	`
+
+	var lastDecisionStr sql.NullString
+	var firstAttemptAt sql.NullTime
+	var returnedIdempotencyKey sql.NullString
 
 	err := r.db.QueryRowContext(ctx, query,
 		step.WorkflowID,
@@ -490,10 +539,31 @@ func (r *PostgresRepository) AddStep(ctx context.Context, step *WorkflowStep) er
 		step.TokensOut,
 		step.CostUSD,
 		step.GateCheckedAt,
-	).Scan(&step.ID)
+		idempotencyKey,
+	).Scan(
+		&step.ID,
+		&step.GateCount,
+		&step.CompletionCount,
+		&lastDecisionStr,
+		&firstAttemptAt,
+		&returnedIdempotencyKey,
+	)
 
 	if err != nil {
 		return err
+	}
+
+	if lastDecisionStr.Valid {
+		step.LastDecision = GateDecision(lastDecisionStr.String)
+	}
+	if firstAttemptAt.Valid {
+		step.FirstAttemptAt = &firstAttemptAt.Time
+	}
+	if returnedIdempotencyKey.Valid {
+		k := returnedIdempotencyKey.String
+		step.IdempotencyKey = &k
+	} else {
+		step.IdempotencyKey = nil
 	}
 
 	// Update workflow's current step index
@@ -507,18 +577,54 @@ func (r *PostgresRepository) AddStep(ctx context.Context, step *WorkflowStep) er
 	return nil
 }
 
-// GetStep retrieves a specific step
-func (r *PostgresRepository) GetStep(ctx context.Context, workflowID, stepID string) (*WorkflowStep, error) {
+// BumpGateCountCached is called from the cached-hit path of StepGate (Issue
+// #1673 Phase 1). When /gate returns a cached decision (the step was already
+// evaluated and retry_policy is idempotent), we still want to track that the
+// gate was called: gate_count increments, last_decision is snapshotted from
+// the current decision so the NEXT call can surface it as
+// retry_context.last_decision, and gate_checked_at moves to now.
+//
+// The stored decision is NOT changed — this is purely a counter/timestamp
+// bump. If the row doesn't exist (shouldn't happen on the cached path),
+// returns an error so the service layer can fall through to AddStep.
+func (r *PostgresRepository) BumpGateCountCached(ctx context.Context, workflowID, stepID string) (*WorkflowStep, error) {
+	now := time.Now()
 	query := `
-		SELECT id, workflow_id, step_id, step_index, step_name, step_type,
-			   decision, decision_reason, policies_evaluated, policies_matched,
-			   approval_status, approved_by, approved_at,
-			   step_input, model, provider, tokens_in, tokens_out, cost_usd,
-			   step_output, approval_comment, gate_checked_at, step_completed_at
-		FROM workflow_steps
-		WHERE workflow_id = $1 AND step_id = $2
+		UPDATE workflow_steps
+		SET gate_count = gate_count + 1,
+		    last_decision = decision,
+		    gate_checked_at = $1
+		WHERE workflow_id = $2 AND step_id = $3
+		RETURNING ` + stepSelectColumns + `
 	`
+	row := r.db.QueryRowContext(ctx, query, now, workflowID, stepID)
+	step, err := scanWorkflowStepRow(row)
+	if err == sql.ErrNoRows {
+		return nil, fmt.Errorf("step not found: %s/%s", workflowID, stepID)
+	}
+	return step, err
+}
 
+// stepSelectColumns is the canonical column list for reading a workflow_steps row.
+// Kept as a constant so GetStep / GetStepDecision / GetStepsForWorkflow /
+// BumpGateCountCached stay in sync when new columns are added.
+const stepSelectColumns = `
+	id, workflow_id, step_id, step_index, step_name, step_type,
+	decision, decision_reason, policies_evaluated, policies_matched,
+	approval_status, approved_by, approved_at,
+	step_input, model, provider, tokens_in, tokens_out, cost_usd,
+	step_output, approval_comment, gate_checked_at, step_completed_at,
+	gate_count, completion_count, last_decision, first_attempt_at,
+	idempotency_key
+`
+
+// scanWorkflowStepRow reads one row into a WorkflowStep. Assumes the SELECT
+// column order matches stepSelectColumns. Used by GetStep / GetStepDecision
+// / BumpGateCountCached / GetStepsForWorkflow so nullable-column handling is
+// consistent.
+func scanWorkflowStepRow(row interface {
+	Scan(dest ...interface{}) error
+}) (*WorkflowStep, error) {
 	var step WorkflowStep
 	var approvalStatus sql.NullString
 	var approvedBy sql.NullString
@@ -526,8 +632,11 @@ func (r *PostgresRepository) GetStep(ctx context.Context, workflowID, stepID str
 	var approvalComment sql.NullString
 	var stepCompletedAt sql.NullTime
 	var stepOutput []byte
+	var lastDecisionStr sql.NullString
+	var firstAttemptAt sql.NullTime
+	var idempotencyKey sql.NullString
 
-	err := r.db.QueryRowContext(ctx, query, workflowID, stepID).Scan(
+	err := row.Scan(
 		&step.ID,
 		&step.WorkflowID,
 		&step.StepID,
@@ -551,11 +660,12 @@ func (r *PostgresRepository) GetStep(ctx context.Context, workflowID, stepID str
 		&approvalComment,
 		&step.GateCheckedAt,
 		&stepCompletedAt,
+		&step.GateCount,
+		&step.CompletionCount,
+		&lastDecisionStr,
+		&firstAttemptAt,
+		&idempotencyKey,
 	)
-
-	if err == sql.ErrNoRows {
-		return nil, fmt.Errorf("step not found: %s/%s", workflowID, stepID)
-	}
 	if err != nil {
 		return nil, err
 	}
@@ -579,86 +689,42 @@ func (r *PostgresRepository) GetStep(ctx context.Context, workflowID, stepID str
 	if stepOutput != nil {
 		step.StepOutput = json.RawMessage(stepOutput)
 	}
+	if lastDecisionStr.Valid {
+		step.LastDecision = GateDecision(lastDecisionStr.String)
+	}
+	if firstAttemptAt.Valid {
+		step.FirstAttemptAt = &firstAttemptAt.Time
+	}
+	if idempotencyKey.Valid {
+		k := idempotencyKey.String
+		step.IdempotencyKey = &k
+	}
 
 	return &step, nil
+}
+
+// GetStep retrieves a specific step
+func (r *PostgresRepository) GetStep(ctx context.Context, workflowID, stepID string) (*WorkflowStep, error) {
+	query := `SELECT ` + stepSelectColumns + ` FROM workflow_steps WHERE workflow_id = $1 AND step_id = $2`
+	row := r.db.QueryRowContext(ctx, query, workflowID, stepID)
+	step, err := scanWorkflowStepRow(row)
+	if err == sql.ErrNoRows {
+		return nil, fmt.Errorf("step not found: %s/%s", workflowID, stepID)
+	}
+	return step, err
 }
 
 // GetStepDecision retrieves a step's cached decision for idempotent retry support (#1414).
 // Unlike GetStep, this returns nil (not error) when the step has not been evaluated yet,
 // making it suitable for the cache-lookup path where "not found" is a normal outcome.
 func (r *PostgresRepository) GetStepDecision(ctx context.Context, workflowID, stepID string) (*WorkflowStep, error) {
-	query := `
-		SELECT id, workflow_id, step_id, step_index, step_name, step_type,
-			   decision, decision_reason, policies_evaluated, policies_matched,
-			   approval_status, approved_by, approved_at,
-			   step_input, model, provider, tokens_in, tokens_out, cost_usd,
-			   step_output, approval_comment, gate_checked_at, step_completed_at
-		FROM workflow_steps
-		WHERE workflow_id = $1 AND step_id = $2
-	`
-
-	var step WorkflowStep
-	var approvalStatus sql.NullString
-	var approvedBy sql.NullString
-	var approvedAt sql.NullTime
-	var approvalComment sql.NullString
-	var stepCompletedAt sql.NullTime
-	var stepOutput []byte
-
-	err := r.db.QueryRowContext(ctx, query, workflowID, stepID).Scan(
-		&step.ID,
-		&step.WorkflowID,
-		&step.StepID,
-		&step.StepIndex,
-		&step.StepName,
-		&step.StepType,
-		&step.Decision,
-		&step.DecisionReason,
-		&step.PoliciesEvaluated,
-		&step.PoliciesMatched,
-		&approvalStatus,
-		&approvedBy,
-		&approvedAt,
-		&step.StepInput,
-		&step.Model,
-		&step.Provider,
-		&step.TokensIn,
-		&step.TokensOut,
-		&step.CostUSD,
-		&stepOutput,
-		&approvalComment,
-		&step.GateCheckedAt,
-		&stepCompletedAt,
-	)
-
+	query := `SELECT ` + stepSelectColumns + ` FROM workflow_steps WHERE workflow_id = $1 AND step_id = $2`
+	row := r.db.QueryRowContext(ctx, query, workflowID, stepID)
+	step, err := scanWorkflowStepRow(row)
 	if err == sql.ErrNoRows {
 		return nil, nil // Not found is normal — means no cached decision
 	}
-	if err != nil {
-		return nil, err
-	}
-
-	if approvalStatus.Valid {
-		as := ApprovalStatus(approvalStatus.String)
-		step.ApprovalStatus = &as
-	}
-	if approvedBy.Valid {
-		step.ApprovedBy = approvedBy.String
-	}
-	if approvedAt.Valid {
-		step.ApprovedAt = &approvedAt.Time
-	}
-	if approvalComment.Valid {
-		step.ApprovalComment = approvalComment.String
-	}
-	if stepCompletedAt.Valid {
-		step.StepCompletedAt = &stepCompletedAt.Time
-	}
-	if stepOutput != nil {
-		step.StepOutput = json.RawMessage(stepOutput)
-	}
-
-	return &step, nil
+	return step, err
 }
 
 // UpdateStepApproval updates the approval status of a step
@@ -690,6 +756,12 @@ func (r *PostgresRepository) UpdateStepApproval(ctx context.Context, workflowID,
 }
 
 // MarkStepCompleted marks a step as completed, optionally updating post-execution metrics.
+// Also increments completion_count (Issue #1673 Phase 1) so retry_context on
+// subsequent gate calls reflects that a prior /complete landed.
+//
+// Idempotency-key validation happens in the service layer before this is
+// called; if the key on the complete request doesn't match the stored key,
+// the service returns 409 IDEMPOTENCY_KEY_MISMATCH and never reaches here.
 func (r *PostgresRepository) MarkStepCompleted(ctx context.Context, workflowID, stepID string, req *StepCompleteRequest) error {
 	now := time.Now()
 
@@ -716,7 +788,8 @@ func (r *PostgresRepository) MarkStepCompleted(ctx context.Context, workflowID, 
 		    tokens_in = COALESCE($4, tokens_in),
 		    tokens_out = COALESCE($5, tokens_out),
 		    cost_usd = COALESCE($6, cost_usd),
-		    step_output = COALESCE($7, step_output)
+		    step_output = COALESCE($7, step_output),
+		    completion_count = completion_count + 1
 		WHERE workflow_id = $2 AND step_id = $3
 	`
 	result, err := r.db.ExecContext(ctx, query, now, workflowID, stepID, tokensIn, tokensOut, costUSD, stepOutput)
@@ -737,16 +810,7 @@ func (r *PostgresRepository) MarkStepCompleted(ctx context.Context, workflowID, 
 
 // GetStepsForWorkflow retrieves all steps for a workflow
 func (r *PostgresRepository) GetStepsForWorkflow(ctx context.Context, workflowID string) ([]WorkflowStep, error) {
-	query := `
-		SELECT id, workflow_id, step_id, step_index, step_name, step_type,
-			   decision, decision_reason, policies_evaluated, policies_matched,
-			   approval_status, approved_by, approved_at,
-			   step_input, model, provider, tokens_in, tokens_out, cost_usd,
-			   step_output, approval_comment, gate_checked_at, step_completed_at
-		FROM workflow_steps
-		WHERE workflow_id = $1
-		ORDER BY step_index ASC
-	`
+	query := `SELECT ` + stepSelectColumns + ` FROM workflow_steps WHERE workflow_id = $1 ORDER BY step_index ASC`
 
 	rows, err := r.db.QueryContext(ctx, query, workflowID)
 	if err != nil {
@@ -756,64 +820,11 @@ func (r *PostgresRepository) GetStepsForWorkflow(ctx context.Context, workflowID
 
 	var steps []WorkflowStep
 	for rows.Next() {
-		var step WorkflowStep
-		var approvalStatus sql.NullString
-		var approvedBy sql.NullString
-		var approvedAt sql.NullTime
-		var approvalComment sql.NullString
-		var stepCompletedAt sql.NullTime
-		var stepOutput []byte
-
-		err := rows.Scan(
-			&step.ID,
-			&step.WorkflowID,
-			&step.StepID,
-			&step.StepIndex,
-			&step.StepName,
-			&step.StepType,
-			&step.Decision,
-			&step.DecisionReason,
-			&step.PoliciesEvaluated,
-			&step.PoliciesMatched,
-			&approvalStatus,
-			&approvedBy,
-			&approvedAt,
-			&step.StepInput,
-			&step.Model,
-			&step.Provider,
-			&step.TokensIn,
-			&step.TokensOut,
-			&step.CostUSD,
-			&stepOutput,
-			&approvalComment,
-			&step.GateCheckedAt,
-			&stepCompletedAt,
-		)
-		if err != nil {
-			return nil, err
+		step, scanErr := scanWorkflowStepRow(rows)
+		if scanErr != nil {
+			return nil, scanErr
 		}
-
-		if approvalStatus.Valid {
-			as := ApprovalStatus(approvalStatus.String)
-			step.ApprovalStatus = &as
-		}
-		if approvedBy.Valid {
-			step.ApprovedBy = approvedBy.String
-		}
-		if approvedAt.Valid {
-			step.ApprovedAt = &approvedAt.Time
-		}
-		if approvalComment.Valid {
-			step.ApprovalComment = approvalComment.String
-		}
-		if stepCompletedAt.Valid {
-			step.StepCompletedAt = &stepCompletedAt.Time
-		}
-		if stepOutput != nil {
-			step.StepOutput = json.RawMessage(stepOutput)
-		}
-
-		steps = append(steps, step)
+		steps = append(steps, *step)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("iterate step rows: %w", err)

--- a/platform/orchestrator/workflow_control/repository_integration_test.go
+++ b/platform/orchestrator/workflow_control/repository_integration_test.go
@@ -87,8 +87,19 @@ func workflowControlSchema() string {
 			approval_comment TEXT,
 			gate_checked_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
 			step_completed_at TIMESTAMP WITH TIME ZONE,
+			-- Issue #1673 Phase 1 (migration 071)
+			gate_count INTEGER NOT NULL DEFAULT 0,
+			completion_count INTEGER NOT NULL DEFAULT 0,
+			last_decision VARCHAR(50),
+			first_attempt_at TIMESTAMP WITH TIME ZONE,
+			-- Issue #1673 Phase 2 (migration 072)
+			idempotency_key VARCHAR(255),
 			UNIQUE(workflow_id, step_id)
 		);
+
+		CREATE INDEX IF NOT EXISTS idx_workflow_steps_idempotency_key
+			ON workflow_steps(idempotency_key)
+			WHERE idempotency_key IS NOT NULL;
 	`
 }
 

--- a/platform/orchestrator/workflow_control/retry_context_handler_test.go
+++ b/platform/orchestrator/workflow_control/retry_context_handler_test.go
@@ -1,0 +1,198 @@
+// Copyright 2026 AxonFlow
+// SPDX-License-Identifier: BUSL-1.1
+
+// HTTP-handler-level tests for Issue #1673 Phase 1 + Phase 2.
+// Covers the pieces service-level tests can't reach:
+//   - ?include_prior_output=true query param parsing
+//   - max-length validation for idempotency_key (400)
+//   - writeIdempotencyKeyMismatch envelope on 409
+//   - typed error class surfacing expected/received keys
+
+package workflow_control
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/mux"
+)
+
+// TestHandler_StepGate_IncludePriorOutputParam verifies the ?include_prior_output=true
+// query param reaches the service and populates RetryContext.PriorOutput.
+func TestHandler_StepGate_IncludePriorOutputParam(t *testing.T) {
+	handler, svc, _ := setupTestHandler()
+	ctx := context.Background()
+
+	wf, _ := svc.CreateWorkflow(ctx, &CreateWorkflowRequest{WorkflowName: "tc"},
+		"", "", "", "")
+
+	// Prime: gate + complete so there's a prior output.
+	gateReq := &StepGateRequest{StepType: StepTypeToolCall, StepName: "s"}
+	if _, err := svc.StepGate(ctx, wf.WorkflowID, "s1", gateReq, "", "", "", ""); err != nil {
+		t.Fatalf("prime gate: %v", err)
+	}
+	out := map[string]interface{}{"transfer_id": "TXN-xyz"}
+	if err := svc.MarkStepCompleted(ctx, wf.WorkflowID, "s1",
+		&StepCompleteRequest{Output: out}, "", ""); err != nil {
+		t.Fatalf("prime complete: %v", err)
+	}
+
+	t.Run("without include_prior_output → prior_output null", func(t *testing.T) {
+		body, _ := json.Marshal(StepGateRequest{StepType: StepTypeToolCall})
+		req := httptest.NewRequest(http.MethodPost,
+			"/api/v1/workflows/"+wf.WorkflowID+"/steps/s1/gate",
+			bytes.NewReader(body))
+		req = mux.SetURLVars(req, map[string]string{"id": wf.WorkflowID, "step_id": "s1"})
+		rr := httptest.NewRecorder()
+		handler.StepGate(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+		}
+		var resp StepGateResponse
+		if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if resp.RetryContext.PriorOutput != nil {
+			t.Errorf("PriorOutput: want nil without query param, got %v", resp.RetryContext.PriorOutput)
+		}
+		if !resp.RetryContext.PriorOutputAvailable {
+			t.Error("PriorOutputAvailable: want true (prior completion exists)")
+		}
+	})
+
+	t.Run("with include_prior_output=true → prior_output populated", func(t *testing.T) {
+		body, _ := json.Marshal(StepGateRequest{StepType: StepTypeToolCall})
+		req := httptest.NewRequest(http.MethodPost,
+			"/api/v1/workflows/"+wf.WorkflowID+"/steps/s1/gate?include_prior_output=true",
+			bytes.NewReader(body))
+		req = mux.SetURLVars(req, map[string]string{"id": wf.WorkflowID, "step_id": "s1"})
+		rr := httptest.NewRecorder()
+		handler.StepGate(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+		}
+		var resp StepGateResponse
+		if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if resp.RetryContext.PriorOutput == nil {
+			t.Fatal("PriorOutput: want populated with include_prior_output=true")
+		}
+		if resp.RetryContext.PriorOutput["transfer_id"] != "TXN-xyz" {
+			t.Errorf("PriorOutput[transfer_id]: want TXN-xyz, got %v", resp.RetryContext.PriorOutput["transfer_id"])
+		}
+	})
+}
+
+// TestHandler_IdempotencyKeyMismatch_409Envelope exercises the 409 response
+// shape for both /gate and /complete endpoints — must match
+// technical-docs/WCP_RETRY_IDEMPOTENCY_WIRE_CONTRACT.md §5.
+func TestHandler_IdempotencyKeyMismatch_409Envelope(t *testing.T) {
+	handler, svc, _ := setupTestHandler()
+	ctx := context.Background()
+
+	wf, _ := svc.CreateWorkflow(ctx, &CreateWorkflowRequest{WorkflowName: "tc"}, "", "", "", "")
+	if _, err := svc.StepGate(ctx, wf.WorkflowID, "s1", &StepGateRequest{
+		StepType: StepTypeToolCall, IdempotencyKey: "K-initial",
+	}, "", "", "", ""); err != nil {
+		t.Fatalf("prime gate: %v", err)
+	}
+
+	t.Run("gate mismatch", func(t *testing.T) {
+		body, _ := json.Marshal(StepGateRequest{StepType: StepTypeToolCall, IdempotencyKey: "K-different"})
+		req := httptest.NewRequest(http.MethodPost,
+			"/api/v1/workflows/"+wf.WorkflowID+"/steps/s1/gate",
+			bytes.NewReader(body))
+		req = mux.SetURLVars(req, map[string]string{"id": wf.WorkflowID, "step_id": "s1"})
+		rr := httptest.NewRecorder()
+		handler.StepGate(rr, req)
+		assertMismatch409(t, rr, wf.WorkflowID, "s1", "K-initial", "K-different")
+	})
+
+	t.Run("complete mismatch", func(t *testing.T) {
+		body, _ := json.Marshal(StepCompleteRequest{IdempotencyKey: "K-different"})
+		req := httptest.NewRequest(http.MethodPost,
+			"/api/v1/workflows/"+wf.WorkflowID+"/steps/s1/complete",
+			bytes.NewReader(body))
+		req.ContentLength = int64(len(body))
+		req = mux.SetURLVars(req, map[string]string{"id": wf.WorkflowID, "step_id": "s1"})
+		rr := httptest.NewRecorder()
+		handler.MarkStepCompleted(rr, req)
+		assertMismatch409(t, rr, wf.WorkflowID, "s1", "K-initial", "K-different")
+	})
+}
+
+func assertMismatch409(t *testing.T, rr *httptest.ResponseRecorder, wfID, stepID, expected, received string) {
+	t.Helper()
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("status=%d want=409 body=%s", rr.Code, rr.Body.String())
+	}
+	if ct := rr.Header().Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Errorf("Content-Type: want application/json, got %q", ct)
+	}
+	var env APIErrorResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &env); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if env.Error.Code != ErrorCodeIdempotencyKeyMismatch {
+		t.Errorf("Error.Code: want %s, got %s", ErrorCodeIdempotencyKeyMismatch, env.Error.Code)
+	}
+	if env.Error.Details.WorkflowID != wfID {
+		t.Errorf("WorkflowID: want %s, got %s", wfID, env.Error.Details.WorkflowID)
+	}
+	if env.Error.Details.StepID != stepID {
+		t.Errorf("StepID: want %s, got %s", stepID, env.Error.Details.StepID)
+	}
+	if env.Error.Details.ExpectedIdempotencyKey != expected {
+		t.Errorf("ExpectedKey: want %q, got %q", expected, env.Error.Details.ExpectedIdempotencyKey)
+	}
+	if env.Error.Details.ReceivedIdempotencyKey != received {
+		t.Errorf("ReceivedKey: want %q, got %q", received, env.Error.Details.ReceivedIdempotencyKey)
+	}
+}
+
+// TestHandler_IdempotencyKey_MaxLength covers the 400 response for oversized keys.
+func TestHandler_IdempotencyKey_MaxLength(t *testing.T) {
+	handler, svc, _ := setupTestHandler()
+	ctx := context.Background()
+	wf, _ := svc.CreateWorkflow(ctx, &CreateWorkflowRequest{WorkflowName: "tc"}, "", "", "", "")
+
+	tooLong := strings.Repeat("x", 256) // limit is 255
+
+	t.Run("gate rejects oversized key", func(t *testing.T) {
+		body, _ := json.Marshal(StepGateRequest{StepType: StepTypeToolCall, IdempotencyKey: tooLong})
+		req := httptest.NewRequest(http.MethodPost,
+			"/api/v1/workflows/"+wf.WorkflowID+"/steps/s1/gate",
+			bytes.NewReader(body))
+		req = mux.SetURLVars(req, map[string]string{"id": wf.WorkflowID, "step_id": "s1"})
+		rr := httptest.NewRecorder()
+		handler.StepGate(rr, req)
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("status=%d want=400 body=%s", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("complete rejects oversized key", func(t *testing.T) {
+		// Prime a step to complete
+		if _, err := svc.StepGate(ctx, wf.WorkflowID, "s2",
+			&StepGateRequest{StepType: StepTypeToolCall}, "", "", "", ""); err != nil {
+			t.Fatalf("prime: %v", err)
+		}
+		body, _ := json.Marshal(StepCompleteRequest{IdempotencyKey: tooLong})
+		req := httptest.NewRequest(http.MethodPost,
+			"/api/v1/workflows/"+wf.WorkflowID+"/steps/s2/complete",
+			bytes.NewReader(body))
+		req.ContentLength = int64(len(body))
+		req = mux.SetURLVars(req, map[string]string{"id": wf.WorkflowID, "step_id": "s2"})
+		rr := httptest.NewRecorder()
+		handler.MarkStepCompleted(rr, req)
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("status=%d want=400 body=%s", rr.Code, rr.Body.String())
+		}
+	})
+}

--- a/platform/orchestrator/workflow_control/retry_context_integration_test.go
+++ b/platform/orchestrator/workflow_control/retry_context_integration_test.go
@@ -1,0 +1,320 @@
+// Copyright 2026 AxonFlow
+// SPDX-License-Identifier: BUSL-1.1
+
+// Postgres-backed integration tests for Issue #1673 Phase 1 + Phase 2.
+// Exercises the real DB path for:
+//   - AddStep UPSERT semantics (counters, last_decision snapshot, idempotency_key COALESCE)
+//   - BumpGateCountCached (cached-hit counter bump)
+//   - MarkStepCompleted (completion_count increment)
+//   - Full gate → complete → re-gate lifecycle with retry_context transitions
+//
+// Uses getTestDB / workflowControlSchema from repository_integration_test.go.
+
+package workflow_control
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+)
+
+func seedWorkflow(t *testing.T, repo *PostgresRepository, tenantID string) string {
+	t.Helper()
+	id := fmt.Sprintf("wf_%d", time.Now().UnixNano())
+	wf := &Workflow{
+		WorkflowID:   id,
+		WorkflowName: "integration-retry-context",
+		Source:       WorkflowSourceExternal,
+		TenantID:     tenantID,
+	}
+	if err := repo.Create(context.Background(), wf); err != nil {
+		t.Fatalf("seed workflow: %v", err)
+	}
+	return id
+}
+
+// TestIntegration_AddStep_FirstCallSetsCountersAndFirstAttemptAt verifies
+// the INSERT path: gate_count=1, completion_count=0, last_decision=decision,
+// first_attempt_at=now, idempotency_key persisted.
+func TestIntegration_AddStep_FirstCallSetsCountersAndFirstAttemptAt(t *testing.T) {
+	db := getTestDB(t)
+	defer db.Close()
+	repo := NewPostgresRepository(db)
+	tenantID := fmt.Sprintf("tc-first-%d", time.Now().UnixNano())
+	defer cleanupTestWorkflows(t, db, tenantID)
+	wf := seedWorkflow(t, repo, tenantID)
+
+	key := "payment:wire:inv-1"
+	step := &WorkflowStep{
+		WorkflowID:     wf,
+		StepID:         "s1",
+		StepIndex:      1,
+		StepType:       StepTypeToolCall,
+		Decision:       GateDecisionAllow,
+		IdempotencyKey: &key,
+	}
+	if err := repo.AddStep(context.Background(), step); err != nil {
+		t.Fatalf("AddStep: %v", err)
+	}
+
+	if step.GateCount != 1 {
+		t.Errorf("GateCount: want 1, got %d", step.GateCount)
+	}
+	if step.CompletionCount != 0 {
+		t.Errorf("CompletionCount: want 0, got %d", step.CompletionCount)
+	}
+	if step.LastDecision != GateDecisionAllow {
+		t.Errorf("LastDecision: want allow (first-call invariant), got %s", step.LastDecision)
+	}
+	if step.FirstAttemptAt == nil {
+		t.Error("FirstAttemptAt: want non-nil after insert")
+	}
+	if step.IdempotencyKey == nil || *step.IdempotencyKey != key {
+		t.Errorf("IdempotencyKey: want %q, got %v", key, step.IdempotencyKey)
+	}
+}
+
+// TestIntegration_AddStep_ReGateBumpsCountAndSnapshotsLastDecision verifies
+// the UPSERT branch on re-gate: counter bumps, OLD decision becomes
+// last_decision, idempotency_key preserved even when caller supplies a
+// different value (immutability via COALESCE).
+func TestIntegration_AddStep_ReGateBumpsCountAndSnapshotsLastDecision(t *testing.T) {
+	db := getTestDB(t)
+	defer db.Close()
+	repo := NewPostgresRepository(db)
+	tenantID := fmt.Sprintf("tc-regate-%d", time.Now().UnixNano())
+	defer cleanupTestWorkflows(t, db, tenantID)
+	wf := seedWorkflow(t, repo, tenantID)
+
+	ctx := context.Background()
+	originalKey := "K-original"
+	step := &WorkflowStep{
+		WorkflowID:     wf,
+		StepID:         "s1",
+		StepIndex:      1,
+		StepType:       StepTypeToolCall,
+		Decision:       GateDecisionAllow,
+		IdempotencyKey: &originalKey,
+	}
+	if err := repo.AddStep(ctx, step); err != nil {
+		t.Fatalf("first AddStep: %v", err)
+	}
+	firstAttempt := *step.FirstAttemptAt
+
+	// Simulate delay so first_attempt_at stays earlier than gate_checked_at
+	time.Sleep(10 * time.Millisecond)
+
+	// Re-gate with a NEW decision and DIFFERENT idempotency_key.
+	// Repo should preserve first_attempt_at and keep the original key
+	// (immutability enforced via COALESCE in the UPSERT).
+	differentKey := "K-different"
+	step2 := &WorkflowStep{
+		WorkflowID:     wf,
+		StepID:         "s1",
+		StepIndex:      1,
+		StepType:       StepTypeToolCall,
+		Decision:       GateDecisionBlock, // changed
+		IdempotencyKey: &differentKey,     // would-be new key
+	}
+	if err := repo.AddStep(ctx, step2); err != nil {
+		t.Fatalf("re-AddStep: %v", err)
+	}
+
+	if step2.GateCount != 2 {
+		t.Errorf("GateCount: want 2, got %d", step2.GateCount)
+	}
+	if step2.CompletionCount != 0 {
+		t.Errorf("CompletionCount: want preserved 0, got %d", step2.CompletionCount)
+	}
+	// LastDecision should be the OLD (first) decision, not the new block.
+	if step2.LastDecision != GateDecisionAllow {
+		t.Errorf("LastDecision: want allow (snapshot of prior), got %s", step2.LastDecision)
+	}
+	if step2.FirstAttemptAt == nil || !step2.FirstAttemptAt.Equal(firstAttempt) {
+		t.Errorf("FirstAttemptAt: want preserved %v, got %v", firstAttempt, step2.FirstAttemptAt)
+	}
+	if step2.IdempotencyKey == nil || *step2.IdempotencyKey != originalKey {
+		t.Errorf("IdempotencyKey: want preserved %q (immutable), got %v", originalKey, step2.IdempotencyKey)
+	}
+}
+
+// TestIntegration_BumpGateCountCached_OnlyTouchesCounterAndLastDecision
+// verifies the UPDATE-only path used by the cached StepGate branch.
+func TestIntegration_BumpGateCountCached_OnlyTouchesCounterAndLastDecision(t *testing.T) {
+	db := getTestDB(t)
+	defer db.Close()
+	repo := NewPostgresRepository(db)
+	tenantID := fmt.Sprintf("tc-bump-%d", time.Now().UnixNano())
+	defer cleanupTestWorkflows(t, db, tenantID)
+	wf := seedWorkflow(t, repo, tenantID)
+
+	ctx := context.Background()
+	step := &WorkflowStep{
+		WorkflowID: wf,
+		StepID:     "s1",
+		StepIndex:  1,
+		StepType:   StepTypeToolCall,
+		Decision:   GateDecisionAllow,
+	}
+	if err := repo.AddStep(ctx, step); err != nil {
+		t.Fatalf("AddStep: %v", err)
+	}
+	originalDecision := step.Decision
+	originalFirstAttempt := *step.FirstAttemptAt
+
+	time.Sleep(10 * time.Millisecond)
+
+	bumped, err := repo.BumpGateCountCached(ctx, wf, "s1")
+	if err != nil {
+		t.Fatalf("BumpGateCountCached: %v", err)
+	}
+	if bumped.GateCount != 2 {
+		t.Errorf("GateCount: want 2, got %d", bumped.GateCount)
+	}
+	if bumped.Decision != originalDecision {
+		t.Errorf("Decision: want preserved %s, got %s", originalDecision, bumped.Decision)
+	}
+	if bumped.LastDecision != originalDecision {
+		t.Errorf("LastDecision: want snapshotted %s, got %s", originalDecision, bumped.LastDecision)
+	}
+	if bumped.FirstAttemptAt == nil || !bumped.FirstAttemptAt.Equal(originalFirstAttempt) {
+		t.Errorf("FirstAttemptAt: want preserved, got %v", bumped.FirstAttemptAt)
+	}
+}
+
+// TestIntegration_MarkStepCompleted_IncrementsCompletionCount verifies the
+// complete path bumps completion_count and that a subsequent GetStepDecision
+// reflects the new value.
+func TestIntegration_MarkStepCompleted_IncrementsCompletionCount(t *testing.T) {
+	db := getTestDB(t)
+	defer db.Close()
+	repo := NewPostgresRepository(db)
+	tenantID := fmt.Sprintf("tc-complete-%d", time.Now().UnixNano())
+	defer cleanupTestWorkflows(t, db, tenantID)
+	wf := seedWorkflow(t, repo, tenantID)
+
+	ctx := context.Background()
+	step := &WorkflowStep{
+		WorkflowID: wf,
+		StepID:     "s1",
+		StepIndex:  1,
+		StepType:   StepTypeToolCall,
+		Decision:   GateDecisionAllow,
+	}
+	if err := repo.AddStep(ctx, step); err != nil {
+		t.Fatalf("AddStep: %v", err)
+	}
+
+	if err := repo.MarkStepCompleted(ctx, wf, "s1", &StepCompleteRequest{}); err != nil {
+		t.Fatalf("MarkStepCompleted: %v", err)
+	}
+
+	after, err := repo.GetStepDecision(ctx, wf, "s1")
+	if err != nil {
+		t.Fatalf("GetStepDecision: %v", err)
+	}
+	if after == nil {
+		t.Fatal("expected step to exist after complete")
+	}
+	if after.CompletionCount != 1 {
+		t.Errorf("CompletionCount: want 1, got %d", after.CompletionCount)
+	}
+	if after.StepCompletedAt == nil {
+		t.Error("StepCompletedAt: want non-nil after complete")
+	}
+}
+
+// TestIntegration_FullLifecycle_ThroughServiceLayer exercises the real
+// service + repo end-to-end across every retry_context transition plus
+// idempotency-key enforcement. This is the smoke test that verifies the
+// platform as a unit, against a real Postgres.
+func TestIntegration_FullLifecycle_ThroughServiceLayer(t *testing.T) {
+	db := getTestDB(t)
+	defer db.Close()
+	repo := NewPostgresRepository(db)
+	tenantID := fmt.Sprintf("tc-full-%d", time.Now().UnixNano())
+	defer cleanupTestWorkflows(t, db, tenantID)
+
+	svc := NewService(repo,
+		&fixedEvaluator{decision: GateDecisionAllow, reason: "ok"},
+		&ServiceConfig{BaseURL: "https://portal.test"},
+	)
+	ctx := context.Background()
+	wf, err := svc.CreateWorkflow(ctx, &CreateWorkflowRequest{
+		WorkflowName: "lifecycle",
+	}, tenantID, "", "", "")
+	if err != nil {
+		t.Fatalf("CreateWorkflow: %v", err)
+	}
+	wfID := wf.WorkflowID
+
+	key := "payment:wire:lifecycle-1"
+
+	// 1) First gate — fresh path, key recorded
+	resp1, err := svc.StepGate(ctx, wfID, "s1", &StepGateRequest{
+		StepType:       StepTypeToolCall,
+		IdempotencyKey: key,
+	}, tenantID, "", "", "")
+	if err != nil {
+		t.Fatalf("gate 1: %v", err)
+	}
+	if resp1.RetryContext.GateCount != 1 ||
+		resp1.RetryContext.PriorCompletionStatus != PriorCompletionStatusNone ||
+		resp1.RetryContext.IdempotencyKey != key {
+		t.Errorf("gate 1 retry_context unexpected: %+v", resp1.RetryContext)
+	}
+
+	// 2) Complete with matching key
+	if err := svc.MarkStepCompleted(ctx, wfID, "s1", &StepCompleteRequest{
+		IdempotencyKey: key,
+		Output:         map[string]interface{}{"tx": "TXN-01"},
+	}, tenantID, ""); err != nil {
+		t.Fatalf("complete: %v", err)
+	}
+
+	// 3) Re-gate (cached path) — expect status=completed, prior_output_available=true
+	resp2, err := svc.StepGate(ctx, wfID, "s1", &StepGateRequest{
+		StepType:       StepTypeToolCall,
+		IdempotencyKey: key,
+	}, tenantID, "", "", "")
+	if err != nil {
+		t.Fatalf("gate 2: %v", err)
+	}
+	if resp2.RetryContext.GateCount != 2 ||
+		resp2.RetryContext.CompletionCount != 1 ||
+		resp2.RetryContext.PriorCompletionStatus != PriorCompletionStatusCompleted ||
+		!resp2.RetryContext.PriorOutputAvailable {
+		t.Errorf("gate 2 retry_context unexpected: %+v", resp2.RetryContext)
+	}
+	if !resp2.Cached {
+		t.Error("gate 2 should be Cached")
+	}
+
+	// 4) Second gate with WRONG key — 409 via service error
+	_, err = svc.StepGate(ctx, wfID, "s1", &StepGateRequest{
+		StepType:       StepTypeToolCall,
+		IdempotencyKey: "K-different",
+	}, tenantID, "", "", "")
+	if err == nil {
+		t.Fatal("gate with mismatched key should fail")
+	}
+	if _, ok := err.(*IdempotencyKeyMismatchError); !ok {
+		t.Errorf("want *IdempotencyKeyMismatchError, got %T: %v", err, err)
+	}
+
+	// 5) include_prior_output=true returns payload
+	resp3, err := svc.StepGate(ctx, wfID, "s1", &StepGateRequest{
+		StepType:           StepTypeToolCall,
+		IdempotencyKey:     key,
+		IncludePriorOutput: true,
+	}, tenantID, "", "", "")
+	if err != nil {
+		t.Fatalf("gate 3: %v", err)
+	}
+	if resp3.RetryContext.PriorOutput == nil ||
+		resp3.RetryContext.PriorOutput["tx"] != "TXN-01" {
+		t.Errorf("gate 3 prior_output: want populated with tx=TXN-01, got %v",
+			resp3.RetryContext.PriorOutput)
+	}
+}

--- a/platform/orchestrator/workflow_control/retry_context_test.go
+++ b/platform/orchestrator/workflow_control/retry_context_test.go
@@ -1,0 +1,696 @@
+// Copyright 2026 AxonFlow
+// SPDX-License-Identifier: BUSL-1.1
+
+// Tests for Issue #1673 Phase 1 (retry_context) + Phase 2 (idempotency_key).
+//
+// These exercise the service + mock-repository stack so we verify counter
+// bookkeeping, prior_completion_status transitions, and idempotency-key
+// validation at the same level the Postgres repo enforces them in production.
+//
+// The contract these tests target is
+// technical-docs/WCP_RETRY_IDEMPOTENCY_WIRE_CONTRACT.md.
+
+package workflow_control
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+)
+
+// --- Phase 1: retry_context construction ---
+
+// TestRetryContext_FirstCall_Invariants covers the first-call shape promised by
+// contract §3. Every invariant is checked: counters == 1/0, status == none,
+// first_attempt == last_attempt, last_decision == decision.
+func TestRetryContext_FirstCall_Invariants(t *testing.T) {
+	svc, _ := setupTestService(&fixedEvaluator{decision: GateDecisionAllow, reason: "ok"})
+	wf := createTestWorkflow(t, svc)
+	ctx := context.Background()
+
+	resp, err := svc.StepGate(ctx, wf, "step-1", &StepGateRequest{
+		StepType: StepTypeToolCall,
+	}, "tenant-1", "org-1", "user-1", "client-1")
+	if err != nil {
+		t.Fatalf("first gate failed: %v", err)
+	}
+
+	rc := resp.RetryContext
+	if rc.GateCount != 1 {
+		t.Errorf("GateCount: want 1, got %d", rc.GateCount)
+	}
+	if rc.CompletionCount != 0 {
+		t.Errorf("CompletionCount: want 0, got %d", rc.CompletionCount)
+	}
+	if rc.PriorCompletionStatus != PriorCompletionStatusNone {
+		t.Errorf("PriorCompletionStatus: want none, got %s", rc.PriorCompletionStatus)
+	}
+	if rc.PriorOutputAvailable {
+		t.Error("PriorOutputAvailable: want false, got true")
+	}
+	if rc.PriorOutput != nil {
+		t.Error("PriorOutput: want nil on first call")
+	}
+	if rc.PriorCompletionAt != nil {
+		t.Error("PriorCompletionAt: want nil on first call")
+	}
+	if rc.LastDecision != resp.Decision {
+		t.Errorf("first-call invariant broken: LastDecision=%s, Decision=%s", rc.LastDecision, resp.Decision)
+	}
+	if !rc.FirstAttemptAt.Equal(rc.LastAttemptAt) {
+		t.Errorf("first-call invariant broken: FirstAttemptAt=%v != LastAttemptAt=%v",
+			rc.FirstAttemptAt, rc.LastAttemptAt)
+	}
+	if rc.IdempotencyKey != "" {
+		t.Errorf("IdempotencyKey: want empty on no-key call, got %q", rc.IdempotencyKey)
+	}
+}
+
+// TestRetryContext_SecondGate_WithCompletion covers the canonical "upstream
+// retried after a clean completion" scenario (contract's Scenario A). Expected:
+// counters bump, prior_completion_status = completed, prior_output_available = true.
+func TestRetryContext_SecondGate_WithCompletion(t *testing.T) {
+	svc, _ := setupTestService(&fixedEvaluator{decision: GateDecisionAllow, reason: "ok"})
+	wf := createTestWorkflow(t, svc)
+	ctx := context.Background()
+
+	// Gate 1 + Complete
+	if _, err := svc.StepGate(ctx, wf, "step-1", &StepGateRequest{StepType: StepTypeToolCall},
+		"tenant-1", "org-1", "user-1", "client-1"); err != nil {
+		t.Fatalf("gate 1: %v", err)
+	}
+	out := map[string]interface{}{"transfer_id": "TXN-1"}
+	if err := svc.MarkStepCompleted(ctx, wf, "step-1", &StepCompleteRequest{Output: out},
+		"tenant-1", "org-1"); err != nil {
+		t.Fatalf("complete: %v", err)
+	}
+
+	// Gate 2 (no include_prior_output)
+	resp, err := svc.StepGate(ctx, wf, "step-1", &StepGateRequest{StepType: StepTypeToolCall},
+		"tenant-1", "org-1", "user-1", "client-1")
+	if err != nil {
+		t.Fatalf("gate 2: %v", err)
+	}
+
+	rc := resp.RetryContext
+	if rc.GateCount != 2 {
+		t.Errorf("GateCount: want 2, got %d", rc.GateCount)
+	}
+	if rc.CompletionCount != 1 {
+		t.Errorf("CompletionCount: want 1, got %d", rc.CompletionCount)
+	}
+	if rc.PriorCompletionStatus != PriorCompletionStatusCompleted {
+		t.Errorf("PriorCompletionStatus: want completed, got %s", rc.PriorCompletionStatus)
+	}
+	if !rc.PriorOutputAvailable {
+		t.Error("PriorOutputAvailable: want true after complete")
+	}
+	if rc.PriorOutput != nil {
+		t.Errorf("PriorOutput should be nil without ?include_prior_output=true, got %v", rc.PriorOutput)
+	}
+	if rc.PriorCompletionAt == nil {
+		t.Error("PriorCompletionAt: want non-nil after complete")
+	}
+}
+
+// TestRetryContext_IncludePriorOutput_True verifies opt-in prior_output.
+func TestRetryContext_IncludePriorOutput_True(t *testing.T) {
+	svc, _ := setupTestService(&fixedEvaluator{decision: GateDecisionAllow, reason: "ok"})
+	wf := createTestWorkflow(t, svc)
+	ctx := context.Background()
+
+	if _, err := svc.StepGate(ctx, wf, "step-1", &StepGateRequest{StepType: StepTypeToolCall},
+		"tenant-1", "org-1", "user-1", "client-1"); err != nil {
+		t.Fatalf("gate 1: %v", err)
+	}
+	out := map[string]interface{}{"transfer_id": "TXN-42", "amount": 500.0}
+	if err := svc.MarkStepCompleted(ctx, wf, "step-1", &StepCompleteRequest{Output: out},
+		"tenant-1", "org-1"); err != nil {
+		t.Fatalf("complete: %v", err)
+	}
+
+	resp, err := svc.StepGate(ctx, wf, "step-1", &StepGateRequest{
+		StepType:           StepTypeToolCall,
+		IncludePriorOutput: true,
+	}, "tenant-1", "org-1", "user-1", "client-1")
+	if err != nil {
+		t.Fatalf("gate 2: %v", err)
+	}
+	if resp.RetryContext.PriorOutput == nil {
+		t.Fatal("PriorOutput: want populated with include_prior_output=true")
+	}
+	if got := resp.RetryContext.PriorOutput["transfer_id"]; got != "TXN-42" {
+		t.Errorf("PriorOutput[transfer_id]: want TXN-42, got %v", got)
+	}
+}
+
+// TestRetryContext_SecondGate_NoCompletion covers the "uncertain territory"
+// scenario — agent crashed between gate and complete, retries with no prior
+// /complete. Expected: prior_completion_status = gated_not_completed.
+func TestRetryContext_SecondGate_NoCompletion(t *testing.T) {
+	svc, _ := setupTestService(&fixedEvaluator{decision: GateDecisionAllow, reason: "ok"})
+	wf := createTestWorkflow(t, svc)
+	ctx := context.Background()
+
+	// Gate 1, no complete
+	if _, err := svc.StepGate(ctx, wf, "step-1", &StepGateRequest{StepType: StepTypeToolCall},
+		"tenant-1", "org-1", "user-1", "client-1"); err != nil {
+		t.Fatalf("gate 1: %v", err)
+	}
+
+	resp, err := svc.StepGate(ctx, wf, "step-1", &StepGateRequest{StepType: StepTypeToolCall},
+		"tenant-1", "org-1", "user-1", "client-1")
+	if err != nil {
+		t.Fatalf("gate 2: %v", err)
+	}
+
+	rc := resp.RetryContext
+	if rc.GateCount != 2 {
+		t.Errorf("GateCount: want 2, got %d", rc.GateCount)
+	}
+	if rc.CompletionCount != 0 {
+		t.Errorf("CompletionCount: want 0, got %d", rc.CompletionCount)
+	}
+	if rc.PriorCompletionStatus != PriorCompletionStatusGatedNotCompleted {
+		t.Errorf("PriorCompletionStatus: want gated_not_completed, got %s", rc.PriorCompletionStatus)
+	}
+	if rc.PriorOutputAvailable {
+		t.Error("PriorOutputAvailable: want false with no prior complete")
+	}
+}
+
+// TestRetryContext_LastDecision_SnapshotsPriorDecision verifies that
+// last_decision on the response reflects the decision of the PRIOR gate call
+// (not the current). Covers the reevaluate case where decision changes.
+func TestRetryContext_LastDecision_SnapshotsPriorDecision(t *testing.T) {
+	// First evaluator allows, then we swap to block for a reevaluate.
+	eval := &switchableEvaluator{current: GateDecisionAllow}
+	svc, _ := setupTestService(eval)
+	wf := createTestWorkflow(t, svc)
+	ctx := context.Background()
+
+	resp1, err := svc.StepGate(ctx, wf, "step-1", &StepGateRequest{StepType: StepTypeToolCall},
+		"tenant-1", "org-1", "user-1", "client-1")
+	if err != nil {
+		t.Fatalf("gate 1: %v", err)
+	}
+	if resp1.RetryContext.LastDecision != GateDecisionAllow {
+		t.Errorf("gate 1 first-call invariant broken: LastDecision=%s", resp1.RetryContext.LastDecision)
+	}
+
+	// Reevaluate with a different decision
+	eval.current = GateDecisionBlock
+	resp2, err := svc.StepGate(ctx, wf, "step-1", &StepGateRequest{
+		StepType:    StepTypeToolCall,
+		RetryPolicy: RetryPolicyReevaluate,
+	}, "tenant-1", "org-1", "user-1", "client-1")
+	if err != nil {
+		t.Fatalf("gate 2 (reevaluate): %v", err)
+	}
+	if resp2.Decision != GateDecisionBlock {
+		t.Errorf("gate 2 decision: want block (reevaluated), got %s", resp2.Decision)
+	}
+	if resp2.RetryContext.LastDecision != GateDecisionAllow {
+		t.Errorf("gate 2 LastDecision: want allow (prior), got %s", resp2.RetryContext.LastDecision)
+	}
+
+	// Cached retry after the block: LastDecision becomes block (most recent
+	// decision becomes the "prior" for the next call).
+	resp3, err := svc.StepGate(ctx, wf, "step-1", &StepGateRequest{StepType: StepTypeToolCall},
+		"tenant-1", "org-1", "user-1", "client-1")
+	if err != nil {
+		t.Fatalf("gate 3: %v", err)
+	}
+	if resp3.RetryContext.LastDecision != GateDecisionBlock {
+		t.Errorf("gate 3 LastDecision: want block (prior cached call), got %s", resp3.RetryContext.LastDecision)
+	}
+}
+
+// TestRetryContext_GateCount_BumpsOnCachedRetries verifies that even the cached
+// path bumps gate_count — otherwise a busy retry loop would appear static.
+func TestRetryContext_GateCount_BumpsOnCachedRetries(t *testing.T) {
+	svc, _ := setupTestService(&fixedEvaluator{decision: GateDecisionAllow, reason: "ok"})
+	wf := createTestWorkflow(t, svc)
+	ctx := context.Background()
+
+	for i := 1; i <= 5; i++ {
+		resp, err := svc.StepGate(ctx, wf, "step-1", &StepGateRequest{StepType: StepTypeToolCall},
+			"tenant-1", "org-1", "user-1", "client-1")
+		if err != nil {
+			t.Fatalf("gate %d: %v", i, err)
+		}
+		if resp.RetryContext.GateCount != i {
+			t.Errorf("gate %d: GateCount want %d, got %d", i, i, resp.RetryContext.GateCount)
+		}
+		if i > 1 && !resp.Cached {
+			t.Errorf("gate %d: should be cached", i)
+		}
+	}
+}
+
+// TestRetryContext_CachedDeprecatedFieldsPreserved ensures the deprecated
+// cached/decision_source fields still populate on every response, so existing
+// SDK clients continue to work during the deprecation window.
+func TestRetryContext_CachedDeprecatedFieldsPreserved(t *testing.T) {
+	svc, _ := setupTestService(&fixedEvaluator{decision: GateDecisionAllow, reason: "ok"})
+	wf := createTestWorkflow(t, svc)
+	ctx := context.Background()
+
+	resp1, err := svc.StepGate(ctx, wf, "step-1", &StepGateRequest{StepType: StepTypeToolCall},
+		"tenant-1", "org-1", "user-1", "client-1")
+	if err != nil {
+		t.Fatalf("gate 1: %v", err)
+	}
+	if resp1.Cached || resp1.DecisionSource != "fresh" {
+		t.Errorf("gate 1: want cached=false decision_source=fresh, got cached=%v source=%s",
+			resp1.Cached, resp1.DecisionSource)
+	}
+
+	resp2, err := svc.StepGate(ctx, wf, "step-1", &StepGateRequest{StepType: StepTypeToolCall},
+		"tenant-1", "org-1", "user-1", "client-1")
+	if err != nil {
+		t.Fatalf("gate 2: %v", err)
+	}
+	if !resp2.Cached || resp2.DecisionSource != "cached" {
+		t.Errorf("gate 2: want cached=true decision_source=cached, got cached=%v source=%s",
+			resp2.Cached, resp2.DecisionSource)
+	}
+}
+
+// TestRetryContext_EmptyIdempotencyKey_EmitsAsEmptyString is a shape lock
+// for the case the caller did not supply an idempotency_key. Per contract
+// §3 the field is always in the schema — emitted as empty string `""`,
+// never omitted and never null. If the JSON tag on RetryContext.IdempotencyKey
+// silently gains an `omitempty`, SDK deserializers that treat the field as
+// required will break; this test catches that.
+func TestRetryContext_EmptyIdempotencyKey_EmitsAsEmptyString(t *testing.T) {
+	rc := RetryContext{
+		GateCount:             1,
+		CompletionCount:       0,
+		PriorCompletionStatus: PriorCompletionStatusNone,
+		FirstAttemptAt:        time.Unix(0, 0).UTC(),
+		LastAttemptAt:         time.Unix(0, 0).UTC(),
+		LastDecision:          GateDecisionAllow,
+		IdempotencyKey:        "",
+	}
+	data, err := json.Marshal(rc)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	v, ok := decoded["idempotency_key"]
+	if !ok {
+		t.Fatalf("idempotency_key must be present even when empty; raw JSON: %s", string(data))
+	}
+	if v != "" {
+		t.Errorf("idempotency_key: want empty string, got %v", v)
+	}
+}
+
+// TestAPIError_EmptyKeys_EmitAsEmptyString mirrors the shape lock for the
+// 409 envelope. Contract §5 says expected/received keys "will be the empty
+// string" when one side is absent; both fields must emit as "" not be
+// omitted, so SDK typed errors can always render them side-by-side.
+func TestAPIError_EmptyKeys_EmitAsEmptyString(t *testing.T) {
+	envelope := APIErrorResponse{
+		Error: APIError{
+			Code:    ErrorCodeIdempotencyKeyMismatch,
+			Message: "idempotency_key does not match",
+			Details: APIErrorDetails{
+				WorkflowID:             "wf_1",
+				StepID:                 "step-1",
+				ExpectedIdempotencyKey: "", // gate had no key, complete did
+				ReceivedIdempotencyKey: "K-received",
+			},
+		},
+	}
+	data, err := json.Marshal(envelope)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	details := decoded["error"].(map[string]interface{})["details"].(map[string]interface{})
+	if _, ok := details["expected_idempotency_key"]; !ok {
+		t.Errorf("expected_idempotency_key must be present when empty; raw JSON: %s", string(data))
+	}
+	if details["expected_idempotency_key"] != "" {
+		t.Errorf("expected_idempotency_key: want empty string, got %v", details["expected_idempotency_key"])
+	}
+	if details["received_idempotency_key"] != "K-received" {
+		t.Errorf("received_idempotency_key round-trip: want K-received, got %v", details["received_idempotency_key"])
+	}
+}
+
+// TestRetryContext_MarshalsToJSONShape is a shape lock — the JSON produced by
+// Encode must match the wire contract in technical-docs/WCP_RETRY_IDEMPOTENCY_WIRE_CONTRACT.md §3.
+// If this test breaks, an SDK's deserializer will also break.
+func TestRetryContext_MarshalsToJSONShape(t *testing.T) {
+	k := "payment:wire:invoice-77"
+	now := time.Date(2026, 4, 21, 15, 30, 45, 0, time.UTC)
+	done := now.Add(5 * time.Second)
+	rc := RetryContext{
+		GateCount:             2,
+		CompletionCount:       1,
+		PriorCompletionStatus: PriorCompletionStatusCompleted,
+		PriorOutputAvailable:  true,
+		PriorOutput:           nil, // opt-in, still in schema as null
+		PriorCompletionAt:     &done,
+		FirstAttemptAt:        now,
+		LastAttemptAt:         now.Add(10 * time.Second),
+		LastDecision:          GateDecisionAllow,
+		IdempotencyKey:        k,
+	}
+
+	data, err := json.Marshal(rc)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	// Every field must be present (no omitempty on the contract surface —
+	// idempotency_key is the exception because it's optional per §3).
+	for _, field := range []string{
+		"gate_count", "completion_count", "prior_completion_status",
+		"prior_output_available", "prior_output", "prior_completion_at",
+		"first_attempt_at", "last_attempt_at", "last_decision",
+	} {
+		if _, ok := decoded[field]; !ok {
+			t.Errorf("missing required field %q in retry_context JSON", field)
+		}
+	}
+	if decoded["prior_output"] != nil {
+		t.Error("prior_output must marshal as null when nil, not omitted")
+	}
+	if decoded["gate_count"].(float64) != 2 {
+		t.Errorf("gate_count round-trip: want 2, got %v", decoded["gate_count"])
+	}
+	if decoded["idempotency_key"] != k {
+		t.Errorf("idempotency_key: want %q, got %v", k, decoded["idempotency_key"])
+	}
+}
+
+// --- Phase 2: idempotency_key validation ---
+
+// TestIdempotencyKey_GateRoundTrip verifies that the key provided on the first
+// gate is echoed on subsequent gate retry_contexts and passes to /complete.
+func TestIdempotencyKey_GateRoundTrip(t *testing.T) {
+	svc, _ := setupTestService(&fixedEvaluator{decision: GateDecisionAllow, reason: "ok"})
+	wf := createTestWorkflow(t, svc)
+	ctx := context.Background()
+
+	key := "payment:wire:invoice-1"
+	resp1, err := svc.StepGate(ctx, wf, "step-1", &StepGateRequest{
+		StepType:       StepTypeToolCall,
+		IdempotencyKey: key,
+	}, "tenant-1", "org-1", "user-1", "client-1")
+	if err != nil {
+		t.Fatalf("gate 1: %v", err)
+	}
+	if resp1.RetryContext.IdempotencyKey != key {
+		t.Errorf("gate 1 retry_context.idempotency_key: want %q, got %q", key, resp1.RetryContext.IdempotencyKey)
+	}
+
+	// Gate 2 with same key → OK and echoed
+	resp2, err := svc.StepGate(ctx, wf, "step-1", &StepGateRequest{
+		StepType:       StepTypeToolCall,
+		IdempotencyKey: key,
+	}, "tenant-1", "org-1", "user-1", "client-1")
+	if err != nil {
+		t.Fatalf("gate 2 same key: %v", err)
+	}
+	if resp2.RetryContext.IdempotencyKey != key {
+		t.Errorf("gate 2 retry_context.idempotency_key: want %q, got %q", key, resp2.RetryContext.IdempotencyKey)
+	}
+
+	// Complete with matching key → OK
+	if err := svc.MarkStepCompleted(ctx, wf, "step-1", &StepCompleteRequest{
+		IdempotencyKey: key,
+	}, "tenant-1", "org-1"); err != nil {
+		t.Errorf("complete with matching key should succeed: %v", err)
+	}
+}
+
+// TestIdempotencyKey_StrictMismatch covers every row of contract §5's rules.
+func TestIdempotencyKey_StrictMismatch(t *testing.T) {
+	type scenario struct {
+		name              string
+		gateKey           string
+		secondActionKey   string
+		secondIsComplete  bool // true: /complete; false: /gate
+		wantMismatchError bool
+	}
+	tests := []scenario{
+		{"gate-K1,complete-K1", "K1", "K1", true, false},
+		{"gate-K1,complete-K2", "K1", "K2", true, true},
+		{"gate-K1,complete-no-key", "K1", "", true, true},
+		{"gate-no-key,complete-K1", "", "K1", true, true},
+		{"gate-no-key,complete-no-key", "", "", true, false},
+		{"gate-K1,gate-K1", "K1", "K1", false, false},
+		{"gate-K1,gate-K2", "K1", "K2", false, true},
+		{"gate-K1,gate-no-key", "K1", "", false, true},
+		{"gate-no-key,gate-K1", "", "K1", false, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			svc, _ := setupTestService(&fixedEvaluator{decision: GateDecisionAllow, reason: "ok"})
+			wf := createTestWorkflow(t, svc)
+			ctx := context.Background()
+
+			if _, err := svc.StepGate(ctx, wf, "step-1", &StepGateRequest{
+				StepType:       StepTypeToolCall,
+				IdempotencyKey: tc.gateKey,
+			}, "tenant-1", "org-1", "user-1", "client-1"); err != nil {
+				t.Fatalf("initial gate: %v", err)
+			}
+
+			var err error
+			if tc.secondIsComplete {
+				err = svc.MarkStepCompleted(ctx, wf, "step-1", &StepCompleteRequest{
+					IdempotencyKey: tc.secondActionKey,
+				}, "tenant-1", "org-1")
+			} else {
+				_, err = svc.StepGate(ctx, wf, "step-1", &StepGateRequest{
+					StepType:       StepTypeToolCall,
+					IdempotencyKey: tc.secondActionKey,
+				}, "tenant-1", "org-1", "user-1", "client-1")
+			}
+
+			var mismatchErr *IdempotencyKeyMismatchError
+			gotMismatch := errors.As(err, &mismatchErr)
+			if gotMismatch != tc.wantMismatchError {
+				t.Errorf("want mismatch=%v, got err=%v", tc.wantMismatchError, err)
+			}
+			if gotMismatch {
+				if mismatchErr.ExpectedKey != tc.gateKey {
+					t.Errorf("ExpectedKey: want %q, got %q", tc.gateKey, mismatchErr.ExpectedKey)
+				}
+				if mismatchErr.ReceivedKey != tc.secondActionKey {
+					t.Errorf("ReceivedKey: want %q, got %q", tc.secondActionKey, mismatchErr.ReceivedKey)
+				}
+			}
+		})
+	}
+}
+
+// TestIdempotencyKey_AuditTrail verifies the key lands on both step_gate and
+// step_completed audit entries (contract §4 last bullet).
+func TestIdempotencyKey_AuditTrail(t *testing.T) {
+	svc, _ := setupTestService(&fixedEvaluator{decision: GateDecisionAllow, reason: "ok"})
+	wf := createTestWorkflow(t, svc)
+	ctx := context.Background()
+
+	capture := &captureAuditLogger{}
+	svc.SetAuditLogger(capture)
+
+	key := "payment:wire:audit-1"
+	if _, err := svc.StepGate(ctx, wf, "step-1", &StepGateRequest{
+		StepType:       StepTypeToolCall,
+		IdempotencyKey: key,
+	}, "tenant-1", "org-1", "user-1", "client-1"); err != nil {
+		t.Fatalf("gate: %v", err)
+	}
+	if err := svc.MarkStepCompleted(ctx, wf, "step-1", &StepCompleteRequest{
+		IdempotencyKey: key,
+	}, "tenant-1", "org-1"); err != nil {
+		t.Fatalf("complete: %v", err)
+	}
+
+	var gateEntry, completeEntry *WorkflowAuditEntry
+	for i, e := range capture.entries {
+		switch e.Operation {
+		case "step_gate":
+			gateEntry = capture.entries[i]
+		case "step_completed":
+			completeEntry = capture.entries[i]
+		}
+	}
+	if gateEntry == nil {
+		t.Fatal("no step_gate audit entry captured")
+	}
+	if got := gateEntry.Metadata["idempotency_key"]; got != key {
+		t.Errorf("step_gate audit metadata idempotency_key: want %q, got %v", key, got)
+	}
+	if completeEntry == nil {
+		t.Fatal("no step_completed audit entry captured")
+	}
+	if got := completeEntry.Metadata["idempotency_key"]; got != key {
+		t.Errorf("step_completed audit metadata idempotency_key: want %q, got %v", key, got)
+	}
+}
+
+// --- Policy-semantics ---
+
+// TestApplyRetryContextToGate_Semantics covers every branch of the helper
+// that feeds the policy evaluator's retry-aware context. On the fresh path
+// the policy engine sees values BEFORE the upcoming DB write — verify
+// projected counter semantics.
+func TestApplyRetryContextToGate_Semantics(t *testing.T) {
+	t.Run("no existing step → first-call projections", func(t *testing.T) {
+		var gate StepGateContext
+		applyRetryContextToGate(&gate, nil, "")
+		if gate.GateCount != 1 {
+			t.Errorf("GateCount: want 1, got %d", gate.GateCount)
+		}
+		if gate.CompletionCount != 0 {
+			t.Errorf("CompletionCount: want 0, got %d", gate.CompletionCount)
+		}
+		if gate.PriorCompletionStatus != PriorCompletionStatusNone {
+			t.Errorf("PriorCompletionStatus: want none, got %s", gate.PriorCompletionStatus)
+		}
+		if gate.LastDecision != "" {
+			t.Errorf("LastDecision on first call should be empty for policy semantics, got %s", gate.LastDecision)
+		}
+		if gate.FirstAttemptAgeSeconds != 0 {
+			t.Errorf("FirstAttemptAgeSeconds: want 0, got %d", gate.FirstAttemptAgeSeconds)
+		}
+	})
+
+	t.Run("existing with complete → status=completed, last=prior decision", func(t *testing.T) {
+		first := time.Now().Add(-30 * time.Second)
+		existing := &WorkflowStep{
+			GateCount:       1,
+			CompletionCount: 1,
+			Decision:        GateDecisionAllow,
+			FirstAttemptAt:  &first,
+		}
+		var gate StepGateContext
+		applyRetryContextToGate(&gate, existing, "")
+		if gate.GateCount != 2 {
+			t.Errorf("GateCount: want 2, got %d", gate.GateCount)
+		}
+		if gate.PriorCompletionStatus != PriorCompletionStatusCompleted {
+			t.Errorf("PriorCompletionStatus: want completed, got %s", gate.PriorCompletionStatus)
+		}
+		if gate.LastDecision != GateDecisionAllow {
+			t.Errorf("LastDecision: want allow, got %s", gate.LastDecision)
+		}
+		if gate.FirstAttemptAgeSeconds < 20 {
+			t.Errorf("FirstAttemptAgeSeconds: want ~30, got %d", gate.FirstAttemptAgeSeconds)
+		}
+	})
+
+	t.Run("existing without complete → status=gated_not_completed", func(t *testing.T) {
+		first := time.Now().Add(-5 * time.Second)
+		existing := &WorkflowStep{
+			GateCount:      1,
+			Decision:       GateDecisionAllow,
+			FirstAttemptAt: &first,
+		}
+		var gate StepGateContext
+		applyRetryContextToGate(&gate, existing, "")
+		if gate.PriorCompletionStatus != PriorCompletionStatusGatedNotCompleted {
+			t.Errorf("PriorCompletionStatus: want gated_not_completed, got %s", gate.PriorCompletionStatus)
+		}
+	})
+
+	t.Run("existing key takes precedence over supplied", func(t *testing.T) {
+		stored := "K-original"
+		existing := &WorkflowStep{
+			GateCount:      1,
+			IdempotencyKey: &stored,
+			Decision:       GateDecisionAllow,
+		}
+		var gate StepGateContext
+		applyRetryContextToGate(&gate, existing, "K-new")
+		if gate.IdempotencyKey != stored {
+			t.Errorf("IdempotencyKey should prefer stored: want %q, got %q", stored, gate.IdempotencyKey)
+		}
+	})
+}
+
+// TestBuildRetryContext_PriorCompletionStatus_AllBranches exercises every
+// branch of the enum derivation in buildRetryContext, matching
+// applyRetryContextToGate's semantics.
+func TestBuildRetryContext_PriorCompletionStatus_AllBranches(t *testing.T) {
+	tests := []struct {
+		name         string
+		gateCount    int
+		completeCnt  int
+		want         PriorCompletionStatus
+		wantAvail    bool
+	}{
+		{"first call", 1, 0, PriorCompletionStatusNone, false},
+		{"retry post-complete", 2, 1, PriorCompletionStatusCompleted, true},
+		{"retry with no complete", 2, 0, PriorCompletionStatusGatedNotCompleted, false},
+		{"many retries post-complete", 7, 1, PriorCompletionStatusCompleted, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			step := &WorkflowStep{
+				GateCount:       tc.gateCount,
+				CompletionCount: tc.completeCnt,
+				Decision:        GateDecisionAllow,
+			}
+			rc := buildRetryContext(step, false)
+			if rc.PriorCompletionStatus != tc.want {
+				t.Errorf("PriorCompletionStatus: want %s, got %s", tc.want, rc.PriorCompletionStatus)
+			}
+			if rc.PriorOutputAvailable != tc.wantAvail {
+				t.Errorf("PriorOutputAvailable: want %v, got %v", tc.wantAvail, rc.PriorOutputAvailable)
+			}
+		})
+	}
+}
+
+// --- Test helpers ---
+
+// switchableEvaluator returns whatever decision `current` is set to at call
+// time; used to simulate policy decisions that change between gate calls.
+type switchableEvaluator struct {
+	current GateDecision
+}
+
+func (e *switchableEvaluator) EvaluateStepGate(ctx context.Context, step *StepGateContext) *StepGateEvaluation {
+	return &StepGateEvaluation{
+		Decision: e.current,
+		Reason:   fmt.Sprintf("switchable:%s", e.current),
+		PolicyIDs: []string{"switchable-policy"},
+		PoliciesEvaluated: []PolicyMatch{{
+			PolicyID: "switchable-policy", PolicyName: "Switchable", Action: string(e.current),
+		}},
+	}
+}
+
+// captureAuditLogger accumulates every WorkflowAuditEntry so tests can assert
+// on metadata (e.g. idempotency_key recorded on step_gate + step_completed).
+type captureAuditLogger struct {
+	entries []*WorkflowAuditEntry
+}
+
+func (c *captureAuditLogger) LogWorkflowOperation(ctx context.Context, entry *WorkflowAuditEntry) {
+	cp := *entry
+	c.entries = append(c.entries, &cp)
+}

--- a/platform/orchestrator/workflow_control/service.go
+++ b/platform/orchestrator/workflow_control/service.go
@@ -40,6 +40,29 @@ type StepGateContext struct {
 	UserID       string
 	ClientID     string
 	ToolContext  *ToolContext
+
+	// Retry-aware policy fields (Issue #1673 Phase 1).
+	// Populated by the service layer from the existing workflow_steps row
+	// BEFORE policy evaluation runs, so policies can condition on retry state.
+	// Semantics match response retry_context with one exception: LastDecision
+	// here is empty on first call (no prior decision to report) rather than
+	// equal to the current decision — policies need "was there a prior?" not
+	// response's first-call invariant.
+	//
+	//   - GateCount: projected post-bump (1 on first call, existing+1 on retry)
+	//   - CompletionCount: existing.CompletionCount (0 if no prior /complete)
+	//   - PriorCompletionStatus: derived from counters
+	//   - PriorOutputAvailable: CompletionCount >= 1
+	//   - LastDecision: existing.Decision (empty string on first call)
+	//   - FirstAttemptAgeSeconds: now - first_attempt_at (0 on first call)
+	//   - IdempotencyKey: effective key (existing's, else caller-supplied)
+	GateCount              int
+	CompletionCount        int
+	PriorCompletionStatus  PriorCompletionStatus
+	PriorOutputAvailable   bool
+	LastDecision           GateDecision
+	FirstAttemptAgeSeconds int
+	IdempotencyKey         string
 }
 
 // StepGateEvaluation is the result of policy evaluation
@@ -315,6 +338,164 @@ func workflowBelongsTo(workflow *Workflow, tenantID, orgID string) bool {
 	return true
 }
 
+// buildRetryContext computes the retry_context response block from a persisted
+// step row (Issue #1673 Phase 1). The step argument must reflect post-write
+// state — i.e. after AddStep or BumpGateCountCached has run — so counters,
+// timestamps, and last_decision are fresh.
+//
+// includePriorOutput controls whether prior_output is populated. Even when
+// true, prior_output is only populated if a prior /complete actually landed
+// (PriorCompletionStatus == completed). Otherwise nil, which JSON-marshals as
+// null — matching the contract at technical-docs/WCP_RETRY_IDEMPOTENCY_WIRE_CONTRACT.md §3.
+func buildRetryContext(step *WorkflowStep, includePriorOutput bool) RetryContext {
+	// Derive prior_completion_status from counter state.
+	// After any successful AddStep or BumpGateCountCached, GateCount >= 1.
+	// On a first-call fresh INSERT, GateCount == 1 and CompletionCount == 0,
+	// which we map to "none" because there were no *prior* gate calls before
+	// this one.
+	var priorStatus PriorCompletionStatus
+	switch {
+	case step.GateCount <= 1:
+		priorStatus = PriorCompletionStatusNone
+	case step.CompletionCount >= 1:
+		priorStatus = PriorCompletionStatusCompleted
+	default:
+		priorStatus = PriorCompletionStatusGatedNotCompleted
+	}
+
+	// Always present fields
+	rc := RetryContext{
+		GateCount:             step.GateCount,
+		CompletionCount:       step.CompletionCount,
+		PriorCompletionStatus: priorStatus,
+		PriorOutputAvailable:  priorStatus == PriorCompletionStatusCompleted,
+		PriorOutput:           nil,
+		PriorCompletionAt:     step.StepCompletedAt,
+		LastAttemptAt:         step.GateCheckedAt,
+		LastDecision:          step.LastDecision,
+	}
+	if step.FirstAttemptAt != nil {
+		rc.FirstAttemptAt = *step.FirstAttemptAt
+	} else {
+		// Backstop: if somehow the column is null (shouldn't happen post-migration),
+		// fall back to gate_checked_at so the field is always populated.
+		rc.FirstAttemptAt = step.GateCheckedAt
+	}
+	if step.IdempotencyKey != nil {
+		rc.IdempotencyKey = *step.IdempotencyKey
+	}
+	// Opt-in prior_output inclusion (contract §3): only populate if caller
+	// asked AND a completed prior exists.
+	if includePriorOutput && rc.PriorOutputAvailable && step.StepOutput != nil {
+		var out map[string]interface{}
+		if err := json.Unmarshal(step.StepOutput, &out); err == nil {
+			rc.PriorOutput = out
+		}
+	}
+	return rc
+}
+
+// applyRetryContextToGate populates the retry-context fields on a
+// StepGateContext from the existing workflow_steps row (may be nil) so policy
+// conditions see projected post-bump state at evaluation time. Called on the
+// fresh-eval path only — the cached path never runs policy.
+//
+// "Projected" means: the values reflect what the row will look like after the
+// upcoming AddStep bumps the counters, so a policy condition like
+// `step.gate_count > 1` correctly matches on the second gate call, not the
+// third.
+func applyRetryContextToGate(gateCtx *StepGateContext, existing *WorkflowStep, suppliedKey string) {
+	if existing == nil {
+		// First call — counters start at 1 (this call) / 0 (no prior complete),
+		// prior_completion_status is "none", last_decision is empty (policy
+		// semantics: "no prior decision to report"), age is 0.
+		gateCtx.GateCount = 1
+		gateCtx.CompletionCount = 0
+		gateCtx.PriorCompletionStatus = PriorCompletionStatusNone
+		gateCtx.PriorOutputAvailable = false
+		gateCtx.LastDecision = ""
+		gateCtx.FirstAttemptAgeSeconds = 0
+		gateCtx.IdempotencyKey = suppliedKey
+		return
+	}
+	gateCtx.GateCount = existing.GateCount + 1
+	gateCtx.CompletionCount = existing.CompletionCount
+	// Mirror buildRetryContext's derivation for consistency.
+	switch {
+	case gateCtx.GateCount <= 1:
+		gateCtx.PriorCompletionStatus = PriorCompletionStatusNone
+	case gateCtx.CompletionCount >= 1:
+		gateCtx.PriorCompletionStatus = PriorCompletionStatusCompleted
+	default:
+		gateCtx.PriorCompletionStatus = PriorCompletionStatusGatedNotCompleted
+	}
+	gateCtx.PriorOutputAvailable = gateCtx.CompletionCount >= 1
+	gateCtx.LastDecision = existing.Decision
+	if existing.FirstAttemptAt != nil {
+		age := time.Since(*existing.FirstAttemptAt)
+		if age < 0 {
+			age = 0
+		}
+		gateCtx.FirstAttemptAgeSeconds = int(age.Seconds())
+	}
+	// Effective key: caller-supplied value wins if existing has none
+	// (COALESCE semantics at the repo level — immutability enforced by the
+	// repo's UPSERT on subsequent writes).
+	if existing.IdempotencyKey != nil && *existing.IdempotencyKey != "" {
+		gateCtx.IdempotencyKey = *existing.IdempotencyKey
+	} else {
+		gateCtx.IdempotencyKey = suppliedKey
+	}
+}
+
+// IdempotencyKeyMismatchError is returned by the service when a /gate or
+// /complete request supplies an idempotency_key that does not match the key
+// recorded on the step's earlier /gate call (Issue #1673 Phase 2). Handler
+// layer maps this to HTTP 409 with APIError.Code == ErrorCodeIdempotencyKeyMismatch.
+type IdempotencyKeyMismatchError struct {
+	WorkflowID  string
+	StepID      string
+	ExpectedKey string // "" if the step had no prior key
+	ReceivedKey string // "" if the caller didn't supply one
+}
+
+func (e *IdempotencyKeyMismatchError) Error() string {
+	return fmt.Sprintf("idempotency_key mismatch on %s/%s: expected %q, received %q",
+		e.WorkflowID, e.StepID, e.ExpectedKey, e.ReceivedKey)
+}
+
+// validateIdempotencyKeyMatch implements the strict rules in technical-docs/
+// WCP_RETRY_IDEMPOTENCY_WIRE_CONTRACT.md §5. existing is the row loaded via
+// GetStepDecision (may be nil = no prior gate). suppliedKey is the key the
+// caller passed on this /gate or /complete (empty string = omitted).
+//
+// Returns a non-nil *IdempotencyKeyMismatchError when the strict rules would
+// reject, nil otherwise. No existing row ⇒ always OK (first gate call).
+func validateIdempotencyKeyMatch(existing *WorkflowStep, suppliedKey, workflowID, stepID string) error {
+	if existing == nil {
+		return nil
+	}
+	var storedKey string
+	if existing.IdempotencyKey != nil {
+		storedKey = *existing.IdempotencyKey
+	}
+	// Both absent → match.
+	if storedKey == "" && suppliedKey == "" {
+		return nil
+	}
+	// Both present and equal → match.
+	if storedKey != "" && storedKey == suppliedKey {
+		return nil
+	}
+	// Any other combination: mismatch (prior had, now absent; prior absent, now has; different values).
+	return &IdempotencyKeyMismatchError{
+		WorkflowID:  workflowID,
+		StepID:      stepID,
+		ExpectedKey: storedKey,
+		ReceivedKey: suppliedKey,
+	}
+}
+
 // buildCachedResponse constructs a StepGateResponse from a previously persisted step decision.
 // This supports idempotent retry semantics (#1414): same (workflow_id, step_id) returns the
 // same decision without re-running the policy evaluator.
@@ -322,7 +503,11 @@ func workflowBelongsTo(workflow *Workflow, tenantID, orgID string) bool {
 // Special case: if the original decision was require_approval but the step has since been
 // approved, we return "allow" — the approval resolved the gate and the step can proceed.
 // If rejected, we return "block" since the workflow was aborted.
-func buildCachedResponse(step *WorkflowStep, workflowID, baseURL string) *StepGateResponse {
+//
+// step must be the post-bump row (after BumpGateCountCached) so retry_context
+// reflects the just-bumped counters. includePriorOutput is the caller's opt-in
+// query param for Issue #1673 Phase 1.
+func buildCachedResponse(step *WorkflowStep, workflowID, baseURL string, includePriorOutput bool) *StepGateResponse {
 	decision := step.Decision
 	reason := step.DecisionReason
 
@@ -363,6 +548,7 @@ func buildCachedResponse(step *WorkflowStep, workflowID, baseURL string) *StepGa
 		PoliciesMatched:   policiesMatched,
 		Cached:            true,
 		DecisionSource:    "cached",
+		RetryContext:      buildRetryContext(step, includePriorOutput),
 	}
 
 	// Include approval URL for pending require_approval decisions
@@ -406,19 +592,36 @@ func (s *Service) StepGate(ctx context.Context, workflowID string, stepID string
 		retryPolicy = RetryPolicyIdempotent
 	}
 
+	// Always load existing step row up front (Issue #1673) so we can:
+	//   1. Validate idempotency_key match before doing any work.
+	//   2. Decide whether this is a first-call fresh eval or a retry.
+	// Legacy behavior under retry_policy=idempotent called GetStepDecision
+	// conditionally; with first-class retry_context we need the row anyway.
+	existing, err := s.repo.GetStepDecision(ctx, workflowID, stepID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check cached decision: %w", err)
+	}
+
+	// Phase 2: idempotency_key validation. Strict rules per contract §5 —
+	// supplied key must equal stored key (or both be absent). Handler maps
+	// *IdempotencyKeyMismatchError to HTTP 409.
+	if err := validateIdempotencyKeyMatch(existing, req.IdempotencyKey, workflowID, stepID); err != nil {
+		return nil, err
+	}
+
 	// Idempotent cache lookup: return prior decision if step was already evaluated.
 	// This MUST run before the pending-approval guard so that retrying the same
 	// step that has a pending approval returns the cached require_approval decision
 	// instead of an error. GateOverride (MAP confirm/step modes) bypasses the cache
 	// because those modes have their own evaluator-level caching via sync.Map.
-	if retryPolicy == RetryPolicyIdempotent && req.GateOverride == nil {
-		cached, err := s.repo.GetStepDecision(ctx, workflowID, stepID)
-		if err != nil {
-			return nil, fmt.Errorf("failed to check cached decision: %w", err)
+	if retryPolicy == RetryPolicyIdempotent && req.GateOverride == nil && existing != nil {
+		// Bump gate_count + snapshot last_decision before returning the cached
+		// response so retry_context reflects this call (Issue #1673 Phase 1).
+		bumped, bumpErr := s.repo.BumpGateCountCached(ctx, workflowID, stepID)
+		if bumpErr != nil {
+			return nil, fmt.Errorf("failed to bump gate_count on cached retry: %w", bumpErr)
 		}
-		if cached != nil {
-			return buildCachedResponse(cached, workflowID, s.baseURL), nil
-		}
+		return buildCachedResponse(bumped, workflowID, s.baseURL, req.IncludePriorOutput), nil
 	}
 
 	// Check for pending approval on a DIFFERENT step.
@@ -459,6 +662,10 @@ func (s *Service) StepGate(ctx context.Context, workflowID string, stepID string
 		ClientID:     clientID,
 		ToolContext:  req.ToolContext,
 	}
+	// Issue #1673 Phase 1: populate retry-context fields on the gate context
+	// so policy conditions like step.gate_count > 1 work correctly on the
+	// FRESH-eval path (including retry_policy=reevaluate and first-call).
+	applyRetryContextToGate(gateCtx, existing, req.IdempotencyKey)
 
 	// Evaluate policies (or use override for MAP confirm/step modes)
 	var evaluation *StepGateEvaluation
@@ -484,7 +691,15 @@ func (s *Service) StepGate(ctx context.Context, workflowID string, stepID string
 		approvalStatus = &pending
 	}
 
-	// Record the step decision
+	// Record the step decision. AddStep atomically bumps gate_count and
+	// snapshots last_decision (Issue #1673), returning the post-write counter
+	// state via its RETURNING clause so we can populate retry_context without
+	// a follow-up read.
+	var idempotencyKeyPtr *string
+	if req.IdempotencyKey != "" {
+		k := req.IdempotencyKey
+		idempotencyKeyPtr = &k
+	}
 	step := &WorkflowStep{
 		WorkflowID:        workflowID,
 		StepID:            stepID,
@@ -502,6 +717,7 @@ func (s *Service) StepGate(ctx context.Context, workflowID string, stepID string
 		TokensIn:          req.TokensIn,
 		TokensOut:         req.TokensOut,
 		CostUSD:           req.CostUSD,
+		IdempotencyKey:    idempotencyKeyPtr,
 	}
 
 	if err := s.repo.AddStep(ctx, step); err != nil {
@@ -521,7 +737,7 @@ func (s *Service) StepGate(ctx context.Context, workflowID string, stepID string
 		s.logger.Printf("[WorkflowControl] Concurrent race detected: workflow=%s step=%s evaluated=%s persisted=%s (returning persisted)",
 			logutil.Sanitize(workflowID), logutil.Sanitize(stepID),
 			logutil.Sanitize(string(evaluation.Decision)), logutil.Sanitize(string(persisted.Decision)))
-		return buildCachedResponse(persisted, workflowID, s.baseURL), nil
+		return buildCachedResponse(persisted, workflowID, s.baseURL, req.IncludePriorOutput), nil
 	}
 
 	// Create step-gate checkpoint for safe resume.
@@ -561,7 +777,20 @@ func (s *Service) StepGate(ctx context.Context, workflowID string, stepID string
 			workflowID, stepID, cpErr)
 	}
 
-	// Build response (Issue #1021: Include policy info in response)
+	// Build response (Issue #1021: Include policy info in response;
+	// Issue #1673 Phase 1: include retry_context from post-write state).
+	//
+	// Prefer `persisted` over `step` for retry_context so counters reflect
+	// the actual DB state under concurrent-race conditions. `persisted` is
+	// loaded after AddStep via GetStepDecision (above) and will include any
+	// counter increments that landed from a racing call. In the common
+	// non-race case `persisted` and `step` are equivalent. Falls back to
+	// `step` defensively if `persisted` is nil (shouldn't happen — we just
+	// wrote the row — but guards against transient read failure).
+	rcStep := step
+	if persisted != nil {
+		rcStep = persisted
+	}
 	response := &StepGateResponse{
 		Decision:          evaluation.Decision,
 		StepID:            stepID,
@@ -573,6 +802,7 @@ func (s *Service) StepGate(ctx context.Context, workflowID string, stepID string
 		PoliciesMatched:   evaluation.PoliciesMatched,
 		Cached:            false,
 		DecisionSource:    "fresh",
+		RetryContext:      buildRetryContext(rcStep, req.IncludePriorOutput),
 	}
 
 	// Add approval URL for require_approval decisions
@@ -591,10 +821,17 @@ func (s *Service) StepGate(ctx context.Context, workflowID string, stepID string
 		"provider":           req.Provider,
 		"policies_evaluated": len(evaluation.PoliciesEvaluated),
 		"policies_matched":   len(evaluation.PoliciesMatched),
+		// Issue #1673: retry_context fields on audit trail.
+		"gate_count":      step.GateCount,
+		"completion_count": step.CompletionCount,
 	}
 	if req.ToolContext != nil {
 		auditMeta["tool_name"] = req.ToolContext.ToolName
 		auditMeta["tool_type"] = req.ToolContext.ToolType
+	}
+	// Issue #1673 Phase 2: record idempotency_key on every gate audit event.
+	if step.IdempotencyKey != nil && *step.IdempotencyKey != "" {
+		auditMeta["idempotency_key"] = *step.IdempotencyKey
 	}
 	s.logAudit(ctx, &WorkflowAuditEntry{
 		WorkflowID:   workflowID,
@@ -954,6 +1191,8 @@ func (s *Service) CountPendingApprovals(ctx context.Context, tenantID string) (i
 
 // MarkStepCompleted marks a step as completed after the external orchestrator executes it.
 // The optional req carries post-execution metrics (tokens, cost, output) from the SDK.
+// Validates idempotency_key match before writing (Issue #1673 Phase 2); mismatch returns
+// *IdempotencyKeyMismatchError which handlers map to HTTP 409.
 func (s *Service) MarkStepCompleted(ctx context.Context, workflowID, stepID string, req *StepCompleteRequest, tenantID, orgID string) error {
 	// Get workflow for audit logging and ownership check
 	workflow, err := s.repo.GetByID(ctx, workflowID)
@@ -969,6 +1208,21 @@ func (s *Service) MarkStepCompleted(ctx context.Context, workflowID, stepID stri
 		return fmt.Errorf("%s: %w", workflowID, ErrWorkflowNotFound)
 	}
 
+	// Issue #1673 Phase 2: idempotency_key validation. Strict rules per
+	// contract §5 — key on complete must match key recorded on gate, or
+	// both must be absent.
+	suppliedKey := ""
+	if req != nil {
+		suppliedKey = req.IdempotencyKey
+	}
+	existing, err := s.repo.GetStepDecision(ctx, workflowID, stepID)
+	if err != nil {
+		return fmt.Errorf("failed to load step for idempotency check: %w", err)
+	}
+	if err := validateIdempotencyKeyMatch(existing, suppliedKey, workflowID, stepID); err != nil {
+		return err
+	}
+
 	if err := s.repo.MarkStepCompleted(ctx, workflowID, stepID, req); err != nil {
 		return fmt.Errorf("failed to mark step completed: %w", err)
 	}
@@ -982,7 +1236,13 @@ func (s *Service) MarkStepCompleted(ctx context.Context, workflowID, stepID stri
 		}
 	}
 
-	// Audit log: step completed
+	// Audit log: step completed (Issue #1673 Phase 2: include idempotency_key).
+	// If we got past validateIdempotencyKeyMatch with a non-empty key, it
+	// matches the stored key by construction — we just need to record it.
+	auditMeta := map[string]interface{}{}
+	if suppliedKey != "" {
+		auditMeta["idempotency_key"] = suppliedKey
+	}
 	s.logAudit(ctx, &WorkflowAuditEntry{
 		WorkflowID:   workflowID,
 		WorkflowName: workflow.WorkflowName,
@@ -992,6 +1252,7 @@ func (s *Service) MarkStepCompleted(ctx context.Context, workflowID, stepID stri
 		TenantID:     workflow.TenantID,
 		ClientID:     workflow.ClientID,
 		UserID:       workflow.UserID,
+		Metadata:     auditMeta,
 	})
 
 	// Unified execution tracking

--- a/platform/orchestrator/workflow_control/step_gate_retry_test.go
+++ b/platform/orchestrator/workflow_control/step_gate_retry_test.go
@@ -546,7 +546,7 @@ func TestBuildCachedResponse_Allow(t *testing.T) {
 		}),
 	}
 
-	resp := buildCachedResponse(step, "wf-1", "https://portal.test")
+	resp := buildCachedResponse(step, "wf-1", "https://portal.test", false)
 
 	if resp.Decision != GateDecisionAllow {
 		t.Errorf("expected allow, got %s", resp.Decision)
@@ -579,7 +579,7 @@ func TestBuildCachedResponse_RequireApproval_Approved(t *testing.T) {
 		PoliciesMatched:   mustMarshal([]PolicyMatch{}),
 	}
 
-	resp := buildCachedResponse(step, "wf-1", "https://portal.test")
+	resp := buildCachedResponse(step, "wf-1", "https://portal.test", false)
 
 	if resp.Decision != GateDecisionAllow {
 		t.Errorf("approved step should resolve to allow, got %s", resp.Decision)
@@ -600,7 +600,7 @@ func TestBuildCachedResponse_RequireApproval_Rejected(t *testing.T) {
 		PoliciesMatched:   mustMarshal([]PolicyMatch{}),
 	}
 
-	resp := buildCachedResponse(step, "wf-1", "https://portal.test")
+	resp := buildCachedResponse(step, "wf-1", "https://portal.test", false)
 
 	if resp.Decision != GateDecisionBlock {
 		t.Errorf("rejected step should resolve to block, got %s", resp.Decision)
@@ -618,7 +618,7 @@ func TestBuildCachedResponse_RequireApproval_Pending(t *testing.T) {
 		PoliciesMatched:   mustMarshal([]PolicyMatch{}),
 	}
 
-	resp := buildCachedResponse(step, "wf-1", "https://portal.test")
+	resp := buildCachedResponse(step, "wf-1", "https://portal.test", false)
 
 	if resp.Decision != GateDecisionRequireApproval {
 		t.Errorf("pending step should stay require_approval, got %s", resp.Decision)
@@ -637,7 +637,7 @@ func TestBuildCachedResponse_Block(t *testing.T) {
 		PoliciesMatched:   mustMarshal([]PolicyMatch{}),
 	}
 
-	resp := buildCachedResponse(step, "wf-1", "https://portal.test")
+	resp := buildCachedResponse(step, "wf-1", "https://portal.test", false)
 
 	if resp.Decision != GateDecisionBlock {
 		t.Errorf("expected block, got %s", resp.Decision)

--- a/platform/orchestrator/workflow_control/types.go
+++ b/platform/orchestrator/workflow_control/types.go
@@ -52,6 +52,59 @@ const (
 	ApprovalStatusRejected ApprovalStatus = "rejected"
 )
 
+// PriorCompletionStatus describes whether a prior execution of this
+// (workflow_id, step_id) landed a /complete call. Returned inside
+// StepGateResponse.RetryContext (Issue #1673 Phase 1).
+//
+//   - PriorCompletionStatusNone               — no prior gate call on this step (first attempt)
+//   - PriorCompletionStatusCompleted          — prior /gate + prior /complete both landed
+//   - PriorCompletionStatusGatedNotCompleted  — prior /gate landed but no /complete followed (uncertain territory)
+type PriorCompletionStatus string
+
+const (
+	PriorCompletionStatusNone              PriorCompletionStatus = "none"
+	PriorCompletionStatusCompleted         PriorCompletionStatus = "completed"
+	PriorCompletionStatusGatedNotCompleted PriorCompletionStatus = "gated_not_completed"
+)
+
+// ErrorCode constants returned in the `error.code` field of structured error
+// responses. Kept stable because SDKs match on these strings to construct
+// typed exceptions.
+const (
+	// ErrorCodeIdempotencyKeyMismatch is returned with HTTP 409 when the
+	// idempotency_key on a /complete (or repeat /gate) call does not match
+	// the key recorded on the step's earlier /gate (Issue #1673 Phase 2).
+	ErrorCodeIdempotencyKeyMismatch = "IDEMPOTENCY_KEY_MISMATCH"
+)
+
+// APIErrorDetails carries structured fields for debugging / typed SDK errors.
+//
+// ExpectedIdempotencyKey and ReceivedIdempotencyKey deliberately omit
+// `omitempty` — the contract (WCP_RETRY_IDEMPOTENCY_WIRE_CONTRACT.md §5)
+// states they must be emitted even when empty ("... will be the empty
+// string ..."), so SDK typed errors always see both fields and can render
+// them side-by-side.
+type APIErrorDetails struct {
+	WorkflowID             string `json:"workflow_id,omitempty"`
+	StepID                 string `json:"step_id,omitempty"`
+	ExpectedIdempotencyKey string `json:"expected_idempotency_key"`
+	ReceivedIdempotencyKey string `json:"received_idempotency_key"`
+}
+
+// APIError is the structured error payload returned on 4xx/5xx from WCP
+// endpoints that need machine-readable detail. The contract is documented in
+// technical-docs/WCP_RETRY_IDEMPOTENCY_WIRE_CONTRACT.md §5.
+type APIError struct {
+	Code    string          `json:"code"`
+	Message string          `json:"message"`
+	Details APIErrorDetails `json:"details,omitempty"`
+}
+
+// APIErrorResponse is the wrapper envelope: {"error": {...}}.
+type APIErrorResponse struct {
+	Error APIError `json:"error"`
+}
+
 // RetryPolicy controls how step gate decisions behave on repeated calls for the
 // same (workflow_id, step_id) pair. The default is idempotent: same step, same
 // boundary, same decision — unless the caller explicitly re-opens it.
@@ -139,6 +192,22 @@ type WorkflowStep struct {
 	ApprovalComment   string          `json:"approval_comment,omitempty" db:"approval_comment"`
 	GateCheckedAt     time.Time       `json:"gate_checked_at" db:"gate_checked_at"`
 	StepCompletedAt   *time.Time      `json:"step_completed_at,omitempty" db:"step_completed_at"`
+	// GateCount is the number of /gate calls for this step (Issue #1673).
+	// Incremented atomically on every gate call.
+	GateCount int `json:"gate_count" db:"gate_count"`
+	// CompletionCount is the number of /complete calls (Issue #1673).
+	// Normally 0 or 1.
+	CompletionCount int `json:"completion_count" db:"completion_count"`
+	// LastDecision is the decision of the prior gate call (Issue #1673).
+	// On first gate call, equals Decision.
+	LastDecision GateDecision `json:"last_decision,omitempty" db:"last_decision"`
+	// IdempotencyKey is the caller-supplied business-level key, if any
+	// (Issue #1673 Phase 2). Immutable once set on a step.
+	IdempotencyKey *string `json:"idempotency_key,omitempty" db:"idempotency_key"`
+	// FirstAttemptAt is the timestamp of the first /gate call on this step
+	// (Issue #1673). Preserved across UPSERTs so retry_context.first_attempt_at
+	// can surface the original gate time even after many retries.
+	FirstAttemptAt *time.Time `json:"first_attempt_at,omitempty" db:"first_attempt_at"`
 }
 
 // PendingApprovalResponse is the shape returned by the pending approvals API.
@@ -196,9 +265,19 @@ type StepGateRequest struct {
 	// Default (empty or "idempotent"): return cached decision from DB.
 	// "reevaluate": force fresh policy evaluation regardless of prior decision.
 	RetryPolicy RetryPolicy `json:"retry_policy,omitempty"`
+	// IdempotencyKey is an optional caller-supplied opaque business-level key
+	// (Issue #1673 Phase 2). Max 255 chars. Recorded on the first /gate call
+	// that sets it; subsequent /gate and /complete calls must pass the same
+	// key or receive 409 IDEMPOTENCY_KEY_MISMATCH.
+	IdempotencyKey string `json:"idempotency_key,omitempty"`
 	// GateOverride bypasses the policy evaluator and forces a specific decision.
 	// Used by MAP confirm/step modes to enforce require_approval regardless of policies.
 	GateOverride *GateDecision `json:"-"`
+	// IncludePriorOutput is set by the handler from the ?include_prior_output
+	// query param (Issue #1673 Phase 1). When true, RetryContext.PriorOutput
+	// is populated if a prior /complete landed. Opt-in because prior output
+	// may be large and/or contain sensitive data.
+	IncludePriorOutput bool `json:"-"`
 }
 
 // StepCompleteRequest is the optional request body for marking a step as completed.
@@ -208,6 +287,70 @@ type StepCompleteRequest struct {
 	TokensIn  *int                   `json:"tokens_in,omitempty"`
 	TokensOut *int                   `json:"tokens_out,omitempty"`
 	CostUSD   *float64               `json:"cost_usd,omitempty"`
+	// IdempotencyKey must match the key recorded on the step's earlier /gate
+	// call (Issue #1673 Phase 2). Mismatch returns 409 IDEMPOTENCY_KEY_MISMATCH.
+	IdempotencyKey string `json:"idempotency_key,omitempty"`
+}
+
+// RetryContext surfaces first-class same-workflow execution state for a step
+// gate evaluation (Issue #1673 Phase 1). Returned on every StepGateResponse,
+// including the very first gate call on a step.
+//
+// Replaces the ambiguous `cached: bool` signal — which conflated "agent crashed
+// between gate and complete, now retrying" with "upstream orchestrator retried
+// the whole workflow after a clean completion" — with unambiguous execution
+// state the agent and policy engine can reason about.
+//
+// See technical-docs/WCP_RETRY_IDEMPOTENCY_WIRE_CONTRACT.md §3 for the full
+// field-by-field wire contract.
+type RetryContext struct {
+	// GateCount is the number of times /gate has been called for this
+	// (workflow_id, step_id), including the current call. First call returns 1.
+	GateCount int `json:"gate_count"`
+
+	// CompletionCount is the number of times /complete has been successfully
+	// called for this (workflow_id, step_id). Normally 0 or 1.
+	CompletionCount int `json:"completion_count"`
+
+	// PriorCompletionStatus directly answers "did a prior execution finish,
+	// or are we in uncertain territory?" without arithmetic on the counters.
+	PriorCompletionStatus PriorCompletionStatus `json:"prior_completion_status"`
+
+	// PriorOutputAvailable is true iff PriorCompletionStatus == "completed".
+	// Mirrors whether PriorOutput *could* be returned if include_prior_output
+	// was requested.
+	PriorOutputAvailable bool `json:"prior_output_available"`
+
+	// PriorOutput is always present in the schema. Populated only when the
+	// caller set ?include_prior_output=true AND PriorOutputAvailable is true.
+	// Otherwise nil (emits as `null` in JSON).
+	PriorOutput map[string]interface{} `json:"prior_output"`
+
+	// PriorCompletionAt is the timestamp of the prior /complete, if any.
+	PriorCompletionAt *time.Time `json:"prior_completion_at"`
+
+	// FirstAttemptAt is the timestamp of the first /gate call on this step.
+	// On the first call, equals LastAttemptAt.
+	FirstAttemptAt time.Time `json:"first_attempt_at"`
+
+	// LastAttemptAt is the timestamp of the current /gate call (the one that
+	// produced this response).
+	LastAttemptAt time.Time `json:"last_attempt_at"`
+
+	// LastDecision is the decision of the immediately prior /gate call.
+	// On the first call (GateCount == 1), equals the current Decision.
+	LastDecision GateDecision `json:"last_decision"`
+
+	// IdempotencyKey is the caller-supplied business-level key recorded on
+	// this step (Issue #1673 Phase 2). Empty string when the caller never
+	// supplied one. Once set on a step, it is immutable for the step's
+	// lifetime — subsequent /gate and /complete calls must pass the same key
+	// or receive 409 IDEMPOTENCY_KEY_MISMATCH.
+	//
+	// Deliberately no `omitempty` — the wire contract §3 says this field is
+	// always in the schema (empty string when not supplied) so SDK
+	// deserializers can rely on it always being present.
+	IdempotencyKey string `json:"idempotency_key"`
 }
 
 // StepGateResponse is the response for a step gate check
@@ -224,11 +367,24 @@ type StepGateResponse struct {
 	// Cached indicates whether this response was served from a prior decision
 	// rather than a fresh policy evaluation. True when retry_policy is "idempotent"
 	// (the default) and the step was previously evaluated.
+	//
+	// Deprecated: Use RetryContext.GateCount > 1 to detect retry; use
+	// RetryContext.PriorCompletionStatus to reason about prior completion.
+	// Cached remains populated for backward compatibility; removal is planned
+	// for a future major version.
 	Cached bool `json:"cached"`
 	// DecisionSource indicates how the decision was produced:
 	// "fresh" — policy evaluator ran for this request
 	// "cached" — returned from a prior evaluation stored in the database
+	//
+	// Deprecated: Use RetryContext fields instead. Kept for back-compat.
 	DecisionSource string `json:"decision_source"`
+	// RetryContext is first-class retry / execution state for this step gate
+	// call (Issue #1673 Phase 1). Always present on every response, including
+	// the first gate call (in which case GateCount == 1, PriorCompletionStatus
+	// == "none"). See RetryContext doc and
+	// technical-docs/WCP_RETRY_IDEMPOTENCY_WIRE_CONTRACT.md for the full shape.
+	RetryContext RetryContext `json:"retry_context"`
 }
 
 // WorkflowStatusResponse is the response for workflow status


### PR DESCRIPTION
## Summary

v7.3.0 adds retry-awareness and caller-supplied idempotency to the Workflow Control Plane. Purely additive — no breaking changes. Two additive migrations (071 + 072).

### Community (every tier)

- **`retry_context` on every `StepGateResponse`** — first-class retry state block present on every gate response, including the first call. Fields: `gate_count`, `completion_count`, `prior_completion_status` (enum `none` / `completed` / `gated_not_completed`), `prior_output_available`, `prior_output`, `prior_completion_at`, `first_attempt_at`, `last_attempt_at`, `last_decision`, `idempotency_key`. Replaces the ambiguous `cached: bool` flag, which stays populated for back-compat and is marked deprecated.
- **`?include_prior_output=true`** — opt-in query param on `/gate`. When the opt-in is set and a prior `/complete` landed, `retry_context.prior_output` carries the stored payload so agents can short-circuit re-execution safely.
- **`idempotency_key` on `/gate` + `/complete`** — optional caller-supplied opaque string (max 255 chars), recorded on the first gate and immutable thereafter. Strict match validation; mismatch returns `HTTP 409 IDEMPOTENCY_KEY_MISMATCH` with a structured error envelope (`workflow_id`, `step_id`, `expected_idempotency_key`, `received_idempotency_key` — always present, empty string when one side is absent).
- **Handler consistency fix** — `MarkStepCompleted` now reads tenant from `X-Tenant-ID` like `StepGate` does. A multi-tenant caller setting that header now works on both endpoints.

### Evaluation (Evaluation or Enterprise license)

- **Retry-aware dynamic policy conditions** — seven new `step.*` fields resolve against the retry state the platform already tracks: `step.gate_count`, `step.completion_count`, `step.prior_completion_status`, `step.prior_output_available`, `step.last_decision`, `step.first_attempt_age_seconds`, `step.idempotency_key`.
- **Tier-gated at every mutation path** — create, update, and bulk import all reject `step.*` conditions with `HTTP 403 FEATURE_REQUIRES_EVALUATION_LICENSE` on Community licenses. The check runs before any DB roundtrip so rejection is fast.
- **UX note for policy authors**: retry-aware policies only fire when the caller passes `retry_policy: "reevaluate"` on subsequent gate calls. The default-idempotent path hits the cache and bypasses the policy engine, consistent with existing WCP cache semantics. The bundled Evaluation-tier example asserts this boundary.

### SDK parity

All four SDKs (TypeScript, Python, Go, Java) expose the `retry_context` model and a typed `IdempotencyKeyMismatch` error class. SDK releases follow in their respective repos.

### Examples

`examples/wcp-retry-idempotency/` ships 10 hardened end-to-end validators:

- `community/{http,go,typescript,python,java}/` — exercise the primitives (counters, enum, opt-in prior output, 409 envelope).
- `evaluation/{http,go,typescript,python,java}/` — author a retry-aware policy, verify it fires on `reevaluate`.

Every example asserts actual behaviour (counter values, enum strings, error-envelope fields) and exits non-zero on mismatch. They are release-gate tests, not smoke demos.

### Schema

- Migration 071: `gate_count`, `completion_count`, `last_decision`, `first_attempt_at` columns on `workflow_steps` (additive; legacy rows backfilled).
- Migration 072: `idempotency_key` column + partial non-null index on `workflow_steps`.

### Version

Platform `7.2.1` → `7.3.0`. `validate-version-alignment.sh` clean across `docker-compose.yml`, `docker-compose.enterprise.yml`, and the agent + orchestrator Dockerfiles.

### Drive-by

`docker-compose.yml` made `ORG_ID` overridable via env (`${ORG_ID:-local-dev-org}`) so licensed deployments can boot without hardcoded `local-dev-org` mismatches.

## Test plan

- [x] Unit + integration tests on the platform (workflow_control + policy tier) — all green
- [x] 10 hardened E2E examples run green against v7.3.0 Docker stack (5 Community examples on Community license, 5 Evaluation examples on Evaluation license)
- [x] Community license correctly rejects Evaluation examples with `HTTP 403 FEATURE_REQUIRES_EVALUATION_LICENSE`
- [x] OpenAPI spec (`docs/api/orchestrator-api.yaml`) updated to match code
- [ ] Community CI green