### PR TITLE
docs(readme): reposition demo videos as two-demo system

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,9 @@ All policies are configurable. Teams typically start in observe-only mode and en
 
 **[Full Documentation](https://docs.getaxonflow.com)** · **[Getting Started Guide](https://docs.getaxonflow.com/docs/getting-started)** · **[API Reference](./docs/api/)**
 
-**2-minute demo:** See AxonFlow enforcing runtime policies and execution control in a real workflow — [Watch on YouTube](https://youtu.be/BSqU1z0xxCo)
+**Community Quickstart Demo (Code + Terminal, 2.5 min):** Governed calls, PII block, Gateway Mode with LangChain/CrewAI, and MAP from YAML — [Watch on YouTube](https://youtu.be/BSqU1z0xxCo)
+
+**Runtime Control Demo (Portal + Workflow, 3 min):** Want the product/runtime view? See approvals, retry safety, execution state, and the audit viewer in action — [Watch on YouTube](https://youtu.be/6UatGpn7KwE)
 
 **Architecture deep dive (12 min):** How the control plane works, policy enforcement flow, and multi-agent planning — [Watch on YouTube](https://youtu.be/Q2CZ1qnquhg)
 
@@ -139,7 +141,7 @@ This creates a WCP workflow, runs step-level gate checks, records a step ledger,
 
 ## Quick Start
 
-If you want to see how this looks before setting it up, here's a short demo: [2-minute walkthrough](https://youtu.be/BSqU1z0xxCo)
+If you want to see how this looks before setting it up, here's a short demo: [Community Quickstart walkthrough (2.5 min)](https://youtu.be/BSqU1z0xxCo)
 
 **Prerequisites:** [Docker Desktop](https://docs.docker.com/get-docker/) installed and running.
 


### PR DESCRIPTION
## Summary

Reposition the two published demo videos so each has a clear job on the README, rather than competing for the same 'watch the demo' slot.

- **Community Quickstart Demo (Code + Terminal, 2.5 min)** — kept as the lead on this dev-facing README. Governed calls, PII block, Gateway Mode (LangChain / CrewAI), MAP from YAML. (\`BSqU1z0xxCo\`)
- **Runtime Control Demo (Portal + Workflow, 3 min)** — added as a cross-link for viewers who want the product/runtime view. Approvals, retry safety, execution state, audit viewer. (\`6UatGpn7KwE\`)
- **Architecture deep dive (12 min)** — unchanged; architecture hasn't materially shifted. (\`Q2CZ1qnquhg\`)

## Why

The old video is not obsolete — it's the best answer to 'what does this look like in code / can I run this locally / what does Community give me'. The new video is the best answer to 'why does this matter operationally / how do approvals + execution state + audit work together'. Different funnel stages, different buyer/viewer questions. Keeping both with clear labels is stronger than forcing one video to do every job.

On this README (dev audience), the Quickstart Demo stays primary. The docs landing page and the main homepage flip the priority — those changes land in companion PRs on \`axonflow-docs\` and \`axonflow-landing\`.

## Test plan

- [ ] Review rendered README on GitHub — three video lines read cleanly with the right hierarchy
- [ ] Confirm both YouTube URLs resolve