### PR TITLE
fix(orchestrator): /health compat parity + readme upgrade banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ It operates inside the execution path between your workflow logic and model or t
 
 It runs self-hosted (Docker or Kubernetes), with SDKs for **Python**, **TypeScript**, **Go**, and **Java**.
 
+> **Upgrade strongly recommended.** AxonFlow ships substantial monthly security and quality hardening; staying on the latest major is the security-supported release line. [Latest release](https://github.com/getaxonflow/axonflow/releases/latest) · [Security advisories](https://github.com/getaxonflow/axonflow/security/advisories)
+
 ## Why AxonFlow Exists
 
 Production AI systems are multi-step, non-deterministic, and increasingly regulated. In practice:

--- a/platform/orchestrator/capabilities.go
+++ b/platform/orchestrator/capabilities.go
@@ -21,6 +21,21 @@ type SDKCompatInfo struct {
 	RecommendedSDKVersion map[string]string `json:"recommended_sdk_version"`
 }
 
+// PluginCompatInfo describes plugin version compatibility for this platform
+// version. Mirrors SDKCompatInfo + the agent-side getPluginCompatibility()
+// so /health on both ports (agent 8080 and orchestrator 8081) returns the
+// same downgrade-warning gate to plugin clients.
+//
+// Keys are the canonical plugin IDs:
+//   - openclaw     — npm @axonflow/openclaw
+//   - claude-code  — Claude Code IDE plugin
+//   - cursor       — Cursor IDE plugin
+//   - codex        — Codex CLI plugin
+type PluginCompatInfo struct {
+	MinPluginVersion         map[string]string `json:"min_plugin_version"`
+	RecommendedPluginVersion map[string]string `json:"recommended_plugin_version"`
+}
+
 var orchVersionRegex = regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$`)
 
 // getPlatformVersion returns the platform version from the AXONFLOW_VERSION env var.
@@ -55,17 +70,52 @@ func getCapabilities() []PlatformCapability {
 
 func getSDKCompatibility() SDKCompatInfo {
 	return SDKCompatInfo{
+		// Floor of the current major line. SDKs below 7.0.0 ran the
+		// pre-DNT-removal opt-out contract; bumping the floor signals
+		// to those callers that they should upgrade to keep their
+		// telemetry opt-out (and assorted v6.x→v7.x cleanups) honored.
+		// Kept in lockstep with platform/agent/capabilities.go so /health
+		// on agent (8080) and orchestrator (8081) report identical pins.
 		MinSDKVersion: map[string]string{
-			"python":     "3.0.0",
-			"typescript": "3.0.0",
-			"go":         "3.0.0",
-			"java":       "3.0.0",
+			"python":     "7.0.0",
+			"typescript": "7.0.0",
+			"go":         "7.0.0",
+			"java":       "7.0.0",
 		},
+		// Latest tag this platform was tested against. Kept in lockstep
+		// with each SDK's release-train tag.
 		RecommendedSDKVersion: map[string]string{
-			"python":     "6.9.0",
-			"typescript": "6.2.0",
-			"go":         "6.0.0",
-			"java":       "6.2.0",
+			"python":     "7.0.0",
+			"typescript": "7.0.0",
+			"go":         "7.0.0",
+			"java":       "7.0.0",
+		},
+	}
+}
+
+// getPluginCompatibility reports the min and recommended plugin versions for
+// every plugin the platform speaks to. Mirrors platform/agent/capabilities.go
+// so /health on both ports surfaces the same downgrade-warning gate.
+func getPluginCompatibility() PluginCompatInfo {
+	return PluginCompatInfo{
+		// Floor of each plugin's current major line. OpenClaw graduated
+		// from the v1.x line to v2.0.0 alongside the SDK v7.0.0 cycle;
+		// the three CLI plugins (Claude / Cursor / Codex) graduated
+		// from 0.x to 1.0.0 in the same release train. Plugins below
+		// these floors ran the pre-DNT-removal contract.
+		MinPluginVersion: map[string]string{
+			"openclaw":    "2.0.0",
+			"claude-code": "1.0.0",
+			"cursor":      "1.0.0",
+			"codex":       "1.0.0",
+		},
+		// Latest tag this platform was tested against. Kept in lockstep
+		// with each plugin's release-train tag.
+		RecommendedPluginVersion: map[string]string{
+			"openclaw":    "2.0.0",
+			"claude-code": "1.0.0",
+			"cursor":      "1.0.0",
+			"codex":       "1.0.0",
 		},
 	}
 }

--- a/platform/orchestrator/capabilities_test.go
+++ b/platform/orchestrator/capabilities_test.go
@@ -1,0 +1,86 @@
+// Copyright 2026 AxonFlow
+// SPDX-License-Identifier: BUSL-1.1
+
+package orchestrator
+
+import (
+	"testing"
+)
+
+// TestSDKCompatibilityPinnedToReleaseTrain pins the orchestrator's SDK
+// version compat block to the v7.0.0 release train. This regresses on the
+// drift that left orchestrator's /health reporting last-cycle pins
+// (v6.x.x recommended, 3.0.0 floor) while the agent's /health correctly
+// reported v7.0.0 — operators hitting orchestrator /health for diagnostics
+// would see inconsistent guidance versus the agent surface.
+//
+// Update both files in lockstep on the next release train; this test
+// failing is the loud reminder that they have to move together.
+func TestSDKCompatibilityPinnedToReleaseTrain(t *testing.T) {
+	c := getSDKCompatibility()
+
+	wantMin := map[string]string{
+		"python":     "7.0.0",
+		"typescript": "7.0.0",
+		"go":         "7.0.0",
+		"java":       "7.0.0",
+	}
+	wantRecommended := map[string]string{
+		"python":     "7.0.0",
+		"typescript": "7.0.0",
+		"go":         "7.0.0",
+		"java":       "7.0.0",
+	}
+
+	for lang, want := range wantMin {
+		if got := c.MinSDKVersion[lang]; got != want {
+			t.Errorf("MinSDKVersion[%q] = %q; want %q", lang, got, want)
+		}
+	}
+	for lang, want := range wantRecommended {
+		if got := c.RecommendedSDKVersion[lang]; got != want {
+			t.Errorf("RecommendedSDKVersion[%q] = %q; want %q", lang, got, want)
+		}
+	}
+	if len(c.MinSDKVersion) != 4 || len(c.RecommendedSDKVersion) != 4 {
+		t.Errorf("expected 4 SDKs, got Min=%d Recommended=%d",
+			len(c.MinSDKVersion), len(c.RecommendedSDKVersion))
+	}
+}
+
+// TestPluginCompatibilityPinnedToReleaseTrain pins the orchestrator's
+// plugin compat block to the same release-train values the agent's
+// PluginCompatInfo carries. The block was missing entirely before the
+// orchestrator-vs-agent compat-drift fix; this test prevents regression
+// to the empty / missing state.
+func TestPluginCompatibilityPinnedToReleaseTrain(t *testing.T) {
+	c := getPluginCompatibility()
+
+	wantMin := map[string]string{
+		"openclaw":    "2.0.0",
+		"claude-code": "1.0.0",
+		"cursor":      "1.0.0",
+		"codex":       "1.0.0",
+	}
+	wantRecommended := map[string]string{
+		"openclaw":    "2.0.0",
+		"claude-code": "1.0.0",
+		"cursor":      "1.0.0",
+		"codex":       "1.0.0",
+	}
+
+	for id, want := range wantMin {
+		if got := c.MinPluginVersion[id]; got != want {
+			t.Errorf("MinPluginVersion[%q] = %q; want %q", id, got, want)
+		}
+	}
+	for id, want := range wantRecommended {
+		if got := c.RecommendedPluginVersion[id]; got != want {
+			t.Errorf("RecommendedPluginVersion[%q] = %q; want %q", id, got, want)
+		}
+	}
+	if len(c.MinPluginVersion) != 4 || len(c.RecommendedPluginVersion) != 4 {
+		t.Errorf("expected 4 plugins, got Min=%d Recommended=%d",
+			len(c.MinPluginVersion), len(c.RecommendedPluginVersion))
+	}
+}

--- a/platform/orchestrator/run.go
+++ b/platform/orchestrator/run.go
@@ -1563,8 +1563,9 @@ func healthHandler(w http.ResponseWriter, r *http.Request) {
 		"version":           getPlatformVersion(),
 		"timestamp":         time.Now().UTC(),
 		"components":        components,
-		"capabilities":      getCapabilities(),
-		"sdk_compatibility": getSDKCompatibility(),
+		"capabilities":         getCapabilities(),
+		"sdk_compatibility":    getSDKCompatibility(),
+		"plugin_compatibility": getPluginCompatibility(),
 		"features": map[string]bool{
 			"multi_agent_planning": planningEngine != nil && resultAggregator != nil,
 			"sebi_compliance":      sebiModule != nil && sebiModule.IsHealthy(),


### PR DESCRIPTION
fix(orchestrator): /health compat parity + readme upgrade banner

Two small platform-side cleanups landed after the v7.5.0 sync:

- Orchestrator's /health (port 8081) now reports the same SDK and plugin
  compatibility pins the agent's /health (port 8080) reports. SDK floor
  bumped to 7.0.0 across all four SDKs; plugin compatibility map added
  with openclaw 2.0.0 and the three CLI plugins (claude-code, cursor,
  codex) at 1.0.0. Operators hitting orchestrator /health for diagnostics
  no longer see last-cycle SDK pins or a missing plugin compat block.

- README gains a one-line evergreen upgrade-recommended banner near the
  top, between the intro and the first ## section. Wording avoids
  version numbers; the two links resolve to canonical surfaces that
  always reflect current state (latest release tag + security advisories).