### PR TITLE
fix(v7.4.4): CreateOverrideResponse schema split

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ community mirror, **Enterprise** changes are EE-only.
 
 ## [Unreleased]
 
+## [7.4.4] - 2026-04-25 — `CreateOverrideResponse` schema split
+
+PATCH: documentation-grade correction — no platform behaviour change. Splits the `POST /api/v1/policies/{id}/overrides` create-response shape from the at-rest `PolicyOverride` entity, matching what the platform server has been emitting all along and the precedent established by `CreateWorkflowResponse` (orchestrator-api.yaml). Code-generated clients written against the prior spec would have read `undefined` for the create-time TTL clamping fields (`ttl_seconds`, `requested_ttl`, `clamped`, `clamped_reason`) and looked for at-rest fields (`action_override`, `enabled_override`, `tool_signature`) that the create response doesn't carry.
+
+### Community
+
+#### Fixed
+
+- **`CreateOverrideResponse` schema added** to `docs/api/agent-api.yaml`. The `createStaticPolicyOverride: 201` response now references this dedicated schema instead of the at-rest `PolicyOverride`. Carries `id`, `policy_id`, `policy_type`, `expires_at`, `ttl_seconds`, optional `requested_ttl` / `clamped` / `clamped_reason` (populated when server-side TTL clamping kicked in), and `created_at`. The at-rest `PolicyOverride` schema retains its role on `GET /api/v1/policy-overrides` / `GET /api/v1/policy-overrides/{id}`. Source of truth: `platform/orchestrator/overrides_handler.go` (`CreateOverrideResponse`).
+
+  AxonFlow's hand-written OpenClaw plugin already implements `CreateOverrideResult` matching the actual server shape — this fix aligns the spec with the plugin's reality and unblocks code-generated clients. Surfaced via the OpenClaw plugin's wire-shape contract gate (axonflow-openclaw-plugin#57).
+
 ## [7.4.3] - 2026-04-25 — Plugin Batch 1 / ADR-043 spec corrections
 
 PATCH: documentation-grade corrections — no platform behaviour change. Companion to the 4 plugin wire-shape contract gates landing alongside (parity with the four SDK gates per ADR-047). Auto-resolves the bulk of those plugins' initial baseline drift entries.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,7 +87,7 @@ services:
       DEPLOYMENT_MODE: ${DEPLOYMENT_MODE:-community}
       AXONFLOW_INTEGRATIONS: ${AXONFLOW_INTEGRATIONS:-}
       AXONFLOW_LICENSE_KEY: ${AXONFLOW_LICENSE_KEY:-}
-      AXONFLOW_VERSION: "${AXONFLOW_VERSION:-7.4.3}"
+      AXONFLOW_VERSION: "${AXONFLOW_VERSION:-7.4.4}"
 
       # Media governance (v4.5.0+) - set to "true" to enable in Community mode
       MEDIA_GOVERNANCE_ENABLED: ${MEDIA_GOVERNANCE_ENABLED:-}
@@ -223,7 +223,7 @@ services:
       PORT: 8081
       DEPLOYMENT_MODE: ${DEPLOYMENT_MODE:-community}
       AXONFLOW_LICENSE_KEY: ${AXONFLOW_LICENSE_KEY:-}
-      AXONFLOW_VERSION: "${AXONFLOW_VERSION:-7.4.3}"
+      AXONFLOW_VERSION: "${AXONFLOW_VERSION:-7.4.4}"
 
       # HITL mode (Evaluation+) — set to "true" to enable the HITL workflow
       # engine backing WCP /steps/{step_id}/approve|reject, MAP plan-scoped

--- a/docs/api/agent-api.yaml
+++ b/docs/api/agent-api.yaml
@@ -2782,11 +2782,18 @@ paths:
                   override_reason: "Regulatory requirement to warn instead of block"
       responses:
         '201':
-          description: Override created successfully
+          description: |
+            Override created successfully. Returns `CreateOverrideResponse`
+            with the effective `ttl_seconds` (post server-side clamping)
+            and, when applicable, the `requested_ttl` / `clamped` /
+            `clamped_reason` metadata so callers can surface clamping
+            decisions in their UX. The at-rest `PolicyOverride` entity
+            is returned by `GET /api/v1/policy-overrides` /
+            `GET /api/v1/policy-overrides/{id}`.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PolicyOverride'
+                $ref: '#/components/schemas/CreateOverrideResponse'
         '400':
           description: Invalid request body or missing required fields
           content:
@@ -3217,6 +3224,68 @@ components:
           type: string
           format: date-time
           description: Optional expiration for the override
+
+    CreateOverrideResponse:
+      type: object
+      description: |
+        Response returned by `POST /api/v1/policies/{id}/overrides` on
+        successful create. Carries the create-time-only TTL clamping
+        metadata (`requested_ttl`, `clamped`, `clamped_reason`) that
+        is not present on the at-rest `PolicyOverride` entity returned
+        by `GET /api/v1/policy-overrides` / `GET /api/v1/policy-overrides/{id}`.
+        Source of truth: `platform/orchestrator/overrides_handler.go`
+        (`CreateOverrideResponse`). Mirrors the `CreateWorkflowResponse`
+        precedent (orchestrator-api.yaml) — create-time concerns split
+        from at-rest concerns rather than overloaded onto one schema.
+      required:
+        - id
+        - policy_id
+        - policy_type
+        - expires_at
+        - ttl_seconds
+        - created_at
+      properties:
+        id:
+          type: string
+          description: Unique override identifier
+        policy_id:
+          type: string
+          description: ID of the policy being overridden
+        policy_type:
+          type: string
+          enum: [static, dynamic]
+          description: Type of policy being overridden
+        expires_at:
+          type: string
+          format: date-time
+          description: Override expiration timestamp (clamped server-side per ADR-044)
+        ttl_seconds:
+          type: integer
+          format: int64
+          description: |
+            Effective time-to-live in seconds, after server-side clamping.
+            Default 60m, hard cap 24h, minimum 60s.
+        requested_ttl:
+          type: integer
+          format: int64
+          description: |
+            The TTL the caller originally requested, included only when it
+            differs from `ttl_seconds` (i.e. when `clamped: true`). Lets
+            callers detect and surface clamping in their UX.
+        clamped:
+          type: boolean
+          description: |
+            `true` if the requested TTL was adjusted by server-side
+            clamping. Omitted when no clamping occurred.
+        clamped_reason:
+          type: string
+          enum: [exceeds_hard_cap, below_minimum]
+          description: |
+            Why the TTL was clamped. Present only when `clamped: true`.
+        created_at:
+          type: string
+          format: date-time
+          description: When the override was created.
 
     TestPatternRequest:
       type: object

--- a/platform/agent/Dockerfile
+++ b/platform/agent/Dockerfile
@@ -125,7 +125,7 @@ RUN set -e && \
 # Final stage - minimal runtime image
 FROM alpine:3.23
 
-ARG AXONFLOW_VERSION=7.4.3
+ARG AXONFLOW_VERSION=7.4.4
 ENV AXONFLOW_VERSION=${AXONFLOW_VERSION}
 
 # AWS Marketplace metadata

--- a/platform/orchestrator/Dockerfile
+++ b/platform/orchestrator/Dockerfile
@@ -136,7 +136,7 @@ RUN set -e && \
 # Final stage - minimal runtime image
 FROM alpine:3.23
 
-ARG AXONFLOW_VERSION=7.4.3
+ARG AXONFLOW_VERSION=7.4.4
 ENV AXONFLOW_VERSION=${AXONFLOW_VERSION}
 
 # AWS Marketplace metadata


### PR DESCRIPTION
## Summary

Sync of platform v7.4.4 — documentation-grade OpenAPI correction, no platform behaviour change.

Splits the \`POST /api/v1/policies/{id}/overrides\` create-response shape from the at-rest \`PolicyOverride\` entity, matching what the platform server has been emitting all along (\`platform/orchestrator/overrides_handler.go::CreateOverrideResponse\`). Mirrors the \`CreateWorkflowResponse\` precedent (orchestrator-api.yaml) — create-time concerns (TTL clamping metadata) split from at-rest concerns rather than overloaded onto one schema.

### Changes

- New \`CreateOverrideResponse\` schema in \`docs/api/agent-api.yaml\` carrying the create-time fields: \`id\`, \`policy_id\`, \`policy_type\`, \`expires_at\`, \`ttl_seconds\`, optional \`requested_ttl\` / \`clamped\` / \`clamped_reason\`, \`created_at\`.
- \`createStaticPolicyOverride: 201\` response retargeted to \`CreateOverrideResponse\`.
- \`PolicyOverride\` retains its at-rest role on \`GET /api/v1/policy-overrides\` / \`GET /api/v1/policy-overrides/{id}\`.

### Why

Code-generated clients written against the prior spec would have read \`undefined\` for the create-time TTL clamping fields and looked for at-rest fields (\`action_override\`, \`enabled_override\`, \`tool_signature\`) that the create response doesn't carry. Hand-written clients (the OpenClaw plugin) already match the actual server shape — this fix aligns the spec with reality.

Default platform version bumped 7.4.3 → 7.4.4.

## Test plan

- [ ] CHANGELOG renders the v7.4.4 section correctly
- [ ] \`docs/api/agent-api.yaml\` validates as OpenAPI 3.0 with the new schema
- [ ] \`createStaticPolicyOverride: 201\` references \`CreateOverrideResponse\` (not \`PolicyOverride\`)
- [ ] \`PolicyOverride\` still referenced by \`GET\` endpoints (unchanged)