### PR TITLE
fix(v7.4.3): Plugin Batch 1 spec corrections + SDK example bumps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ community mirror, **Enterprise** changes are EE-only.
 
 ## [Unreleased]
 
+## [7.4.3] - 2026-04-25 — Plugin Batch 1 / ADR-043 spec corrections
+
+PATCH: documentation-grade corrections — no platform behaviour change. Companion to the 4 plugin wire-shape contract gates landing alongside (parity with the four SDK gates per ADR-047). Auto-resolves the bulk of those plugins' initial baseline drift entries.
+
+### Community
+
+#### Fixed
+
+- **OpenAPI spec corrections — Plugin Batch 1 / ADR-043 explainability fields.** Two MCP-response schemas have been stale relative to what the agent has emitted since Plugin Batch 1 / ADR-042 / ADR-043 shipped. The fix unblocks code-generated clients and auto-resolves baseline drift entries on every AxonFlow plugin's wire-shape contract gate.
+  - **`MCPCheckInputResponse`** gains the five Plugin Batch 1 fields the agent has emitted since v7.1.0 (`decision_id`, `risk_level`, `policy_matches`, `override_available`, `override_existing_id`). Source of truth: `platform/agent/mcp_server_handler.go:880-940`.
+  - **`MCPCheckOutputResponse`** gains `redacted_message` (text-redaction counterpart to `redacted_data`), `decision_id`, and `policy_matches`. Source of truth: `platform/agent/mcp_server_handler.go:988, 1005, 1051`.
+  - **`ExplainPolicy`**, **`ExplainRule`**, **`DecisionExplanation`** schemas added — these are the ADR-043 explainability shapes returned by the `explain_decision` MCP tool. Hand-written SDKs and plugins are already aligned with what the agent emits; this just documents the wire contract.
+
 ## [7.4.2] - 2026-04-25 — OpenAPI spec corrections
 
 PATCH: documentation-grade corrections — no platform behavior change.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,7 +87,7 @@ services:
       DEPLOYMENT_MODE: ${DEPLOYMENT_MODE:-community}
       AXONFLOW_INTEGRATIONS: ${AXONFLOW_INTEGRATIONS:-}
       AXONFLOW_LICENSE_KEY: ${AXONFLOW_LICENSE_KEY:-}
-      AXONFLOW_VERSION: "${AXONFLOW_VERSION:-7.4.2}"
+      AXONFLOW_VERSION: "${AXONFLOW_VERSION:-7.4.3}"
 
       # Media governance (v4.5.0+) - set to "true" to enable in Community mode
       MEDIA_GOVERNANCE_ENABLED: ${MEDIA_GOVERNANCE_ENABLED:-}
@@ -223,7 +223,7 @@ services:
       PORT: 8081
       DEPLOYMENT_MODE: ${DEPLOYMENT_MODE:-community}
       AXONFLOW_LICENSE_KEY: ${AXONFLOW_LICENSE_KEY:-}
-      AXONFLOW_VERSION: "${AXONFLOW_VERSION:-7.4.2}"
+      AXONFLOW_VERSION: "${AXONFLOW_VERSION:-7.4.3}"
 
       # HITL mode (Evaluation+) — set to "true" to enable the HITL workflow
       # engine backing WCP /steps/{step_id}/approve|reject, MAP plan-scoped

--- a/docs/api/agent-api.yaml
+++ b/docs/api/agent-api.yaml
@@ -3753,6 +3753,105 @@ components:
         dynamic_policy_info:
           $ref: '#/components/schemas/DynamicPolicyInfo'
 
+    ExplainPolicy:
+      type: object
+      description: |
+        Per-policy explainability record (ADR-043). Surfaced in
+        MCPCheckInputResponse.policy_matches and MCPCheckOutputResponse.policy_matches
+        when dynamic policy evaluation produces non-empty matches.
+      properties:
+        policy_id:
+          type: string
+          description: Unique policy identifier.
+        policy_name:
+          type: string
+          description: Human-readable policy name.
+        action:
+          type: string
+          description: Action taken for this policy match (e.g. "block", "redact", "warn").
+        risk_level:
+          type: string
+          enum: [low, medium, high, critical]
+          description: Risk level configured on this policy.
+        allow_override:
+          type: boolean
+          description: Whether this policy permits a session override.
+        policy_description:
+          type: string
+          description: Optional description text shown to operators.
+
+    ExplainRule:
+      type: object
+      description: |
+        Per-rule explainability record (ADR-043). Surfaced in
+        DecisionExplanation.matched_rules to attribute a decision to the
+        specific rule that fired.
+      properties:
+        policy_id:
+          type: string
+          description: Parent policy identifier.
+        rule_id:
+          type: string
+          description: Unique rule identifier within the policy.
+        rule_text:
+          type: string
+          description: The rule text or pattern that matched.
+        matched_on:
+          type: string
+          description: The portion of the input/output that matched the rule.
+
+    DecisionExplanation:
+      type: object
+      description: |
+        Full explainability payload (ADR-043). Returned by the
+        explain_decision MCP tool given a decision_id.
+      properties:
+        decision_id:
+          type: string
+          description: Unique audit correlator (matches MCPCheck*Response.decision_id).
+        timestamp:
+          type: string
+          format: date-time
+          description: When the decision was made.
+        policy_matches:
+          type: array
+          items:
+            $ref: '#/components/schemas/ExplainPolicy'
+          description: All policies that matched in this decision.
+        matched_rules:
+          type: array
+          items:
+            $ref: '#/components/schemas/ExplainRule'
+          description: All specific rules that fired (sub-policy level).
+        decision:
+          type: string
+          enum: [allow, block, redact, warn]
+          description: Final decision applied to the request.
+        reason:
+          type: string
+          description: Human-readable explanation of the decision.
+        risk_level:
+          type: string
+          enum: [low, medium, high, critical]
+          description: Highest risk level across all matches.
+        override_available:
+          type: boolean
+          description: Whether a session override is available for this decision.
+        override_existing_id:
+          type: string
+          description: ID of an active override consumed by this decision (if any).
+        historical_hit_count_session:
+          type: integer
+          description: |
+            Number of times this decision-class has fired in the current
+            session — useful for surfacing repeat-offender context.
+        policy_source_link:
+          type: string
+          description: Optional URL pointing to the policy definition source.
+        tool_signature:
+          type: string
+          description: Optional signature identifying the calling tool/connector.
+
     ExfiltrationCheckInfo:
       type: object
       description: Information about exfiltration limit checks (v3.2.0+)
@@ -3948,6 +4047,40 @@ components:
           description: Total number of policies evaluated
         policy_info:
           $ref: '#/components/schemas/PolicyInfo'
+        # Plugin Batch 1 / ADR-042 / ADR-043 — richer governance context
+        # surfaced when the platform is v7.1.0+. Source of truth:
+        # platform/agent/mcp_server_handler.go, lines ~880-940.
+        decision_id:
+          type: string
+          description: |
+            Unique audit correlator for this policy decision. Links the gate
+            response to its row in the audit log; surfaceable to end users
+            for explainability ("decision: dec_abc123").
+        risk_level:
+          type: string
+          enum: [low, medium, high, critical]
+          description: |
+            Highest risk level across all matched policies. Plugins use this
+            to map the block reason to severity (warning vs hard error).
+        policy_matches:
+          type: array
+          items:
+            $ref: '#/components/schemas/ExplainPolicy'
+          description: |
+            Per-policy explainability records (ADR-043). Surfaced when
+            dynamic policy evaluation produces non-empty matches.
+        override_available:
+          type: boolean
+          description: |
+            Whether at least one matched policy permits a session override.
+            Used by plugins to render an "override via explain_decision"
+            hint when the block is overrideable.
+        override_existing_id:
+          type: string
+          description: |
+            ID of an active override consumed by this decision (if any).
+            Distinguishes "you already have an override" from "you can
+            request one".
 
     MCPCheckOutputRequest:
       type: object
@@ -3999,7 +4132,18 @@ components:
           type: string
           description: Human-readable reason if blocked (omitted when allowed)
         redacted_data:
-          description: Response data with PII fields masked (omitted if no redaction needed)
+          description: |
+            Tabular response data with PII fields masked (used when the
+            connector returned rows; e.g. SQL/CSV results). Omitted if no
+            redaction was needed or if the response was a text message.
+        redacted_message:
+          type: string
+          description: |
+            Text message with PII fields masked (used when the connector
+            returned a string message rather than tabular rows; e.g.
+            execute-style responses). Omitted if no redaction was needed
+            or if the response was tabular. Source of truth:
+            `platform/agent/mcp_server_handler.go:988`.
         policies_evaluated:
           type: integer
           description: Total number of policies evaluated
@@ -4007,6 +4151,16 @@ components:
           $ref: '#/components/schemas/ExfiltrationCheckInfo'
         policy_info:
           $ref: '#/components/schemas/PolicyInfo'
+        # Plugin Batch 1 / ADR-043 — explainability context (matches the
+        # MCPCheckInputResponse fields on the same call site).
+        decision_id:
+          type: string
+          description: Unique audit correlator for this policy decision.
+        policy_matches:
+          type: array
+          items:
+            $ref: '#/components/schemas/ExplainPolicy'
+          description: Per-policy explainability records (ADR-043).
 
     ConnectorRefreshResponse:
       type: object

--- a/examples/audit-logging/go/go.mod
+++ b/examples/audit-logging/go/go.mod
@@ -3,6 +3,6 @@ module github.com/getaxonflow/axonflow/examples/audit-logging/go
 go 1.21
 
 require (
-	github.com/getaxonflow/axonflow-sdk-go/v5 v5.6.0
+	github.com/getaxonflow/axonflow-sdk-go/v5 v5.7.0
 	github.com/sashabaranov/go-openai v1.17.9
 )

--- a/examples/audit-logging/java/pom.xml
+++ b/examples/audit-logging/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.7.0</version>
+            <version>6.0.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/audit-logging/python/requirements.txt
+++ b/examples/audit-logging/python/requirements.txt
@@ -1,3 +1,3 @@
-axonflow>=6.6.0
+axonflow>=6.7.0
 python-dotenv>=1.0.0
 openai>=1.0.0

--- a/examples/audit-logging/typescript/package.json
+++ b/examples/audit-logging/typescript/package.json
@@ -7,7 +7,7 @@
     "start": "ts-node index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.6.0",
+    "@axonflow/sdk": "^6.0.0",
     "dotenv": "^16.6.1",
     "openai": "^4.104.0"
   },

--- a/examples/code-governance/go/go.mod
+++ b/examples/code-governance/go/go.mod
@@ -2,4 +2,4 @@ module github.com/axonflow/examples/code-governance
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.6.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.7.0

--- a/examples/code-governance/java/pom.xml
+++ b/examples/code-governance/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.7.0</version>
+            <version>6.0.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/code-governance/python/requirements.txt
+++ b/examples/code-governance/python/requirements.txt
@@ -1,2 +1,2 @@
-axonflow>=6.6.0
+axonflow>=6.7.0
 python-dotenv>=1.0.0

--- a/examples/code-governance/typescript/package.json
+++ b/examples/code-governance/typescript/package.json
@@ -9,7 +9,7 @@
     "start:built": "node dist/index.js"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.6.0",
+    "@axonflow/sdk": "^6.0.0",
     "dotenv": "^16.3.1"
   },
   "devDependencies": {

--- a/examples/cost-controls/enforcement/go/go.mod
+++ b/examples/cost-controls/enforcement/go/go.mod
@@ -2,4 +2,4 @@ module cost-controls-enforcement
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.6.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.7.0

--- a/examples/cost-controls/enforcement/java/pom.xml
+++ b/examples/cost-controls/enforcement/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.7.0</version>
+            <version>6.0.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/cost-controls/enforcement/python/requirements.txt
+++ b/examples/cost-controls/enforcement/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=6.6.0
+axonflow>=6.7.0

--- a/examples/cost-controls/enforcement/typescript/package.json
+++ b/examples/cost-controls/enforcement/typescript/package.json
@@ -9,7 +9,7 @@
     "test": "npm run start"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.6.0"
+    "@axonflow/sdk": "^6.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/examples/cost-controls/go/go.mod
+++ b/examples/cost-controls/go/go.mod
@@ -2,4 +2,4 @@ module github.com/getaxonflow/axonflow/examples/cost-controls/go
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.6.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.7.0

--- a/examples/cost-controls/java/pom.xml
+++ b/examples/cost-controls/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.7.0</version>
+            <version>6.0.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/cost-controls/python/requirements.txt
+++ b/examples/cost-controls/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=6.6.0
+axonflow>=6.7.0

--- a/examples/cost-controls/typescript/package.json
+++ b/examples/cost-controls/typescript/package.json
@@ -8,7 +8,7 @@
     "start": "npx tsx src/index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.6.0"
+    "@axonflow/sdk": "^6.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/examples/cost-estimation/go/go.mod
+++ b/examples/cost-estimation/go/go.mod
@@ -2,4 +2,4 @@ module cost-estimation
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.6.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.7.0

--- a/examples/cost-estimation/java/pom.xml
+++ b/examples/cost-estimation/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.7.0</version>
+            <version>6.0.0</version>
         </dependency>
         <!-- Override transitive jackson for GHSA-72hv-8253-57qq -->
         <dependency>

--- a/examples/cost-estimation/python/requirements.txt
+++ b/examples/cost-estimation/python/requirements.txt
@@ -1,3 +1,3 @@
-axonflow>=6.6.0
+axonflow>=6.7.0
 python-dotenv>=1.0.0
 requests>=2.31.0

--- a/examples/cost-estimation/typescript/package.json
+++ b/examples/cost-estimation/typescript/package.json
@@ -8,7 +8,7 @@
     "start": "npx tsx index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.6.0",
+    "@axonflow/sdk": "^6.0.0",
     "dotenv": "^16.3.1"
   },
   "devDependencies": {

--- a/examples/demo/requirements.txt
+++ b/examples/demo/requirements.txt
@@ -1,5 +1,5 @@
 # Core SDK
-axonflow>=6.6.0
+axonflow>=6.7.0
 
 # HTTP client
 httpx>=0.24.0

--- a/examples/dynamic-policies/compliance/go/go.mod
+++ b/examples/dynamic-policies/compliance/go/go.mod
@@ -2,4 +2,4 @@ module compliance-example
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.6.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.7.0

--- a/examples/dynamic-policies/compliance/java/pom.xml
+++ b/examples/dynamic-policies/compliance/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.7.0</version>
+            <version>6.0.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/dynamic-policies/compliance/typescript/package.json
+++ b/examples/dynamic-policies/compliance/typescript/package.json
@@ -6,7 +6,7 @@
     "start": "npx ts-node --esm index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.6.0"
+    "@axonflow/sdk": "^6.0.0"
   },
   "devDependencies": {
     "ts-node": "^10.9.2",

--- a/examples/dynamic-policies/go/go.mod
+++ b/examples/dynamic-policies/go/go.mod
@@ -2,4 +2,4 @@ module github.com/getaxonflow/axonflow/examples/dynamic-policies/go
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.6.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.7.0

--- a/examples/dynamic-policies/java/pom.xml
+++ b/examples/dynamic-policies/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.7.0</version>
+            <version>6.0.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/dynamic-policies/typescript/package.json
+++ b/examples/dynamic-policies/typescript/package.json
@@ -6,6 +6,6 @@
     "start": "npx tsx index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.6.0"
+    "@axonflow/sdk": "^6.0.0"
   }
 }

--- a/examples/evaluation-tier/go/go.mod
+++ b/examples/evaluation-tier/go/go.mod
@@ -2,4 +2,4 @@ module github.com/getaxonflow/axonflow/examples/evaluation-tier/go
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.6.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.7.0

--- a/examples/evaluation-tier/java/pom.xml
+++ b/examples/evaluation-tier/java/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <axonflow.version>5.7.0</axonflow.version>
+        <axonflow.version>6.0.0</axonflow.version>
     </properties>
 
     <dependencyManagement>

--- a/examples/evaluation-tier/python/requirements.txt
+++ b/examples/evaluation-tier/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=6.6.0
+axonflow>=6.7.0

--- a/examples/evaluation-tier/typescript/package.json
+++ b/examples/evaluation-tier/typescript/package.json
@@ -7,7 +7,7 @@
     "test": "npx ts-node test_tier_limits.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.6.0"
+    "@axonflow/sdk": "^6.0.0"
   },
   "devDependencies": {
     "ts-node": "^10.9.2",

--- a/examples/execution-replay/go/go.mod
+++ b/examples/execution-replay/go/go.mod
@@ -2,4 +2,4 @@ module github.com/getaxonflow/axonflow/examples/execution-replay/go
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.6.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.7.0

--- a/examples/execution-replay/java/pom.xml
+++ b/examples/execution-replay/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.7.0</version>
+            <version>6.0.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/execution-replay/python/requirements.txt
+++ b/examples/execution-replay/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=6.6.0
+axonflow>=6.7.0

--- a/examples/execution-replay/typescript/package.json
+++ b/examples/execution-replay/typescript/package.json
@@ -9,7 +9,7 @@
     "dev": "ts-node src/index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.6.0"
+    "@axonflow/sdk": "^6.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.10.0",

--- a/examples/execution-tracking/go/go.mod
+++ b/examples/execution-tracking/go/go.mod
@@ -2,4 +2,4 @@ module github.com/getaxonflow/axonflow-enterprise/examples/execution-tracking
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.6.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.7.0

--- a/examples/execution-tracking/java/pom.xml
+++ b/examples/execution-tracking/java/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <axonflow.sdk.version>5.7.0</axonflow.sdk.version>
+        <axonflow.sdk.version>6.0.0</axonflow.sdk.version>
     </properties>
 
     <dependencyManagement>

--- a/examples/execution-tracking/python/requirements.txt
+++ b/examples/execution-tracking/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=6.6.0
+axonflow>=6.7.0

--- a/examples/execution-tracking/typescript/package.json
+++ b/examples/execution-tracking/typescript/package.json
@@ -8,7 +8,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.6.0"
+    "@axonflow/sdk": "^6.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/examples/gateway-policy-config/go/go.mod
+++ b/examples/gateway-policy-config/go/go.mod
@@ -2,4 +2,4 @@ module examples/gateway-policy-config/go
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.6.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.7.0

--- a/examples/gateway-policy-config/java/pom.xml
+++ b/examples/gateway-policy-config/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.7.0</version>
+            <version>6.0.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/gateway-policy-config/python/requirements.txt
+++ b/examples/gateway-policy-config/python/requirements.txt
@@ -1,2 +1,2 @@
-axonflow>=6.6.0
+axonflow>=6.7.0
 python-dotenv>=1.0.0

--- a/examples/gateway-policy-config/typescript/package.json
+++ b/examples/gateway-policy-config/typescript/package.json
@@ -7,7 +7,7 @@
     "start": "ts-node index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.6.0",
+    "@axonflow/sdk": "^6.0.0",
     "dotenv": "^16.3.1"
   },
   "devDependencies": {

--- a/examples/health-check/go/go.mod
+++ b/examples/health-check/go/go.mod
@@ -2,4 +2,4 @@ module health-check
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.6.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.7.0

--- a/examples/health-check/java/pom.xml
+++ b/examples/health-check/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.7.0</version>
+            <version>6.0.0</version>
         </dependency>
         <!-- Override transitive jackson for GHSA-72hv-8253-57qq -->
         <dependency>

--- a/examples/health-check/python/requirements.txt
+++ b/examples/health-check/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=6.6.0
+axonflow>=6.7.0

--- a/examples/health-check/typescript/package.json
+++ b/examples/health-check/typescript/package.json
@@ -6,6 +6,6 @@
     "start": "npx tsx index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.6.0"
+    "@axonflow/sdk": "^6.0.0"
   }
 }

--- a/examples/hello-world/go/go.mod
+++ b/examples/hello-world/go/go.mod
@@ -2,4 +2,4 @@ module github.com/axonflow/examples/hello-world
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.6.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.7.0

--- a/examples/hello-world/java/pom.xml
+++ b/examples/hello-world/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.7.0</version>
+            <version>6.0.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/hello-world/python/requirements.txt
+++ b/examples/hello-world/python/requirements.txt
@@ -1,5 +1,5 @@
 # AxonFlow SDK
-axonflow>=6.6.0
+axonflow>=6.7.0
 
 # Environment management
 python-dotenv>=1.0.0

--- a/examples/hello-world/typescript/package.json
+++ b/examples/hello-world/typescript/package.json
@@ -13,7 +13,7 @@
   "author": "AxonFlow",
   "license": "MIT",
   "dependencies": {
-    "@axonflow/sdk": "^5.6.0",
+    "@axonflow/sdk": "^6.0.0",
     "dotenv": "^16.3.0",
     "openai": "^4.0.0"
   },

--- a/examples/hitl-queue/go/go.mod
+++ b/examples/hitl-queue/go/go.mod
@@ -2,4 +2,4 @@ module github.com/axonflow/examples/hitl-queue
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.6.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.7.0

--- a/examples/hitl-queue/java/pom.xml
+++ b/examples/hitl-queue/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.7.0</version>
+            <version>6.0.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/hitl-queue/python/requirements.txt
+++ b/examples/hitl-queue/python/requirements.txt
@@ -1,2 +1,2 @@
-axonflow>=6.6.0
+axonflow>=6.7.0
 python-dotenv>=1.0.0

--- a/examples/hitl-queue/typescript/package.json
+++ b/examples/hitl-queue/typescript/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.6.0",
+    "@axonflow/sdk": "^6.0.0",
     "dotenv": "^16.3.1"
   },
   "devDependencies": {

--- a/examples/hitl/go/go.mod
+++ b/examples/hitl/go/go.mod
@@ -2,4 +2,4 @@ module axonflow-hitl-example
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.6.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.7.0

--- a/examples/hitl/java/pom.xml
+++ b/examples/hitl/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.7.0</version>
+            <version>6.0.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/hitl/python/requirements.txt
+++ b/examples/hitl/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=6.6.0
+axonflow>=6.7.0

--- a/examples/hitl/typescript/package.json
+++ b/examples/hitl/typescript/package.json
@@ -7,7 +7,7 @@
     "example": "npx ts-node --esm require-approval-policy.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.6.0"
+    "@axonflow/sdk": "^6.0.0"
   },
   "devDependencies": {
     "ts-node": "^10.9.2",

--- a/examples/integrations/autogen/java/pom.xml
+++ b/examples/integrations/autogen/java/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.7.0</version>
+            <version>6.0.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/integrations/autogen/requirements.txt
+++ b/examples/integrations/autogen/requirements.txt
@@ -1,3 +1,3 @@
 pyautogen>=0.2.0
-axonflow>=6.6.0
+axonflow>=6.7.0
 python-dotenv>=1.0.0

--- a/examples/integrations/computer-use/python/requirements.txt
+++ b/examples/integrations/computer-use/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=6.6.0
+axonflow>=6.7.0

--- a/examples/integrations/crewai/requirements.txt
+++ b/examples/integrations/crewai/requirements.txt
@@ -1,5 +1,5 @@
 # AxonFlow SDK
-axonflow>=6.6.0
+axonflow>=6.7.0
 
 # CrewAI
 crewai>=0.5.0

--- a/examples/integrations/dspy/go/go.mod
+++ b/examples/integrations/dspy/go/go.mod
@@ -2,4 +2,4 @@ module dspy-axonflow-example
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.6.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.7.0

--- a/examples/integrations/dspy/python/requirements.txt
+++ b/examples/integrations/dspy/python/requirements.txt
@@ -1,2 +1,2 @@
-axonflow>=6.6.0
+axonflow>=6.7.0
 python-dotenv>=1.0.0

--- a/examples/integrations/gateway-mode/go/go.mod
+++ b/examples/integrations/gateway-mode/go/go.mod
@@ -3,6 +3,6 @@ module github.com/getaxonflow/axonflow/examples/integrations/gateway-mode/go
 go 1.21
 
 require (
-	github.com/getaxonflow/axonflow-sdk-go/v5 v5.6.0
+	github.com/getaxonflow/axonflow-sdk-go/v5 v5.7.0
 	github.com/sashabaranov/go-openai v1.17.9
 )

--- a/examples/integrations/gateway-mode/java/pom.xml
+++ b/examples/integrations/gateway-mode/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.7.0</version>
+            <version>6.0.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/integrations/gateway-mode/python/requirements.txt
+++ b/examples/integrations/gateway-mode/python/requirements.txt
@@ -1,5 +1,5 @@
 # AxonFlow SDK
-axonflow>=6.6.0
+axonflow>=6.7.0
 
 # LLM Providers
 openai>=1.6.0

--- a/examples/integrations/gateway-mode/typescript/package.json
+++ b/examples/integrations/gateway-mode/typescript/package.json
@@ -14,7 +14,7 @@
   "author": "AxonFlow",
   "license": "MIT",
   "dependencies": {
-    "@axonflow/sdk": "^5.6.0",
+    "@axonflow/sdk": "^6.0.0",
     "dotenv": "^16.3.0",
     "openai": "^4.20.0",
     "@anthropic-ai/sdk": "^0.32.0"

--- a/examples/integrations/governed-tools/go/go.mod
+++ b/examples/integrations/governed-tools/go/go.mod
@@ -2,4 +2,4 @@ module github.com/axonflow/examples/governed-tools
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.6.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.7.0

--- a/examples/integrations/governed-tools/java/pom.xml
+++ b/examples/integrations/governed-tools/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.7.0</version>
+            <version>6.0.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/integrations/governed-tools/python/requirements.txt
+++ b/examples/integrations/governed-tools/python/requirements.txt
@@ -1,2 +1,2 @@
-axonflow>=6.6.0
+axonflow>=6.7.0
 langchain-core>=0.3.0

--- a/examples/integrations/governed-tools/typescript/package.json
+++ b/examples/integrations/governed-tools/typescript/package.json
@@ -13,7 +13,7 @@
   "author": "AxonFlow",
   "license": "MIT",
   "dependencies": {
-    "@axonflow/sdk": "^5.6.0"
+    "@axonflow/sdk": "^6.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/examples/integrations/langchain/requirements.txt
+++ b/examples/integrations/langchain/requirements.txt
@@ -1,5 +1,5 @@
 # AxonFlow SDK
-axonflow>=6.6.0
+axonflow>=6.7.0
 
 # LangChain
 langchain>=0.1.0

--- a/examples/integrations/langgraph/go/go.mod
+++ b/examples/integrations/langgraph/go/go.mod
@@ -2,4 +2,4 @@ module langgraph-axonflow-example
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.6.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.7.0

--- a/examples/integrations/langgraph/python/requirements.txt
+++ b/examples/integrations/langgraph/python/requirements.txt
@@ -1,2 +1,2 @@
-axonflow>=6.6.0
+axonflow>=6.7.0
 python-dotenv>=1.0.0

--- a/examples/integrations/langgraph/typescript/package.json
+++ b/examples/integrations/langgraph/typescript/package.json
@@ -9,7 +9,7 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.6.0"
+    "@axonflow/sdk": "^6.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.10.0",

--- a/examples/integrations/proxy-mode/go/go.mod
+++ b/examples/integrations/proxy-mode/go/go.mod
@@ -2,4 +2,4 @@ module github.com/getaxonflow/axonflow/examples/integrations/proxy-mode/go
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.6.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.7.0

--- a/examples/integrations/proxy-mode/java/pom.xml
+++ b/examples/integrations/proxy-mode/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.7.0</version>
+            <version>6.0.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/integrations/proxy-mode/python/requirements.txt
+++ b/examples/integrations/proxy-mode/python/requirements.txt
@@ -1,5 +1,5 @@
 # AxonFlow SDK
-axonflow>=6.6.0
+axonflow>=6.7.0
 
 # Environment management
 python-dotenv>=1.0.0

--- a/examples/integrations/proxy-mode/typescript/package.json
+++ b/examples/integrations/proxy-mode/typescript/package.json
@@ -10,7 +10,7 @@
     "dev": "ts-node src/index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.6.0",
+    "@axonflow/sdk": "^6.0.0",
     "dotenv": "^16.6.1"
   },
   "devDependencies": {

--- a/examples/integrations/semantic-kernel/java/pom.xml
+++ b/examples/integrations/semantic-kernel/java/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.7.0</version>
+            <version>6.0.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/integrations/semantic-kernel/typescript/package.json
+++ b/examples/integrations/semantic-kernel/typescript/package.json
@@ -9,7 +9,7 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.6.0"
+    "@axonflow/sdk": "^6.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.10.0",

--- a/examples/integrations/spring-boot/pom.xml
+++ b/examples/integrations/spring-boot/pom.xml
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.7.0</version>
+            <version>6.0.0</version>
         </dependency>
 
         <!-- OpenAI for Gateway Mode demo -->

--- a/examples/interceptors/go/go.mod
+++ b/examples/interceptors/go/go.mod
@@ -2,4 +2,4 @@ module github.com/getaxonflow/axonflow/examples/interceptors/go
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.6.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.7.0

--- a/examples/interceptors/java/pom.xml
+++ b/examples/interceptors/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.7.0</version>
+            <version>6.0.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/interceptors/python/requirements.txt
+++ b/examples/interceptors/python/requirements.txt
@@ -1,2 +1,2 @@
-axonflow>=6.6.0
+axonflow>=6.7.0
 openai>=1.0.0

--- a/examples/interceptors/typescript/package.json
+++ b/examples/interceptors/typescript/package.json
@@ -7,7 +7,7 @@
     "start": "ts-node src/index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.6.0",
+    "@axonflow/sdk": "^6.0.0",
     "dotenv": "^16.3.1",
     "openai": "^4.20.0"
   },

--- a/examples/llm-providers/azure-openai/pii-detection/python/requirements.txt
+++ b/examples/llm-providers/azure-openai/pii-detection/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=6.6.0
+axonflow>=6.7.0

--- a/examples/llm-providers/azure-openai/proxy-mode/go/go.mod
+++ b/examples/llm-providers/azure-openai/proxy-mode/go/go.mod
@@ -2,4 +2,4 @@ module github.com/getaxonflow/axonflow/examples/llm-providers/azure-openai/proxy
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.6.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.7.0

--- a/examples/llm-providers/azure-openai/sqli-scanning/typescript/package.json
+++ b/examples/llm-providers/azure-openai/sqli-scanning/typescript/package.json
@@ -8,7 +8,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.6.0"
+    "@axonflow/sdk": "^6.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/examples/llm-providers/mistral/hello-world/go/go.mod
+++ b/examples/llm-providers/mistral/hello-world/go/go.mod
@@ -2,4 +2,4 @@ module mistral-hello-world
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.6.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.7.0

--- a/examples/llm-providers/mistral/hello-world/java/pom.xml
+++ b/examples/llm-providers/mistral/hello-world/java/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.7.0</version>
+            <version>6.0.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>

--- a/examples/llm-providers/mistral/hello-world/python/requirements.txt
+++ b/examples/llm-providers/mistral/hello-world/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=6.6.0
+axonflow>=6.7.0

--- a/examples/llm-providers/mistral/hello-world/typescript/package.json
+++ b/examples/llm-providers/mistral/hello-world/typescript/package.json
@@ -7,7 +7,7 @@
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.6.0"
+    "@axonflow/sdk": "^6.0.0"
   },
   "devDependencies": {
     "tsx": "^4.7.0",

--- a/examples/llm-routing/e2e-tests/go/go.mod
+++ b/examples/llm-routing/e2e-tests/go/go.mod
@@ -2,4 +2,4 @@ module llm-provider-tests
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.6.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.7.0

--- a/examples/llm-routing/e2e-tests/java/pom.xml
+++ b/examples/llm-routing/e2e-tests/java/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.7.0</version>
+            <version>6.0.0</version>
         </dependency>
         <!-- Override transitive jackson for GHSA-72hv-8253-57qq -->
         <dependency>

--- a/examples/llm-routing/e2e-tests/python/requirements.txt
+++ b/examples/llm-routing/e2e-tests/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=6.6.0
+axonflow>=6.7.0

--- a/examples/llm-routing/e2e-tests/typescript/package.json
+++ b/examples/llm-routing/e2e-tests/typescript/package.json
@@ -7,7 +7,7 @@
     "test": "ts-node main.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.6.0"
+    "@axonflow/sdk": "^6.0.0"
   },
   "devDependencies": {
     "ts-node": "^10.9.0",

--- a/examples/llm-routing/go/go.mod
+++ b/examples/llm-routing/go/go.mod
@@ -2,4 +2,4 @@ module github.com/getaxonflow/axonflow/examples/llm-routing/go
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.6.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.7.0

--- a/examples/llm-routing/java/pom.xml
+++ b/examples/llm-routing/java/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.7.0</version>
+            <version>6.0.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/llm-routing/python/requirements.txt
+++ b/examples/llm-routing/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=6.6.0
+axonflow>=6.7.0

--- a/examples/llm-routing/typescript/package.json
+++ b/examples/llm-routing/typescript/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx provider-routing.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.6.0"
+    "@axonflow/sdk": "^6.0.0"
   },
   "devDependencies": {
     "typescript": "^5.3.0",

--- a/examples/map-confirm-mode/go/go.mod
+++ b/examples/map-confirm-mode/go/go.mod
@@ -2,4 +2,4 @@ module github.com/getaxonflow/axonflow/examples/map-confirm-mode/go
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.6.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.7.0

--- a/examples/map-confirm-mode/java/pom.xml
+++ b/examples/map-confirm-mode/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.7.0</version>
+            <version>6.0.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/map-confirm-mode/python/requirements.txt
+++ b/examples/map-confirm-mode/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=6.6.0
+axonflow>=6.7.0

--- a/examples/map-confirm-mode/typescript/package.json
+++ b/examples/map-confirm-mode/typescript/package.json
@@ -9,7 +9,7 @@
     "start": "npx tsx src/index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.6.0"
+    "@axonflow/sdk": "^6.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/examples/map-lifecycle/go/go.mod
+++ b/examples/map-lifecycle/go/go.mod
@@ -2,4 +2,4 @@ module github.com/getaxonflow/axonflow/examples/map-lifecycle/go
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.6.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.7.0

--- a/examples/map-lifecycle/java/pom.xml
+++ b/examples/map-lifecycle/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.7.0</version>
+            <version>6.0.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/map-lifecycle/python/requirements.txt
+++ b/examples/map-lifecycle/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=6.6.0
+axonflow>=6.7.0

--- a/examples/map-lifecycle/typescript/package.json
+++ b/examples/map-lifecycle/typescript/package.json
@@ -9,7 +9,7 @@
     "start": "npx tsx src/index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.6.0"
+    "@axonflow/sdk": "^6.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/examples/map/go/go.mod
+++ b/examples/map/go/go.mod
@@ -2,4 +2,4 @@ module github.com/getaxonflow/axonflow/examples/map/go
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.6.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.7.0

--- a/examples/map/java/pom.xml
+++ b/examples/map/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.7.0</version>
+            <version>6.0.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/map/python/requirements.txt
+++ b/examples/map/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=6.6.0
+axonflow>=6.7.0

--- a/examples/map/typescript/package.json
+++ b/examples/map/typescript/package.json
@@ -9,7 +9,7 @@
     "start": "npx tsx src/index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.6.0"
+    "@axonflow/sdk": "^6.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/examples/mcp-audit/go/go.mod
+++ b/examples/mcp-audit/go/go.mod
@@ -2,4 +2,4 @@ module mcp-audit-example
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.6.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.7.0

--- a/examples/mcp-audit/java/pom.xml
+++ b/examples/mcp-audit/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.7.0</version>
+            <version>6.0.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/mcp-audit/python/requirements.txt
+++ b/examples/mcp-audit/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=6.6.0
+axonflow>=6.7.0

--- a/examples/mcp-audit/typescript/package.json
+++ b/examples/mcp-audit/typescript/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.6.0"
+    "@axonflow/sdk": "^6.0.0"
   },
   "devDependencies": {
     "tsx": "^4.7.0",

--- a/examples/mcp-connectors/cloud-storage/go/go.mod
+++ b/examples/mcp-connectors/cloud-storage/go/go.mod
@@ -2,4 +2,4 @@ module github.com/getaxonflow/axonflow/examples/mcp-connectors/cloud-storage/go
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.6.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.7.0

--- a/examples/mcp-connectors/cloud-storage/java/pom.xml
+++ b/examples/mcp-connectors/cloud-storage/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.7.0</version>
+            <version>6.0.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/mcp-connectors/cloud-storage/python/requirements.txt
+++ b/examples/mcp-connectors/cloud-storage/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=6.6.0
+axonflow>=6.7.0

--- a/examples/mcp-connectors/cloud-storage/typescript/package.json
+++ b/examples/mcp-connectors/cloud-storage/typescript/package.json
@@ -7,7 +7,7 @@
     "start": "ts-node src/index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.6.0"
+    "@axonflow/sdk": "^6.0.0"
   },
   "devDependencies": {
     "ts-node": "^10.9.2",

--- a/examples/mcp-connectors/http/go/go.mod
+++ b/examples/mcp-connectors/http/go/go.mod
@@ -2,4 +2,4 @@ module github.com/getaxonflow/axonflow-enterprise/examples/mcp-connectors/http/g
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.6.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.7.0

--- a/examples/mcp-connectors/http/go/go.sum
+++ b/examples/mcp-connectors/http/go/go.sum
@@ -1,2 +1,4 @@
-github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.1 h1:G1HL1e1jcrSDhFS9vPiQeLModRsicBq/WrXVyWpZQVk=
-github.com/getaxonflow/axonflow-sdk-go/v5 v5.3.1/go.mod h1:V3UDfEkKe48HHW8L1GNv39plObmSn3P0NgXNsNQ83SY=
+github.com/getaxonflow/axonflow-sdk-go/v5 v5.7.0 h1:yAwPnhuduxbQ6qf8Hd9RLIk4PzNKiCzJ110yKtiFXHQ=
+github.com/getaxonflow/axonflow-sdk-go/v5 v5.7.0/go.mod h1:nZVDl6WSbv5Q54HweQ53IvpT9Hsn9trtP/kvwlsnmEs=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/examples/mcp-connectors/java/pom.xml
+++ b/examples/mcp-connectors/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.7.0</version>
+            <version>6.0.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/mcp-connectors/python/requirements.txt
+++ b/examples/mcp-connectors/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=6.6.0
+axonflow>=6.7.0

--- a/examples/mcp-policies/check-endpoints/go/go.mod
+++ b/examples/mcp-policies/check-endpoints/go/go.mod
@@ -2,4 +2,4 @@ module mcp-check-endpoints-example
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.6.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.7.0

--- a/examples/mcp-policies/check-endpoints/java/pom.xml
+++ b/examples/mcp-policies/check-endpoints/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.7.0</version>
+            <version>6.0.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/mcp-policies/check-endpoints/python/requirements.txt
+++ b/examples/mcp-policies/check-endpoints/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=6.6.0
+axonflow>=6.7.0

--- a/examples/mcp-policies/check-endpoints/typescript/package.json
+++ b/examples/mcp-policies/check-endpoints/typescript/package.json
@@ -7,7 +7,7 @@
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.6.0"
+    "@axonflow/sdk": "^6.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/examples/mcp-policies/go/go.mod
+++ b/examples/mcp-policies/go/go.mod
@@ -2,4 +2,4 @@ module mcp-policies-example
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.6.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.7.0

--- a/examples/mcp-policies/java/pom.xml
+++ b/examples/mcp-policies/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.7.0</version>
+            <version>6.0.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/mcp-policies/pii-redaction/go/go.mod
+++ b/examples/mcp-policies/pii-redaction/go/go.mod
@@ -2,4 +2,4 @@ module mcp-pii-redaction-example
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.6.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.7.0

--- a/examples/mcp-policies/pii-redaction/java/pom.xml
+++ b/examples/mcp-policies/pii-redaction/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.7.0</version>
+            <version>6.0.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/mcp-policies/pii-redaction/python/requirements.txt
+++ b/examples/mcp-policies/pii-redaction/python/requirements.txt
@@ -1,2 +1,2 @@
-axonflow>=6.6.0
+axonflow>=6.7.0
 python-dotenv>=1.0.0

--- a/examples/mcp-policies/pii-redaction/typescript/package.json
+++ b/examples/mcp-policies/pii-redaction/typescript/package.json
@@ -7,7 +7,7 @@
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.6.0"
+    "@axonflow/sdk": "^6.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/examples/mcp-policies/python/requirements.txt
+++ b/examples/mcp-policies/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=6.6.0
+axonflow>=6.7.0

--- a/examples/mcp-policies/typescript/package.json
+++ b/examples/mcp-policies/typescript/package.json
@@ -7,7 +7,7 @@
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.6.0"
+    "@axonflow/sdk": "^6.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/examples/media-governance-policies/go/go.mod
+++ b/examples/media-governance-policies/go/go.mod
@@ -2,4 +2,4 @@ module github.com/axonflow/examples/media-governance-policies
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.6.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.7.0

--- a/examples/media-governance-policies/java/pom.xml
+++ b/examples/media-governance-policies/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.7.0</version>
+            <version>6.0.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/media-governance-policies/python/requirements.txt
+++ b/examples/media-governance-policies/python/requirements.txt
@@ -1,2 +1,2 @@
-axonflow>=6.6.0
+axonflow>=6.7.0
 python-dotenv>=1.0.0

--- a/examples/media-governance-policies/typescript/package.json
+++ b/examples/media-governance-policies/typescript/package.json
@@ -7,7 +7,7 @@
     "start": "ts-node main.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.6.0",
+    "@axonflow/sdk": "^6.0.0",
     "dotenv": "^16.3.1"
   },
   "devDependencies": {

--- a/examples/media-governance/go/go.mod
+++ b/examples/media-governance/go/go.mod
@@ -2,4 +2,4 @@ module github.com/axonflow/examples/media-governance
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.6.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.7.0

--- a/examples/media-governance/java/pom.xml
+++ b/examples/media-governance/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.7.0</version>
+            <version>6.0.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/media-governance/python/requirements.txt
+++ b/examples/media-governance/python/requirements.txt
@@ -1,2 +1,2 @@
-axonflow>=6.6.0
+axonflow>=6.7.0
 python-dotenv>=1.0.0

--- a/examples/media-governance/typescript/package.json
+++ b/examples/media-governance/typescript/package.json
@@ -7,7 +7,7 @@
     "start": "ts-node index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.6.0",
+    "@axonflow/sdk": "^6.0.0",
     "dotenv": "^16.3.1"
   },
   "devDependencies": {

--- a/examples/pii-detection/go/go.mod
+++ b/examples/pii-detection/go/go.mod
@@ -2,4 +2,4 @@ module github.com/getaxonflow/axonflow/examples/pii-detection/go
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.6.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.7.0

--- a/examples/pii-detection/java/pom.xml
+++ b/examples/pii-detection/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.7.0</version>
+            <version>6.0.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/pii-detection/python/requirements.txt
+++ b/examples/pii-detection/python/requirements.txt
@@ -1,2 +1,2 @@
-axonflow>=6.6.0
+axonflow>=6.7.0
 python-dotenv>=1.0.0

--- a/examples/pii-detection/typescript/package.json
+++ b/examples/pii-detection/typescript/package.json
@@ -7,7 +7,7 @@
     "start": "ts-node index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.6.0",
+    "@axonflow/sdk": "^6.0.0",
     "dotenv": "^16.3.1"
   },
   "devDependencies": {

--- a/examples/policies/crud/requirements.txt
+++ b/examples/policies/crud/requirements.txt
@@ -1,5 +1,5 @@
 # AxonFlow SDK
-axonflow>=6.6.0
+axonflow>=6.7.0
 
 # HTTP client for direct API calls
 httpx>=0.25.0

--- a/examples/policies/go/create-custom-policy/go.mod
+++ b/examples/policies/go/create-custom-policy/go.mod
@@ -2,4 +2,4 @@ module github.com/getaxonflow/axonflow-enterprise/examples/policies/go
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.6.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.7.0

--- a/examples/policies/go/list-and-filter/go.mod
+++ b/examples/policies/go/list-and-filter/go.mod
@@ -2,4 +2,4 @@ module github.com/getaxonflow/axonflow-enterprise/examples/policies/go
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.6.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.7.0

--- a/examples/policies/go/test-pattern/go.mod
+++ b/examples/policies/go/test-pattern/go.mod
@@ -2,4 +2,4 @@ module github.com/getaxonflow/axonflow-enterprise/examples/policies/go
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.6.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.7.0

--- a/examples/policies/java/pom.xml
+++ b/examples/policies/java/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.7.0</version>
+            <version>6.0.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/policies/python/requirements.txt
+++ b/examples/policies/python/requirements.txt
@@ -1,5 +1,5 @@
 # AxonFlow SDK (from feature branch)
-axonflow>=6.6.0
+axonflow>=6.7.0
 
 # For loading environment variables
 python-dotenv>=1.0.0

--- a/examples/policies/typescript/package.json
+++ b/examples/policies/typescript/package.json
@@ -10,7 +10,7 @@
     "all": "npm run create && npm run list && npm run test-pattern"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.6.0"
+    "@axonflow/sdk": "^6.0.0"
   },
   "devDependencies": {
     "tsx": "^4.7.0",

--- a/examples/policy-configuration/go/go.mod
+++ b/examples/policy-configuration/go/go.mod
@@ -2,4 +2,4 @@ module examples/policy-configuration/go
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.6.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.7.0

--- a/examples/policy-configuration/java/pom.xml
+++ b/examples/policy-configuration/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.7.0</version>
+            <version>6.0.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/policy-configuration/python/requirements.txt
+++ b/examples/policy-configuration/python/requirements.txt
@@ -1,2 +1,2 @@
-axonflow>=6.6.0
+axonflow>=6.7.0
 python-dotenv>=1.0.0

--- a/examples/policy-configuration/typescript/package.json
+++ b/examples/policy-configuration/typescript/package.json
@@ -7,7 +7,7 @@
     "start": "ts-node index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.6.0",
+    "@axonflow/sdk": "^6.0.0",
     "dotenv": "^16.3.1"
   },
   "devDependencies": {

--- a/examples/retry-semantics/java/pom.xml
+++ b/examples/retry-semantics/java/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.7.0</version>
+            <version>6.0.0</version>
         </dependency>
     </dependencies>
 </project>

--- a/examples/sdk-audit/go/go.mod
+++ b/examples/sdk-audit/go/go.mod
@@ -2,4 +2,4 @@ module github.com/axonflow/examples/sdk-audit
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.6.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.7.0

--- a/examples/sdk-audit/java/pom.xml
+++ b/examples/sdk-audit/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.7.0</version>
+            <version>6.0.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/sdk-audit/python/requirements.txt
+++ b/examples/sdk-audit/python/requirements.txt
@@ -1,2 +1,2 @@
-axonflow>=6.6.0
+axonflow>=6.7.0
 python-dotenv>=1.0.0

--- a/examples/sdk-audit/typescript/package.json
+++ b/examples/sdk-audit/typescript/package.json
@@ -13,7 +13,7 @@
   "author": "AxonFlow",
   "license": "MIT",
   "dependencies": {
-    "@axonflow/sdk": "^5.6.0",
+    "@axonflow/sdk": "^6.0.0",
     "dotenv": "^16.3.0"
   },
   "devDependencies": {

--- a/examples/singapore-pii/go/go.mod
+++ b/examples/singapore-pii/go/go.mod
@@ -2,4 +2,4 @@ module singapore-pii-example
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.6.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.7.0

--- a/examples/singapore-pii/java/pom.xml
+++ b/examples/singapore-pii/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.7.0</version>
+            <version>6.0.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/singapore-pii/python/requirements.txt
+++ b/examples/singapore-pii/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=6.6.0
+axonflow>=6.7.0

--- a/examples/singapore-pii/typescript/package.json
+++ b/examples/singapore-pii/typescript/package.json
@@ -8,7 +8,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.6.0"
+    "@axonflow/sdk": "^6.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/examples/sqli-detection/go/go.mod
+++ b/examples/sqli-detection/go/go.mod
@@ -2,4 +2,4 @@ module github.com/getaxonflow/axonflow/examples/sqli-detection/go
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.6.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.7.0

--- a/examples/sqli-detection/java/pom.xml
+++ b/examples/sqli-detection/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.7.0</version>
+            <version>6.0.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/sqli-detection/python/requirements.txt
+++ b/examples/sqli-detection/python/requirements.txt
@@ -1,2 +1,2 @@
-axonflow>=6.6.0
+axonflow>=6.7.0
 python-dotenv>=1.0.0

--- a/examples/sqli-detection/typescript/package.json
+++ b/examples/sqli-detection/typescript/package.json
@@ -7,7 +7,7 @@
     "start": "ts-node index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.6.0",
+    "@axonflow/sdk": "^6.0.0",
     "dotenv": "^16.3.1"
   },
   "devDependencies": {

--- a/examples/static-policies/go/go.mod
+++ b/examples/static-policies/go/go.mod
@@ -2,4 +2,4 @@ module static-policies-example
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.6.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.7.0

--- a/examples/static-policies/java/pom.xml
+++ b/examples/static-policies/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.7.0</version>
+            <version>6.0.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/static-policies/python/requirements.txt
+++ b/examples/static-policies/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=6.6.0
+axonflow>=6.7.0

--- a/examples/static-policies/typescript/package.json
+++ b/examples/static-policies/typescript/package.json
@@ -7,7 +7,7 @@
     "start": "npx ts-node index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.6.0"
+    "@axonflow/sdk": "^6.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/examples/support-demo/backend/go.mod
+++ b/examples/support-demo/backend/go.mod
@@ -3,7 +3,7 @@ module axonflow-support-demo
 go 1.21
 
 require (
-	github.com/getaxonflow/axonflow-sdk-go/v5 v5.6.0
+	github.com/getaxonflow/axonflow-sdk-go/v5 v5.7.0
 	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/gorilla/mux v1.8.1
 	github.com/lib/pq v1.10.9

--- a/examples/version-check/go/go.mod
+++ b/examples/version-check/go/go.mod
@@ -2,4 +2,4 @@ module version-check-example
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.6.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.7.0

--- a/examples/version-check/java/pom.xml
+++ b/examples/version-check/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.7.0</version>
+            <version>6.0.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/examples/version-check/python/requirements.txt
+++ b/examples/version-check/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=6.6.0
+axonflow>=6.7.0

--- a/examples/version-check/typescript/package.json
+++ b/examples/version-check/typescript/package.json
@@ -7,7 +7,7 @@
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.6.0"
+    "@axonflow/sdk": "^6.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/examples/wcp-retry-idempotency/community/java/pom.xml
+++ b/examples/wcp-retry-idempotency/community/java/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.7.0</version>
+            <version>6.0.0</version>
         </dependency>
     </dependencies>
 

--- a/examples/wcp-retry-idempotency/evaluation/java/pom.xml
+++ b/examples/wcp-retry-idempotency/evaluation/java/pom.xml
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.7.0</version>
+            <version>6.0.0</version>
         </dependency>
     </dependencies>
 

--- a/examples/webhooks/go/go.mod
+++ b/examples/webhooks/go/go.mod
@@ -2,4 +2,4 @@ module webhooks
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.6.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.7.0

--- a/examples/webhooks/java/pom.xml
+++ b/examples/webhooks/java/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.7.0</version>
+            <version>6.0.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/webhooks/python/requirements.txt
+++ b/examples/webhooks/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=6.6.0
+axonflow>=6.7.0

--- a/examples/webhooks/typescript/package.json
+++ b/examples/webhooks/typescript/package.json
@@ -7,7 +7,7 @@
     "start": "npx ts-node src/index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.6.0",
+    "@axonflow/sdk": "^6.0.0",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.0"
   }

--- a/examples/workflow-control/go/go.mod
+++ b/examples/workflow-control/go/go.mod
@@ -2,4 +2,4 @@ module workflow-control
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.6.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.7.0

--- a/examples/workflow-control/java/pom.xml
+++ b/examples/workflow-control/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.7.0</version>
+            <version>6.0.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/workflow-control/python/requirements.txt
+++ b/examples/workflow-control/python/requirements.txt
@@ -1,3 +1,3 @@
-axonflow>=6.6.0
+axonflow>=6.7.0
 python-dotenv>=1.0.0
 langgraph>=0.2.0

--- a/examples/workflow-control/typescript/package.json
+++ b/examples/workflow-control/typescript/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.6.0",
+    "@axonflow/sdk": "^6.0.0",
     "dotenv": "^16.3.1"
   },
   "devDependencies": {

--- a/examples/workflow-fail/go/go.mod
+++ b/examples/workflow-fail/go/go.mod
@@ -2,4 +2,4 @@ module workflow-fail
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.6.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.7.0

--- a/examples/workflow-fail/java/pom.xml
+++ b/examples/workflow-fail/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.7.0</version>
+            <version>6.0.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/workflow-fail/python/requirements.txt
+++ b/examples/workflow-fail/python/requirements.txt
@@ -1,2 +1,2 @@
-axonflow>=6.6.0
+axonflow>=6.7.0
 python-dotenv>=1.0.0

--- a/examples/workflow-fail/typescript/package.json
+++ b/examples/workflow-fail/typescript/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.6.0",
+    "@axonflow/sdk": "^6.0.0",
     "dotenv": "^16.3.1"
   },
   "devDependencies": {

--- a/examples/workflow-policy/go/go.mod
+++ b/examples/workflow-policy/go/go.mod
@@ -2,4 +2,4 @@ module workflow-policy-example
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.6.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.7.0

--- a/examples/workflow-policy/java/pom.xml
+++ b/examples/workflow-policy/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.7.0</version>
+            <version>6.0.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/workflow-policy/python/requirements.txt
+++ b/examples/workflow-policy/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=6.6.0
+axonflow>=6.7.0

--- a/examples/workflow-policy/typescript/package.json
+++ b/examples/workflow-policy/typescript/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.6.0"
+    "@axonflow/sdk": "^6.0.0"
   },
   "devDependencies": {
     "tsx": "^4.0.0",

--- a/examples/workflows/01-simple-sequential/go.mod
+++ b/examples/workflows/01-simple-sequential/go.mod
@@ -2,4 +2,4 @@ module github.com/getaxonflow/axonflow/examples/workflows/01-simple-sequential
 
 go 1.23
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.6.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.7.0

--- a/examples/workflows/01-simple-sequential/package.json
+++ b/examples/workflows/01-simple-sequential/package.json
@@ -7,7 +7,7 @@
     "start": "npx ts-node main.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.6.0"
+    "@axonflow/sdk": "^6.0.0"
   },
   "devDependencies": {
     "ts-node": "^10.9.2",

--- a/examples/workflows/01-simple-sequential/pom.xml
+++ b/examples/workflows/01-simple-sequential/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.7.0</version>
+            <version>6.0.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/workflows/01-simple-sequential/requirements.txt
+++ b/examples/workflows/01-simple-sequential/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=6.6.0
+axonflow>=6.7.0

--- a/examples/workflows/02-parallel-execution/go.mod
+++ b/examples/workflows/02-parallel-execution/go.mod
@@ -2,4 +2,4 @@ module github.com/getaxonflow/axonflow/examples/workflows/02-parallel-execution
 
 go 1.23
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.6.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.7.0

--- a/examples/workflows/02-parallel-execution/package.json
+++ b/examples/workflows/02-parallel-execution/package.json
@@ -7,7 +7,7 @@
     "start": "npx ts-node main.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.6.0"
+    "@axonflow/sdk": "^6.0.0"
   },
   "devDependencies": {
     "ts-node": "^10.9.2",

--- a/examples/workflows/02-parallel-execution/pom.xml
+++ b/examples/workflows/02-parallel-execution/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.7.0</version>
+            <version>6.0.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/workflows/02-parallel-execution/requirements.txt
+++ b/examples/workflows/02-parallel-execution/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=6.6.0
+axonflow>=6.7.0

--- a/examples/workflows/03-conditional-logic/go.mod
+++ b/examples/workflows/03-conditional-logic/go.mod
@@ -2,4 +2,4 @@ module github.com/getaxonflow/axonflow/examples/workflows/03-conditional-logic
 
 go 1.23
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.6.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.7.0

--- a/examples/workflows/03-conditional-logic/package.json
+++ b/examples/workflows/03-conditional-logic/package.json
@@ -7,7 +7,7 @@
     "start": "npx ts-node main.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.6.0"
+    "@axonflow/sdk": "^6.0.0"
   },
   "devDependencies": {
     "ts-node": "^10.9.2",

--- a/examples/workflows/03-conditional-logic/pom.xml
+++ b/examples/workflows/03-conditional-logic/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.7.0</version>
+            <version>6.0.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/workflows/03-conditional-logic/requirements.txt
+++ b/examples/workflows/03-conditional-logic/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=6.6.0
+axonflow>=6.7.0

--- a/examples/workflows/04-travel-booking-fallbacks/go.mod
+++ b/examples/workflows/04-travel-booking-fallbacks/go.mod
@@ -2,4 +2,4 @@ module github.com/getaxonflow/axonflow/examples/workflows/04-travel-booking-fall
 
 go 1.23
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.6.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.7.0

--- a/examples/workflows/04-travel-booking-fallbacks/package.json
+++ b/examples/workflows/04-travel-booking-fallbacks/package.json
@@ -7,7 +7,7 @@
     "start": "npx ts-node main.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.6.0"
+    "@axonflow/sdk": "^6.0.0"
   },
   "devDependencies": {
     "ts-node": "^10.9.2",

--- a/examples/workflows/04-travel-booking-fallbacks/pom.xml
+++ b/examples/workflows/04-travel-booking-fallbacks/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.7.0</version>
+            <version>6.0.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/workflows/04-travel-booking-fallbacks/requirements.txt
+++ b/examples/workflows/04-travel-booking-fallbacks/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=6.6.0
+axonflow>=6.7.0

--- a/examples/workflows/05-data-pipeline/go.mod
+++ b/examples/workflows/05-data-pipeline/go.mod
@@ -2,4 +2,4 @@ module github.com/getaxonflow/axonflow/examples/workflows/05-data-pipeline
 
 go 1.23
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.6.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.7.0

--- a/examples/workflows/05-data-pipeline/package.json
+++ b/examples/workflows/05-data-pipeline/package.json
@@ -7,7 +7,7 @@
     "start": "npx ts-node main.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.6.0"
+    "@axonflow/sdk": "^6.0.0"
   },
   "devDependencies": {
     "ts-node": "^10.9.2",

--- a/examples/workflows/05-data-pipeline/pom.xml
+++ b/examples/workflows/05-data-pipeline/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.7.0</version>
+            <version>6.0.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/workflows/05-data-pipeline/requirements.txt
+++ b/examples/workflows/05-data-pipeline/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=6.6.0
+axonflow>=6.7.0

--- a/examples/workflows/06-multi-step-approval/go.mod
+++ b/examples/workflows/06-multi-step-approval/go.mod
@@ -2,4 +2,4 @@ module github.com/getaxonflow/axonflow/examples/workflows/06-multi-step-approval
 
 go 1.23
 
-require github.com/getaxonflow/axonflow-sdk-go/v5 v5.6.0
+require github.com/getaxonflow/axonflow-sdk-go/v5 v5.7.0

--- a/examples/workflows/06-multi-step-approval/package.json
+++ b/examples/workflows/06-multi-step-approval/package.json
@@ -7,7 +7,7 @@
     "start": "npx ts-node main.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^5.6.0"
+    "@axonflow/sdk": "^6.0.0"
   },
   "devDependencies": {
     "ts-node": "^10.9.2",

--- a/examples/workflows/06-multi-step-approval/pom.xml
+++ b/examples/workflows/06-multi-step-approval/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>5.7.0</version>
+            <version>6.0.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/workflows/06-multi-step-approval/requirements.txt
+++ b/examples/workflows/06-multi-step-approval/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=6.6.0
+axonflow>=6.7.0

--- a/platform/agent/Dockerfile
+++ b/platform/agent/Dockerfile
@@ -125,7 +125,7 @@ RUN set -e && \
 # Final stage - minimal runtime image
 FROM alpine:3.23
 
-ARG AXONFLOW_VERSION=7.4.2
+ARG AXONFLOW_VERSION=7.4.3
 ENV AXONFLOW_VERSION=${AXONFLOW_VERSION}
 
 # AWS Marketplace metadata

--- a/platform/orchestrator/Dockerfile
+++ b/platform/orchestrator/Dockerfile
@@ -136,7 +136,7 @@ RUN set -e && \
 # Final stage - minimal runtime image
 FROM alpine:3.23
 
-ARG AXONFLOW_VERSION=7.4.2
+ARG AXONFLOW_VERSION=7.4.3
 ENV AXONFLOW_VERSION=${AXONFLOW_VERSION}
 
 # AWS Marketplace metadata


### PR DESCRIPTION
## Summary

Sync of platform v7.4.3 (documentation-grade — no platform behaviour change) bundled with the SDK example pin bumps from the v7.4.2 release train that hadn't synced yet.

### Platform v7.4.3 — Plugin Batch 1 / ADR-043 spec corrections

Two MCP-response schemas were stale relative to what the agent has emitted since Plugin Batch 1 / ADR-042 / ADR-043 shipped. AxonFlow's hand-written plugins (OpenClaw, Claude Code, Cursor, Codex) are already aligned with what the agent emits; this just documents the wire contract for code-generated clients and auto-resolves baseline drift entries on every AxonFlow plugin's wire-shape contract gate.

- **\`MCPCheckInputResponse\`** gains 5 fields (\`decision_id\`, \`risk_level\`, \`policy_matches\`, \`override_available\`, \`override_existing_id\`).
- **\`MCPCheckOutputResponse\`** gains \`redacted_message\` (text-redaction counterpart to \`redacted_data\`), \`decision_id\`, \`policy_matches\`.
- **\`ExplainPolicy\`** / **\`ExplainRule\`** / **\`DecisionExplanation\`** — new schemas for the ADR-043 explainability shapes returned by the \`explain_decision\` MCP tool.

Default platform version bumped 7.4.2 → 7.4.3.

### SDK example pin bumps (from prior release train)

Bulk pin updates across 200+ example dirs:
- TypeScript: \`^5.5.0\` / \`^5.6.0\` → \`^6.0.0\`
- Python: \`>=4.3.0\` / \`>=6.5.0\` / \`>=6.6.0\` → \`>=6.7.0\`
- Go: \`v5.5.0\` / \`v5.6.0\` → \`v5.7.0\`
- Java: \`5.6.0\` / \`5.7.0\` → \`6.0.0\`

Breaking-change safety verified by grep: zero example imports of renamed \`PolicyInfo\` / \`MCPPolicyInfo\` types, zero \`WebhookSubscription\` equality/Set/Map usage.

## Test plan

- [ ] CHANGELOG renders the v7.4.3 section correctly
- [ ] \`docs/api/agent-api.yaml\` validates as OpenAPI 3.0 with the new schemas
- [ ] Sample example builds: \`cd examples/audit-logging/go && go build ./...\`
- [ ] Sample example installs: \`cd examples/audit-logging/typescript && npm install --dry-run\`