### PR TITLE
refactor(v1-pro): route MCP tools via service layers

### DIFF
--- a/platform/agent/hitl/handler.go
+++ b/platform/agent/hitl/handler.go
@@ -219,9 +219,15 @@ func (h *Handler) CreateRequest(w http.ResponseWriter, r *http.Request) {
 	req, err := h.service.CreateApprovalRequest(r.Context(), createInput)
 	if err != nil {
 		hitlRequestsTotal.WithLabelValues("POST", "/api/v1/hitl/queue", "error").Inc()
-		if errors.Is(err, ErrPendingApprovalLimitExceeded) {
+		switch {
+		case errors.Is(err, ErrHITLApprovalDisabledByTier):
+			// 403 Forbidden — tier gate; the request shape is fine, the
+			// running license tier is what's denying it. Surfaces a clear
+			// upgrade pointer in the body.
+			h.writeError(w, http.StatusForbidden, err.Error())
+		case errors.Is(err, ErrPendingApprovalLimitExceeded):
 			h.writeError(w, http.StatusTooManyRequests, err.Error())
-		} else {
+		default:
 			h.writeError(w, http.StatusBadRequest, err.Error())
 		}
 		return

--- a/platform/agent/hitl/handler_test.go
+++ b/platform/agent/hitl/handler_test.go
@@ -9,18 +9,35 @@ package hitl
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
+
+	"axonflow/platform/agent/license"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 )
 
+// setupTestHandler builds a handler whose Service has the tier provider
+// pinned to Evaluation. Existing handler tests assume the request flow
+// reaches the DB layer; the tier gate added in #1998 would otherwise
+// short-circuit them at 403. Tests that specifically exercise the
+// Community-tier rejection path call setupTestHandlerCommunityTier.
 func setupTestHandler(t *testing.T) (*Handler, sqlmock.Sqlmock, func()) {
+	return setupTestHandlerWithTier(t, license.TierEvaluation)
+}
+
+func setupTestHandlerCommunityTier(t *testing.T) (*Handler, sqlmock.Sqlmock, func()) {
+	return setupTestHandlerWithTier(t, license.TierCommunity)
+}
+
+func setupTestHandlerWithTier(t *testing.T, tier license.Tier) (*Handler, sqlmock.Sqlmock, func()) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("Failed to create sqlmock: %v", err)
@@ -31,6 +48,7 @@ func setupTestHandler(t *testing.T) (*Handler, sqlmock.Sqlmock, func()) {
 		DefaultExpiry: 24 * time.Hour,
 		MaxExpiry:     168 * time.Hour,
 	})
+	svc.SetTierProviderForTest(func(_ context.Context) license.Tier { return tier })
 	handler := NewHandler(svc)
 
 	cleanup := func() {
@@ -147,6 +165,65 @@ func TestCreateRequest_Success(t *testing.T) {
 
 	if !resp.Success {
 		t.Errorf("Expected success=true, got false: %s", resp.Error)
+	}
+}
+
+// TestCreateRequest_CommunityTierForbidden asserts that a Community-tier
+// process returns 403 Forbidden with the tier-rejection error wording.
+// Added in #1998 to close the parallel bypass on the agent's
+// `POST /api/v1/hitl/queue` endpoint (Fix B).
+func TestCreateRequest_CommunityTierForbidden(t *testing.T) {
+	handler, mock, cleanup := setupTestHandlerCommunityTier(t)
+	defer cleanup()
+
+	// No DB mock expectations registered: if the handler short-circuits
+	// at the tier gate (correct behavior), no DB query fires. Any query
+	// that fires will be flagged by sqlmock.
+
+	input := CreateRequestInput{
+		ClientID:            "client-1",
+		OriginalQuery:       "rm -rf /",
+		RequestType:         "shell_command",
+		TriggeredPolicyID:   "policy-1",
+		TriggeredPolicyName: "Destructive command",
+		TriggerReason:       "deletion attempt",
+		Severity:            "high",
+	}
+	body, _ := json.Marshal(input)
+
+	req := httptest.NewRequest("POST", "/api/v1/hitl/queue", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Org-ID", "org-1")
+	req.Header.Set("X-Tenant-ID", "tenant-1")
+	w := httptest.NewRecorder()
+
+	router := mux.NewRouter()
+	handler.RegisterRoutes(router)
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("Expected status 403, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp APIResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+	if resp.Success {
+		t.Error("Expected success=false")
+	}
+	if resp.Error == "" {
+		t.Error("Expected non-empty error message")
+	}
+	// The error body must surface the upgrade hint so the caller can
+	// tell the user how to unblock — guards against a future refactor
+	// that swallows the message.
+	if !strings.Contains(resp.Error, "Evaluation") {
+		t.Errorf("Expected error to mention 'Evaluation' license tier, got: %q", resp.Error)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("DB query fired despite tier-gate rejection: %v", err)
 	}
 }
 

--- a/platform/agent/hitl/hitl_community.go
+++ b/platform/agent/hitl/hitl_community.go
@@ -18,11 +18,27 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 )
+
+// ErrHITLApprovalDisabledByTier is the sentinel returned by community
+// builds whenever an in-process caller (such as the V1 Plugin Pro MCP
+// tool `axonflow_request_approval`) tries to create an approval. The
+// agent's community build doesn't ship the HITL queue at all — every
+// caller is rejected at this gate so the same error can be translated
+// to user-facing wording at the call site, identical to the
+// enterprise-build's tier rejection on Community-tier processes.
+var ErrHITLApprovalDisabledByTier = errors.New("HITL approvals require an Evaluation or higher license tier; current tier is Community")
+
+// ErrPendingApprovalLimitExceeded is exposed for symbol parity with the
+// enterprise build. Community build never returns it because no rows
+// can be created in the first place.
+var ErrPendingApprovalLimitExceeded = errors.New("pending approval limit exceeded")
 
 // Handler provides HTTP handlers for HITL queue operations.
 // Community Edition: No-op implementation.
@@ -83,4 +99,60 @@ func (s *Service) ExpireStaleRequests(ctx context.Context) (int, error) {
 // Community Edition: Returns a no-op repository.
 func NewRepository(db *sql.DB) *Repository {
 	return &Repository{}
+}
+
+// CreateApprovalInput is the input shape for Service.CreateApprovalRequest.
+// Mirrors the enterprise-build struct field-for-field so callers in
+// agent/mcp_v1_pro_tools.go (no build tag) compile under both builds.
+type CreateApprovalInput struct {
+	OrgID               string
+	TenantID            string
+	ClientID            string
+	UserID              string
+	OriginalQuery       string
+	RequestType         string
+	RequestContext      map[string]interface{}
+	TriggeredPolicyID   string
+	TriggeredPolicyName string
+	TriggerReason       string
+	Severity            string
+	EUAIActArticle      string
+	ComplianceFramework string
+	RiskClassification  string
+	ExpiresIn           time.Duration
+}
+
+// ApprovalRequest is the return shape for Service.CreateApprovalRequest.
+// Field-for-field match with the enterprise build so call sites in
+// agent/ compile in both. Community build never populates a real one
+// because CreateApprovalRequest always rejects.
+type ApprovalRequest struct {
+	RequestID           uuid.UUID
+	OrgID               string
+	TenantID            string
+	ClientID            string
+	UserID              string
+	OriginalQuery       string
+	RequestType         string
+	RequestContext      map[string]interface{}
+	TriggeredPolicyID   string
+	TriggeredPolicyName string
+	TriggerReason       string
+	Severity            string
+	EUAIActArticle      string
+	ComplianceFramework string
+	RiskClassification  string
+	Status              string
+	ExpiresAt           time.Time
+}
+
+// CreateApprovalRequest is the in-process entry point used by the MCP
+// tool path. Community build always rejects with
+// ErrHITLApprovalDisabledByTier — the call site translates this into a
+// user-visible message pointing at the Evaluation license URL. The
+// enterprise build implementation in service.go enforces the same gate
+// for Community-tier processes plus does the real DB write for
+// Evaluation+ tiers.
+func (s *Service) CreateApprovalRequest(_ context.Context, _ CreateApprovalInput) (*ApprovalRequest, error) {
+	return nil, ErrHITLApprovalDisabledByTier
 }

--- a/platform/agent/hitl/service.go
+++ b/platform/agent/hitl/service.go
@@ -10,11 +10,13 @@ package hitl
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"sync/atomic"
 	"time"
 
+	"axonflow/platform/agent/license"
 	logutil "axonflow/platform/shared/logger"
 
 	"github.com/google/uuid"
@@ -23,12 +25,33 @@ import (
 // ErrPendingApprovalLimitExceeded is returned when the pending approval limit is reached.
 var ErrPendingApprovalLimitExceeded = fmt.Errorf("pending approval limit exceeded")
 
+// ErrHITLApprovalDisabledByTier is returned when the running process is on a
+// tier that does not enable HITL approvals (Community). The platform's tier
+// matrix in `license/tier.go` defines `HITLApprovalEnabled: false` for
+// Community-tier; we surface that as an explicit error so callers (HTTP
+// handlers, in-process callers like the MCP tool path) can map to a clear
+// "requires Evaluation+ license" response.
+//
+// Mirrors the orchestrator's existing WCP HITL gate at
+// `platform/orchestrator/hitl_wcp_community.go` so a self-hosted process
+// blocks user-initiated approvals at every entry point uniformly.
+var ErrHITLApprovalDisabledByTier = errors.New("HITL approvals require an Evaluation or higher license tier; current tier is Community")
+
+// tierProvider lets tests override the tier source. In production this
+// resolves to the binary's effective license tier via
+// `license.GetCurrentTier`. Defaults to that on Service construction.
+type tierProvider func(ctx context.Context) license.Tier
+
 // Service provides business logic for HITL queue operations.
 type Service struct {
 	repo                *Repository
 	defaultExpiry       time.Duration
 	maxExpiry           time.Duration
 	maxPendingApprovals atomic.Int64 // 0 or negative = unlimited
+	// currentTier resolves the running process's tier on every call so the
+	// gate reflects hot-reloaded license state (the license validator caches
+	// internally; tier flips take effect on next call).
+	currentTier tierProvider
 }
 
 // ServiceConfig contains configuration for the HITL service.
@@ -50,9 +73,17 @@ func NewService(repo *Repository, config ServiceConfig) *Service {
 		repo:          repo,
 		defaultExpiry: config.DefaultExpiry,
 		maxExpiry:     config.MaxExpiry,
+		currentTier:   license.GetCurrentTier,
 	}
 	svc.maxPendingApprovals.Store(int64(config.MaxPendingApprovals))
 	return svc
+}
+
+// SetTierProviderForTest overrides the tier source. Test-only; production
+// callers must not invoke this (the default `license.GetCurrentTier` is
+// the production source of truth).
+func (s *Service) SetTierProviderForTest(p tierProvider) {
+	s.currentTier = p
 }
 
 // SetMaxPendingApprovals updates the max pending approvals limit (for hot-reload via license changes).
@@ -114,6 +145,21 @@ func (s *Service) CreateApprovalRequest(ctx context.Context, input CreateApprova
 	}
 	if !validSeverities[input.Severity] {
 		return nil, fmt.Errorf("invalid severity: %s", input.Severity)
+	}
+
+	// License-tier gate. Community-tier processes (no AXONFLOW_LICENSE_KEY,
+	// or invalid/expired license) reject HITL-approval creation here so the
+	// `hitl_approval_queue` row is never written. Mirrors the WCP gate at
+	// `platform/orchestrator/hitl_wcp_community.go` so the same call from
+	// the HTTP handler path AND the in-process MCP-tool path both fail at
+	// this single chokepoint.
+	//
+	// Eval-or-higher tiers fall through to the existing flow.
+	if s.currentTier != nil {
+		tier := s.currentTier(ctx)
+		if !license.IsEvaluationOrHigher(tier) {
+			return nil, ErrHITLApprovalDisabledByTier
+		}
 	}
 
 	// Check pending approval limit per tenant (after validation, before DB writes)

--- a/platform/agent/hitl/service_test.go
+++ b/platform/agent/hitl/service_test.go
@@ -10,12 +10,26 @@ package hitl
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"testing"
 	"time"
+
+	"axonflow/platform/agent/license"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/google/uuid"
 )
+
+// newEvalTierService returns a Service whose tier provider is pinned to
+// Evaluation (tier gate passes). Used by every test in this file that
+// exercises the happy path; tier-gate tests construct the Service
+// directly with the desired tier.
+func newEvalTierService(t *testing.T, repo *Repository, cfg ServiceConfig) *Service {
+	t.Helper()
+	svc := NewService(repo, cfg)
+	svc.SetTierProviderForTest(func(_ context.Context) license.Tier { return license.TierEvaluation })
+	return svc
+}
 
 func TestNewService(t *testing.T) {
 	db, _, err := sqlmock.New()
@@ -27,7 +41,7 @@ func TestNewService(t *testing.T) {
 	repo := NewRepository(db)
 
 	// Test default config
-	svc := NewService(repo, ServiceConfig{})
+	svc := newEvalTierService(t, repo, ServiceConfig{})
 	if svc.defaultExpiry != 24*time.Hour {
 		t.Errorf("Expected default expiry 24h, got %v", svc.defaultExpiry)
 	}
@@ -56,7 +70,7 @@ func TestCreateApprovalRequest_Validation(t *testing.T) {
 	defer db.Close()
 
 	repo := NewRepository(db)
-	svc := NewService(repo, ServiceConfig{})
+	svc := newEvalTierService(t, repo, ServiceConfig{})
 	ctx := context.Background()
 
 	tests := []struct {
@@ -178,7 +192,7 @@ func TestCreateApprovalRequest_Success(t *testing.T) {
 	defer db.Close()
 
 	repo := NewRepository(db)
-	svc := NewService(repo, ServiceConfig{
+	svc := newEvalTierService(t, repo, ServiceConfig{
 		DefaultExpiry: 24 * time.Hour,
 	})
 	ctx := context.Background()
@@ -234,7 +248,7 @@ func TestCreateApprovalRequest_DefaultSeverity(t *testing.T) {
 	defer db.Close()
 
 	repo := NewRepository(db)
-	svc := NewService(repo, ServiceConfig{})
+	svc := newEvalTierService(t, repo, ServiceConfig{})
 	ctx := context.Background()
 
 	// Mock the INSERT query
@@ -277,7 +291,7 @@ func TestCreateApprovalRequest_ExpiryLimiting(t *testing.T) {
 	defer db.Close()
 
 	repo := NewRepository(db)
-	svc := NewService(repo, ServiceConfig{
+	svc := newEvalTierService(t, repo, ServiceConfig{
 		DefaultExpiry: 24 * time.Hour,
 		MaxExpiry:     48 * time.Hour,
 	})
@@ -325,7 +339,7 @@ func TestApproveRequest_InvalidStatus(t *testing.T) {
 	defer db.Close()
 
 	repo := NewRepository(db)
-	svc := NewService(repo, ServiceConfig{})
+	svc := newEvalTierService(t, repo, ServiceConfig{})
 	ctx := context.Background()
 
 	requestID := uuid.New()
@@ -373,7 +387,7 @@ func TestApproveRequest_Expired(t *testing.T) {
 	defer db.Close()
 
 	repo := NewRepository(db)
-	svc := NewService(repo, ServiceConfig{})
+	svc := newEvalTierService(t, repo, ServiceConfig{})
 	ctx := context.Background()
 
 	requestID := uuid.New()
@@ -422,7 +436,7 @@ func TestOverrideRequest_RequiresJustification(t *testing.T) {
 	defer db.Close()
 
 	repo := NewRepository(db)
-	svc := NewService(repo, ServiceConfig{})
+	svc := newEvalTierService(t, repo, ServiceConfig{})
 	ctx := context.Background()
 
 	requestID := uuid.New()
@@ -450,7 +464,7 @@ func TestOverrideRequest_RequiresAuthorizedBy(t *testing.T) {
 	defer db.Close()
 
 	repo := NewRepository(db)
-	svc := NewService(repo, ServiceConfig{})
+	svc := newEvalTierService(t, repo, ServiceConfig{})
 	ctx := context.Background()
 
 	requestID := uuid.New()
@@ -482,7 +496,7 @@ func TestOverrideRequest_Success(t *testing.T) {
 	defer db.Close()
 
 	repo := NewRepository(db)
-	svc := NewService(repo, ServiceConfig{})
+	svc := newEvalTierService(t, repo, ServiceConfig{})
 	ctx := context.Background()
 
 	requestID := uuid.New()
@@ -538,7 +552,7 @@ func TestOverrideRequest_NonPendingStatus(t *testing.T) {
 	defer db.Close()
 
 	repo := NewRepository(db)
-	svc := NewService(repo, ServiceConfig{})
+	svc := newEvalTierService(t, repo, ServiceConfig{})
 	ctx := context.Background()
 
 	requestID := uuid.New()
@@ -586,7 +600,7 @@ func TestRejectRequest_Success(t *testing.T) {
 	defer db.Close()
 
 	repo := NewRepository(db)
-	svc := NewService(repo, ServiceConfig{})
+	svc := newEvalTierService(t, repo, ServiceConfig{})
 	ctx := context.Background()
 
 	requestID := uuid.New()
@@ -642,7 +656,7 @@ func TestRejectRequest_NotFoundService(t *testing.T) {
 	defer db.Close()
 
 	repo := NewRepository(db)
-	svc := NewService(repo, ServiceConfig{})
+	svc := newEvalTierService(t, repo, ServiceConfig{})
 	ctx := context.Background()
 
 	requestID := uuid.New()
@@ -670,7 +684,7 @@ func TestApproveRequest_Success(t *testing.T) {
 	defer db.Close()
 
 	repo := NewRepository(db)
-	svc := NewService(repo, ServiceConfig{})
+	svc := newEvalTierService(t, repo, ServiceConfig{})
 	ctx := context.Background()
 
 	requestID := uuid.New()
@@ -726,7 +740,7 @@ func TestApproveRequest_NotFoundService(t *testing.T) {
 	defer db.Close()
 
 	repo := NewRepository(db)
-	svc := NewService(repo, ServiceConfig{})
+	svc := newEvalTierService(t, repo, ServiceConfig{})
 	ctx := context.Background()
 
 	requestID := uuid.New()
@@ -754,7 +768,7 @@ func TestGetApprovalRequest_NotFound(t *testing.T) {
 	defer db.Close()
 
 	repo := NewRepository(db)
-	svc := NewService(repo, ServiceConfig{})
+	svc := newEvalTierService(t, repo, ServiceConfig{})
 	ctx := context.Background()
 
 	requestID := uuid.New()
@@ -788,7 +802,7 @@ func TestListApprovalRequests(t *testing.T) {
 	defer db.Close()
 
 	repo := NewRepository(db)
-	svc := NewService(repo, ServiceConfig{})
+	svc := newEvalTierService(t, repo, ServiceConfig{})
 	ctx := context.Background()
 
 	mock.ExpectQuery("SELECT COUNT").
@@ -844,7 +858,7 @@ func TestGetPendingStats(t *testing.T) {
 	defer db.Close()
 
 	repo := NewRepository(db)
-	svc := NewService(repo, ServiceConfig{})
+	svc := newEvalTierService(t, repo, ServiceConfig{})
 	ctx := context.Background()
 
 	mock.ExpectQuery("SELECT").
@@ -875,7 +889,7 @@ func TestGetRequestHistoryService(t *testing.T) {
 	defer db.Close()
 
 	repo := NewRepository(db)
-	svc := NewService(repo, ServiceConfig{})
+	svc := newEvalTierService(t, repo, ServiceConfig{})
 	ctx := context.Background()
 
 	requestID := uuid.New()
@@ -916,7 +930,7 @@ func TestExpireStaleRequests(t *testing.T) {
 	defer db.Close()
 
 	repo := NewRepository(db)
-	svc := NewService(repo, ServiceConfig{})
+	svc := newEvalTierService(t, repo, ServiceConfig{})
 	ctx := context.Background()
 
 	mock.ExpectQuery("SELECT expire_hitl_requests").
@@ -935,3 +949,186 @@ func TestExpireStaleRequests(t *testing.T) {
 		t.Errorf("Unfulfilled expectations: %v", err)
 	}
 }
+
+// =============================================================================
+// Tier-gate tests (added in #1998)
+//
+// These tests exercise the license-tier gate added at the top of
+// CreateApprovalRequest. The gate is the single chokepoint that both the
+// HTTP handler path AND the in-process MCP-tool path inherit.
+// =============================================================================
+
+// TestCreateApprovalRequest_CommunityTierRejected asserts that a
+// Community-tier process refuses HITL-approval creation BEFORE any DB
+// write occurs.
+func TestCreateApprovalRequest_CommunityTierRejected(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("Failed to create sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	repo := NewRepository(db)
+	svc := NewService(repo, ServiceConfig{DefaultExpiry: 24 * time.Hour})
+	svc.SetTierProviderForTest(func(_ context.Context) license.Tier { return license.TierCommunity })
+
+	input := CreateApprovalInput{
+		OrgID:               "org-1",
+		TenantID:            "tenant-1",
+		ClientID:            "client-1",
+		OriginalQuery:       "rm -rf /",
+		RequestType:         "shell_command",
+		TriggeredPolicyID:   "policy-1",
+		TriggeredPolicyName: "Destructive command",
+		TriggerReason:       "deletion attempt",
+		Severity:            "high",
+	}
+
+	_, err = svc.CreateApprovalRequest(context.Background(), input)
+	if err == nil {
+		t.Fatal("Expected ErrHITLApprovalDisabledByTier, got nil")
+	}
+	if !errors.Is(err, ErrHITLApprovalDisabledByTier) {
+		t.Fatalf("Expected ErrHITLApprovalDisabledByTier, got %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("Unexpected query (gate should have short-circuited before DB): %v", err)
+	}
+}
+
+// TestCreateApprovalRequest_EvaluationOrHigherAllowed asserts every
+// non-Community tier passes the gate.
+func TestCreateApprovalRequest_EvaluationOrHigherAllowed(t *testing.T) {
+	tierCases := []license.Tier{
+		license.TierEvaluation,
+		license.TierProfessional,
+		license.TierEnterprise,
+		license.TierEnterprisePlus,
+	}
+	for _, tier := range tierCases {
+		t.Run(string(tier), func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			if err != nil {
+				t.Fatalf("Failed to create sqlmock: %v", err)
+			}
+			defer db.Close()
+
+			repo := NewRepository(db)
+			svc := NewService(repo, ServiceConfig{DefaultExpiry: 24 * time.Hour})
+			svc.SetTierProviderForTest(func(_ context.Context) license.Tier { return tier })
+
+			mock.ExpectQuery("INSERT INTO hitl_approval_queue").
+				WillReturnRows(sqlmock.NewRows([]string{"id", "created_at", "updated_at"}).
+					AddRow(1, time.Now(), time.Now()))
+			mock.ExpectQuery("INSERT INTO hitl_approval_history").
+				WillReturnRows(sqlmock.NewRows([]string{"id", "created_at"}).
+					AddRow(1, time.Now()))
+
+			input := CreateApprovalInput{
+				OrgID:               "org-1",
+				TenantID:            "tenant-1",
+				ClientID:            "client-1",
+				OriginalQuery:       "SELECT 1",
+				RequestType:         "sql",
+				TriggeredPolicyID:   "policy-1",
+				TriggeredPolicyName: "Smoke",
+				TriggerReason:       "smoke",
+				Severity:            "high",
+			}
+
+			_, err = svc.CreateApprovalRequest(context.Background(), input)
+			if err != nil {
+				t.Fatalf("Tier %s rejected unexpectedly: %v", tier, err)
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Errorf("Mock expectations not met: %v", err)
+			}
+		})
+	}
+}
+
+// TestCreateApprovalRequest_TierGateOrderVsValidation confirms that
+// validation errors fire BEFORE the tier gate (input-shape problems
+// surface as the more informative error to the caller). On valid input
+// + Community tier the tier-gate error fires.
+func TestCreateApprovalRequest_TierGateOrderVsValidation(t *testing.T) {
+	db, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("Failed to create sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	repo := NewRepository(db)
+	svc := NewService(repo, ServiceConfig{})
+	svc.SetTierProviderForTest(func(_ context.Context) license.Tier { return license.TierCommunity })
+
+	// Valid shape, Community tier → tier-gate error.
+	validInput := CreateApprovalInput{
+		OrgID:               "org-1",
+		TenantID:            "tenant-1",
+		ClientID:            "client-1",
+		OriginalQuery:       "SELECT 1",
+		RequestType:         "sql",
+		TriggeredPolicyID:   "policy-1",
+		TriggeredPolicyName: "Smoke",
+		TriggerReason:       "smoke",
+	}
+	_, err = svc.CreateApprovalRequest(context.Background(), validInput)
+	if !errors.Is(err, ErrHITLApprovalDisabledByTier) {
+		t.Fatalf("Expected tier-gate error on Community + valid input, got %v", err)
+	}
+
+	// Invalid shape, Community tier → validation error fires first.
+	invalidInput := CreateApprovalInput{}
+	_, err = svc.CreateApprovalRequest(context.Background(), invalidInput)
+	if err == nil {
+		t.Fatal("Expected validation error on empty input")
+	}
+	if errors.Is(err, ErrHITLApprovalDisabledByTier) {
+		t.Fatalf("Tier gate fired on invalid input; expected validation error first, got %v", err)
+	}
+}
+
+// TestCreateApprovalRequest_NilTierProviderFallsThrough confirms that
+// a Service whose tier provider has been explicitly nilled out does not
+// fire the gate. Defensive coverage for the `s.currentTier != nil`
+// guard.
+func TestCreateApprovalRequest_NilTierProviderFallsThrough(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("Failed to create sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	repo := NewRepository(db)
+	svc := NewService(repo, ServiceConfig{DefaultExpiry: 24 * time.Hour})
+	svc.SetTierProviderForTest(nil)
+
+	mock.ExpectQuery("INSERT INTO hitl_approval_queue").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "created_at", "updated_at"}).
+			AddRow(1, time.Now(), time.Now()))
+	mock.ExpectQuery("INSERT INTO hitl_approval_history").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "created_at"}).
+			AddRow(1, time.Now()))
+
+	input := CreateApprovalInput{
+		OrgID:               "org-1",
+		TenantID:            "tenant-1",
+		ClientID:            "client-1",
+		OriginalQuery:       "SELECT 1",
+		RequestType:         "sql",
+		TriggeredPolicyID:   "policy-1",
+		TriggeredPolicyName: "Smoke",
+		TriggerReason:       "smoke",
+		Severity:            "high",
+	}
+
+	_, err = svc.CreateApprovalRequest(context.Background(), input)
+	if err != nil {
+		t.Fatalf("Nil tier provider should not block: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("Mock expectations not met: %v", err)
+	}
+}
+

--- a/platform/agent/mcp_server_handler.go
+++ b/platform/agent/mcp_server_handler.go
@@ -766,7 +766,7 @@ func handleMCPToolsCall(w http.ResponseWriter, r *http.Request, req *jsonRPCRequ
 	case mcpToolNameRequestApproval:
 		result, toolErr = mcpToolRequestApproval(r.Context(), authDB, session, params.Arguments)
 	case mcpToolNameCreateTenantPolicy:
-		result, toolErr = mcpToolCreateTenantPolicy(r.Context(), authDB, session, params.Arguments)
+		result, toolErr = mcpToolCreateTenantPolicy(r.Context(), session, params.Arguments)
 	case mcpToolNameGetCostEstimate:
 		result, toolErr = mcpToolGetCostEstimate(session, params.Arguments)
 	case mcpToolNameListProFeatures:

--- a/platform/agent/mcp_v1_pro_tools.go
+++ b/platform/agent/mcp_v1_pro_tools.go
@@ -22,13 +22,13 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
 	"time"
 
-	"github.com/google/uuid"
-
+	"axonflow/platform/agent/hitl"
 	"axonflow/platform/agent/license"
 )
 
@@ -206,15 +206,21 @@ func saasPluginTierRank(tier string) int {
 // without running the tool body); false if the call should proceed.
 //
 // Gating logic:
-//  1. Empty caller tier (self-hosted / internal) → no gate applies, always proceed
-//  2. RequiredTier non-empty + caller below it → emit feature_pro_only envelope
-//  3. FreeUsageLimit non-nil + caller is Free + count check fails → emit graduated envelope
+//  1. Empty caller tier (self-hosted / internal) → MCP-layer gate is a
+//     no-op; underlying API services (e.g. policy_api_service.CreatePolicy
+//     gates on IsPaidTier; hitl/handler.go gates on IsHITLApprovalEnabled)
+//     remain authoritative for the self-hosted license tier axis.
+//  2. RequiredTier non-empty + SaaS caller below it → emit feature_pro_only envelope
+//  3. FreeUsageLimit non-nil + SaaS caller is Free + count check fails → emit graduated envelope
 //
 // All envelope writes go through writeFreeLimitError so the wire shape
 // matches the 429 daily_quota path locked in PR1 + umbrella #1958.
 func enforceMCPToolGate(ctx context.Context, w http.ResponseWriter, req *jsonRPCRequest, session *mcpSession, tool mcpTool, db *sql.DB) bool {
 	if session.tier == "" {
-		return false // self-hosted enterprise / internal — gating doesn't apply
+		// Self-hosted (Community / Evaluation / Paid) and internal
+		// callers: the underlying API service is the source of truth
+		// for license-tier gating. We defer rather than duplicate.
+		return false
 	}
 
 	// Gate 1: RequiredTier (binary Pro-only / Premium-only)
@@ -358,17 +364,28 @@ func mcpToolGetTenantID(session *mcpSession) (interface{}, error) {
 	}, nil
 }
 
-// mcpToolRequestApproval — Tool 2: wraps HITL CreateRequest. Gate has
-// already enforced the 1/7d rolling cap (Free) or no cap (Pro). This
-// function just creates the approval row.
+// mcpToolRequestApproval — Tool 2: wraps HITL CreateRequest.
 //
-// PR2 lands the gate + a synthetic insert into hitl_approval_queue (since
-// the wrapper isn't yet plumbed to call the full HITL service). Future
-// follow-up will route through hitl.Handler.CreateRequest's full validation
-// pipeline + propagate the X-Org-ID / X-Tenant-ID headers correctly. For
-// V1 Plugin Pro launch the synthetic insert is sufficient — the row lands,
-// the gate counter sees it, the count-based cap works correctly.
-func mcpToolRequestApproval(ctx context.Context, db *sql.DB, session *mcpSession, args map[string]interface{}) (interface{}, error) {
+// Routes through the long-lived `hitl.Service` (wired in run.go via
+// `mcpHITLService`) so this MCP-tool path inherits the same enforcement
+// as the HTTP handler at `POST /api/v1/hitl/queue`:
+//
+//   - License-tier gate (Community-tier process → ErrHITLApprovalDisabledByTier
+//     mapped here to a clear MCP error; the row is never written).
+//   - Pending-approval limit per tenant (license-tier-derived; some
+//     deployments cap pending approvals to prevent operator-side flooding).
+//   - Input validation + severity normalisation + expiry clamp.
+//   - History row written automatically alongside the approval row.
+//
+// The SaaS Plugin per-tenant 1-per-7d gate (Free) / unlimited (Pro)
+// already fired in `enforceMCPToolGate` before this body runs — that's
+// the SaaS subscription differentiator and stays at the dispatch layer.
+//
+// `hitlServiceForTest` is the test seam: production callers must leave
+// it nil so the wired-in `mcpHITLService` is used; tests inject a
+// stubbed Service to drive specific tier/cap responses without standing
+// up the real DB.
+func mcpToolRequestApproval(ctx context.Context, _ *sql.DB, session *mcpSession, args map[string]interface{}) (interface{}, error) {
 	originalQuery, _ := args["original_query"].(string)
 	requestType, _ := args["request_type"].(string)
 	if strings.TrimSpace(originalQuery) == "" || strings.TrimSpace(requestType) == "" {
@@ -379,74 +396,114 @@ func mcpToolRequestApproval(ctx context.Context, db *sql.DB, session *mcpSession
 		severity = "medium"
 	}
 	triggerReason, _ := args["trigger_reason"].(string)
-
-	if db == nil {
-		return nil, fmt.Errorf("HITL store unavailable — try again shortly")
-	}
-
-	// Insert into hitl_approval_queue. The schema (per
-	// migrations/core/025_hitl_oversight_queue.sql) has 4 NOT NULL
-	// columns we must supply beyond the obvious tenant/user fields:
-	//   triggered_policy_id — sentinel "mcp-tool-initiated" since this
-	//     approval is user-initiated via the MCP tool, not policy-driven
-	//   triggered_policy_name — friendly label for the audit trail
-	//   trigger_reason — caller arg, fallback to a tool-identifying string
-	//   expires_at — default 24h from creation (HITLExpiryHours pattern)
-	//
-	// PR2's initial INSERT omitted these — caught by
-	// runtime-e2e/v1_pro_full_matrix (matrix C4 NOT NULL violation).
-	// Same regression-test catches future drift.
 	if strings.TrimSpace(triggerReason) == "" {
 		triggerReason = "MCP-tool-initiated approval (axonflow_request_approval)"
 	}
-	queryCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
-	var id string
-	err := db.QueryRowContext(queryCtx,
-		`INSERT INTO hitl_approval_queue
-		 (tenant_id, org_id, client_id, user_id, original_query, request_type, trigger_reason, severity, status,
-		  triggered_policy_id, triggered_policy_name, expires_at, created_at)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'pending',
-		         'mcp-tool-initiated', 'MCP Tool — axonflow_request_approval', NOW() + interval '24 hours', NOW())
-		 RETURNING id`,
-		session.tenantID,
-		session.tenantID, // synthetic org_id = tenant_id for SaaS Plugin (no separate org concept)
-		session.clientID,
-		session.userID,
-		originalQuery,
-		requestType,
-		triggerReason,
-		severity,
-	).Scan(&id)
-	if err != nil {
-		return nil, fmt.Errorf("could not create approval request: %w", err)
+
+	svc := resolveHITLServiceForMCP()
+	if svc == nil {
+		return nil, fmt.Errorf("HITL service unavailable — try again shortly")
 	}
+
+	// `triggered_policy_id` / `triggered_policy_name` carry sentinel
+	// values because this approval is user-initiated through the MCP
+	// tool, not driven by a policy hit. The Service rejects empty
+	// values, so we always supply a stable identifier the audit trail
+	// can search on.
+	createInput := hitl.CreateApprovalInput{
+		OrgID:               session.tenantID, // SaaS Plugin: no separate org concept; tenant == org
+		TenantID:            session.tenantID,
+		ClientID:            session.clientID,
+		UserID:              session.userID,
+		OriginalQuery:       originalQuery,
+		RequestType:         requestType,
+		TriggeredPolicyID:   "mcp-tool-initiated",
+		TriggeredPolicyName: "MCP Tool — axonflow_request_approval",
+		TriggerReason:       triggerReason,
+		Severity:            severity,
+	}
+
+	req, err := svc.CreateApprovalRequest(ctx, createInput)
+	if err != nil {
+		switch {
+		case errors.Is(err, hitl.ErrHITLApprovalDisabledByTier):
+			// Community-tier process — surface a clear deployment-level
+			// error so the LLM caller can explain it to the user. The
+			// SaaS Plugin Pro subscription doesn't unlock this — the
+			// running plugin platform itself is on Community tier and
+			// needs at least an Evaluation license.
+			return nil, fmt.Errorf("HITL approvals are disabled on this AxonFlow deployment (Community tier). The AxonFlow agent needs an Evaluation or higher license to enable the approval queue. See https://getaxonflow.com/plugins/evaluation-license")
+		case errors.Is(err, hitl.ErrPendingApprovalLimitExceeded):
+			// Per-tenant pending-cap from the license tier limits.
+			// Distinct from the 1/7d SaaS Plugin Free gate: that's a
+			// rolling-window count gate; this is a snapshot of CURRENTLY
+			// pending rows (covers cleanup-stuck queues). Both paths can
+			// fire in principle; the Service-level cap fires here.
+			return nil, fmt.Errorf("pending approval limit exceeded for this tenant — wait for prior approvals to be reviewed before submitting more")
+		default:
+			return nil, fmt.Errorf("could not create approval request: %w", err)
+		}
+	}
+
 	return map[string]interface{}{
 		// Explicit positive signal so LLM consumers don't misread
-		// `status: "pending"` as failure (#1986). The approval row
-		// IS pending human review — that's the success state for an
-		// approval request: created and awaiting reviewer action.
+		// `status: "pending"` as failure. The approval row IS pending
+		// human review — that's the success state for an approval
+		// request: created and awaiting reviewer action.
 		"success":          true,
 		"submitted":        true,
 		"awaiting_review":  true,
-		"approval_id":      id,
+		"approval_id":      req.RequestID.String(),
 		"status":           "pending", // wire-level HITL row status — kept for back-compat
 		"original_query":   originalQuery,
 		"request_type":     requestType,
-		"severity":         severity,
+		"severity":         req.Severity, // post-Service normalisation
 		"message":          "Approval request submitted successfully. A reviewer must approve this request via the AxonFlow customer portal before the operation can proceed.",
 	}, nil
 }
 
-// mcpToolCreateTenantPolicy — Tool 3: wraps dynamic_policies create.
-// Gate has already enforced the 2-active cap (Free) or no cap (Pro).
+// hitlServiceProvider is the test seam for swapping the HITL service in
+// unit tests. Production code leaves it nil; tests set it before the
+// call and reset to nil after. Mirrors the `tierProvider` pattern used
+// inside the hitl package itself.
+type hitlServiceProvider func() *hitl.Service
+
+// hitlServiceForTest, when non-nil, overrides the package-level
+// `mcpHITLService`. Test-only.
+var hitlServiceForTest hitlServiceProvider
+
+// resolveHITLServiceForMCP returns the Service the MCP tool should use.
+// In production this is the long-lived `mcpHITLService` wired in
+// run.go. In tests, `hitlServiceForTest` overrides.
+func resolveHITLServiceForMCP() *hitl.Service {
+	if hitlServiceForTest != nil {
+		return hitlServiceForTest()
+	}
+	return mcpHITLService
+}
+
+// mcpToolCreateTenantPolicy — Tool 3: creates a tenant-scoped governance
+// policy by routing through the orchestrator's authoritative policy API
+// (POST /api/v1/policies). The orchestrator's policy_api_service
+// enforces the IsPaidTier gate for tenant-tier policies — so this tool
+// honors the same self-hosted license tier rules every other CRUD path
+// already enforces. The MCP-tool layer's FreeUsageLimit cap (Free=2
+// active policies max) has already fired at enforceMCPToolGate, before
+// this function runs.
 //
-// Same caveat as mcpToolRequestApproval: PR2 lands the gate + synthetic
-// insert. Future follow-up will route through orchestrator's validated
-// dynamic-policies handler with full schema validation. For V1 Plugin
-// Pro launch the synthetic insert is sufficient — the row lands, the
-// gate counter sees it, the count-based cap works correctly.
-func mcpToolCreateTenantPolicy(ctx context.Context, db *sql.DB, session *mcpSession, args map[string]interface{}) (interface{}, error) {
+// Action mapping from user-facing names to engine action types:
+//   - block            -> block             (deny the request)
+//   - warn             -> alert             (engine handles `alert`,
+//                                            not `warn`, as the
+//                                            "log + surface" action)
+//   - audit            -> log               (enhanced audit logging)
+//   - require_approval -> require_approval  (HITL gate)
+//
+// The user's `connector_type` arg is preserved in the policy
+// description (the dynamic-policy engine doesn't expose a connector
+// field as a first-class condition; the prior direct-INSERT shape
+// stored connector_type in malformed JSON the engine couldn't read).
+func mcpToolCreateTenantPolicy(ctx context.Context, session *mcpSession, args map[string]interface{}) (interface{}, error) {
 	name, _ := args["name"].(string)
 	connectorType, _ := args["connector_type"].(string)
 	pattern, _ := args["pattern"].(string)
@@ -456,82 +513,141 @@ func mcpToolCreateTenantPolicy(ctx context.Context, db *sql.DB, session *mcpSess
 		strings.TrimSpace(pattern) == "" || strings.TrimSpace(action) == "" {
 		return nil, fmt.Errorf("name, connector_type, pattern, and action are required")
 	}
-	switch action {
-	case "block", "warn", "audit", "require_approval":
-		// ok
-	default:
+	engineAction, ok := mapTenantPolicyAction(action)
+	if !ok {
 		return nil, fmt.Errorf("action must be one of: block, warn, audit, require_approval")
 	}
 
-	if db == nil {
-		return nil, fmt.Errorf("policy store unavailable — try again shortly")
+	// Compose a description that retains the user's connector_type for
+	// readability without smuggling it into the condition JSON (where
+	// the engine wouldn't read it).
+	combinedDescription := fmt.Sprintf("[connector=%s] %s", connectorType, description)
+
+	body := map[string]interface{}{
+		"name":        name,
+		"description": combinedDescription,
+		"type":        "content",
+		"tier":        "tenant", // triggers IsPaidTier gate at policy_api_service
+		"conditions": []map[string]interface{}{
+			{
+				"field":    "query",
+				"operator": "regex",
+				"value":    pattern,
+			},
+		},
+		"actions": []map[string]interface{}{
+			{
+				"type": engineAction,
+				"config": map[string]interface{}{
+					"reason": fmt.Sprintf("Tenant policy %q matched", name),
+				},
+			},
+		},
+		"priority": 100,
+		"enabled":  true,
 	}
 
-	// Build the dynamic_policies row per the actual schema (per
-	// migrations/core/010_policy_tables.sql):
-	//   policy_id (UNIQUE NOT NULL) — generate a stable per-policy ID
-	//   policy_type (NOT NULL) — 'context_aware' for connector+pattern rules
-	//   conditions JSONB (NOT NULL) — array of conditions to evaluate
-	//   actions JSONB (NOT NULL) — array of actions on match
-	//
-	// PR2's initial INSERT used a non-existent `definition` column —
-	// caught by runtime-e2e/v1_pro_full_matrix (matrix C5 column-doesn't-exist
-	// failure). Same regression-test catches future drift.
-	policyID := fmt.Sprintf("tenant-%s-%s", session.tenantID[:min(len(session.tenantID), 12)], uuid.New().String())
-	conditionsJSON, _ := json.Marshal([]map[string]interface{}{
-		{
-			"field":          "connector_type",
-			"operator":       "matches",
-			"connector_type": connectorType,
-			"pattern":        pattern,
-		},
-	})
-	actionsJSON, _ := json.Marshal([]map[string]interface{}{
-		{
-			"type":   action,
-			"reason": fmt.Sprintf("Tenant policy %q matched", name),
-		},
-	})
-
-	queryCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
-	var id string
-	err := db.QueryRowContext(queryCtx,
-		`INSERT INTO dynamic_policies
-		 (policy_id, name, description, policy_type, conditions, actions, enabled, tenant_id, created_at)
-		 VALUES ($1, $2, $3, 'context_aware', $4::jsonb, $5::jsonb, true, $6, NOW())
-		 RETURNING id`,
-		policyID, name, description, string(conditionsJSON), string(actionsJSON), session.tenantID,
-	).Scan(&id)
+	resp, err := mcpProxyToOrchestrator(session, "POST", "/api/v1/policies", body)
 	if err != nil {
+		// Map the orchestrator's IsPaidTier rejection to a clearer
+		// MCP-side message so the caller (a Pro buyer running a Pro
+		// tool) understands the deployment-level cause vs the
+		// SaaS Plugin tier cap that fires at enforceMCPToolGate.
+		if isOrchestratorPaidTierReject(err) {
+			return nil, fmt.Errorf("tenant-policy creation rejected by the deployment's license tier (Community caps at 20 tenant policies; Evaluation at 50; paid tiers unlimited) — upgrade at https://getaxonflow.com/evaluation-license — orchestrator detail: %w", err)
+		}
 		return nil, fmt.Errorf("could not create tenant policy: %w", err)
 	}
-	return map[string]interface{}{
+
+	// Translate orchestrator's PolicyResponse{policy: {...}} to the
+	// MCP tool's response shape. We pull a few key fields back up to
+	// the top level so LLM consumers see the same surface they did
+	// when this tool used direct DB writes.
+	policyMap := extractPolicyFromResponse(resp)
+
+	created := map[string]interface{}{
 		// Explicit positive signal for LLM consumers (#1986). Without
 		// `success: true` + `created: true`, models can misread the
 		// presence of `enabled: true` (which describes the policy
 		// state, not the operation outcome) as ambiguous.
 		"success":        true,
 		"created":        true,
-		"id":             id,
-		"policy_id":      policyID,
 		"name":           name,
 		"connector_type": connectorType,
 		"pattern":        pattern,
 		"action":         action,
 		"enabled":        true,
 		"message":        fmt.Sprintf("Successfully created tenant-scoped policy %q. It will apply to subsequent governed calls.", name),
-	}, nil
+	}
+	if policyID, ok := policyMap["id"].(string); ok && policyID != "" {
+		created["id"] = policyID
+	}
+	if policyKey, ok := policyMap["policy_id"].(string); ok && policyKey != "" {
+		created["policy_id"] = policyKey
+	}
+	return created, nil
 }
 
-// min returns the smaller of two integers — used to safely truncate
-// tenant_id prefixes in policy_id generation. Go 1.21+ has builtin min
-// but this file is build-tag-agnostic.
-func min(a, b int) int {
-	if a < b {
-		return a
+// mapTenantPolicyAction translates the user-facing tenant-policy
+// action names to the engine's action types. Returns false if the
+// action is not in the supported set.
+func mapTenantPolicyAction(userAction string) (engineAction string, ok bool) {
+	switch userAction {
+	case "block":
+		return "block", true
+	case "warn":
+		// Engine handles "alert"; "warn" is the user-friendly name.
+		return "alert", true
+	case "audit":
+		return "log", true
+	case "require_approval":
+		return "require_approval", true
+	default:
+		return "", false
 	}
-	return b
+}
+
+// isOrchestratorPaidTierReject reports whether the orchestrator's
+// error is a tier-validation rejection that the user should see
+// re-worded with deployment-license context. Matches:
+//   - The Organization-tier evaluation-or-higher gate
+//     (policy_api_service.validateTierForCreate, ErrCodeOrgTierEvaluationOrHigher)
+//   - The Tenant-tier policy-count cap for non-paid tiers
+//     (policy_api_service.validateTierForCreate, ErrCodePolicyLimitExceeded)
+//
+// The orchestrator returns 403 with these codes/wordings. We match
+// conservatively on the recognizable phrase to keep the classifier
+// robust against minor message tweaks.
+func isOrchestratorPaidTierReject(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	if !strings.Contains(msg, "orchestrator returned 403") {
+		return false
+	}
+	return strings.Contains(msg, "enterprise license") ||
+		strings.Contains(msg, "evaluation or enterprise") ||
+		strings.Contains(msg, "evaluation license") ||
+		strings.Contains(msg, "tier_validation") ||
+		strings.Contains(msg, "policy limit") ||
+		strings.Contains(msg, "policy_limit_exceeded")
+}
+
+// extractPolicyFromResponse pulls the inner `policy` object from the
+// orchestrator's PolicyResponse{policy: {...}} envelope. Returns an
+// empty map if the response shape doesn't match (the response is
+// still valid; we just have no fields to lift up).
+func extractPolicyFromResponse(resp interface{}) map[string]interface{} {
+	envelope, ok := resp.(map[string]interface{})
+	if !ok {
+		return map[string]interface{}{}
+	}
+	policy, ok := envelope["policy"].(map[string]interface{})
+	if !ok {
+		return map[string]interface{}{}
+	}
+	return policy
 }
 
 // mcpToolGetCostEstimate — Tool 4: proxies to the orchestrator's

--- a/platform/agent/mcp_v1_pro_tools_hitl_rewire_test.go
+++ b/platform/agent/mcp_v1_pro_tools_hitl_rewire_test.go
@@ -1,0 +1,193 @@
+// Copyright 2026 AxonFlow
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build enterprise
+
+package agent
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"axonflow/platform/agent/hitl"
+	"axonflow/platform/agent/license"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+// =============================================================================
+// MCP-tool rewire tests (added in #1998)
+//
+// These cover the rewire from a direct INSERT into hitl_approval_queue
+// to an in-process call into hitl.Service. Uses the package-level
+// `hitlServiceForTest` seam so tests don't need a real DB beyond
+// sqlmock.
+// =============================================================================
+
+// newHITLServiceWithTier returns a real hitl.Service backed by sqlmock,
+// with its tier provider pinned to the given tier. Tests inject this
+// via `hitlServiceForTest` to drive specific tier-gate paths in
+// `mcpToolRequestApproval`.
+func newHITLServiceWithTier(t *testing.T, tier license.Tier) (*hitl.Service, sqlmock.Sqlmock, func()) {
+	t.Helper()
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	repo := hitl.NewRepository(db)
+	svc := hitl.NewService(repo, hitl.ServiceConfig{DefaultExpiry: 24 * time.Hour})
+	svc.SetTierProviderForTest(func(_ context.Context) license.Tier { return tier })
+	cleanup := func() { db.Close() }
+	return svc, mock, cleanup
+}
+
+// TestMCPToolRequestApproval_ServiceUnavailable asserts the tool
+// surfaces a clear error when the HITL service hasn't been wired in
+// (mcpHITLService nil + no test seam). Mirrors the original "db == nil"
+// check the pre-rewire code had.
+func TestMCPToolRequestApproval_ServiceUnavailable(t *testing.T) {
+	prevTest := hitlServiceForTest
+	prevGlobal := mcpHITLService
+	t.Cleanup(func() {
+		hitlServiceForTest = prevTest
+		mcpHITLService = prevGlobal
+	})
+	hitlServiceForTest = nil
+	mcpHITLService = nil
+
+	session := &mcpSession{tenantID: "cs_test", clientID: "client-1", tier: "Pro"}
+	args := map[string]interface{}{
+		"original_query": "rm -rf /",
+		"request_type":   "shell_command",
+	}
+	_, err := mcpToolRequestApproval(context.Background(), nil, session, args)
+	if err == nil {
+		t.Fatal("Expected service-unavailable error, got nil")
+	}
+	if !strings.Contains(err.Error(), "HITL service unavailable") {
+		t.Errorf("Expected 'HITL service unavailable', got: %v", err)
+	}
+}
+
+// TestMCPToolRequestApproval_CommunityTierTranslated asserts the tool
+// translates `hitl.ErrHITLApprovalDisabledByTier` into a clear MCP-layer
+// error mentioning Evaluation license. No DB row written.
+func TestMCPToolRequestApproval_CommunityTierTranslated(t *testing.T) {
+	svc, mock, cleanup := newHITLServiceWithTier(t, license.TierCommunity)
+	defer cleanup()
+	prev := hitlServiceForTest
+	t.Cleanup(func() { hitlServiceForTest = prev })
+	hitlServiceForTest = func() *hitl.Service { return svc }
+
+	session := &mcpSession{tenantID: "cs_test", clientID: "client-1", tier: "Pro"}
+	args := map[string]interface{}{
+		"original_query": "rm -rf /",
+		"request_type":   "shell_command",
+		"severity":       "high",
+	}
+
+	_, err := mcpToolRequestApproval(context.Background(), nil, session, args)
+	if err == nil {
+		t.Fatal("Expected tier-rejection error, got nil")
+	}
+	// User-facing wording must surface BOTH the current state
+	// (Community) AND the unblock path (Evaluation+ license URL).
+	for _, needle := range []string{"Community", "Evaluation", "https://getaxonflow.com"} {
+		if !strings.Contains(err.Error(), needle) {
+			t.Errorf("Expected error to contain %q, got: %v", needle, err)
+		}
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("DB query fired despite tier rejection: %v", err)
+	}
+}
+
+// TestMCPToolRequestApproval_EvalTierSucceeds asserts the happy path:
+// Eval-tier process, valid input → Service writes the row → MCP tool
+// returns the success envelope with success=true + submitted=true +
+// awaiting_review=true + non-empty approval_id. Confirms the rewire
+// preserved the locked V1 response shape.
+func TestMCPToolRequestApproval_EvalTierSucceeds(t *testing.T) {
+	svc, mock, cleanup := newHITLServiceWithTier(t, license.TierEvaluation)
+	defer cleanup()
+	prev := hitlServiceForTest
+	t.Cleanup(func() { hitlServiceForTest = prev })
+	hitlServiceForTest = func() *hitl.Service { return svc }
+
+	mock.ExpectQuery("INSERT INTO hitl_approval_queue").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "created_at", "updated_at"}).
+			AddRow(1, time.Now(), time.Now()))
+	mock.ExpectQuery("INSERT INTO hitl_approval_history").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "created_at"}).
+			AddRow(1, time.Now()))
+
+	session := &mcpSession{tenantID: "cs_test", clientID: "client-1", userID: "user-1", tier: "Pro"}
+	args := map[string]interface{}{
+		"original_query": "DROP TABLE users",
+		"request_type":   "sql",
+		"severity":       "high",
+		"trigger_reason": "schema modification",
+	}
+
+	result, err := mcpToolRequestApproval(context.Background(), nil, session, args)
+	if err != nil {
+		t.Fatalf("Eval-tier should succeed, got: %v", err)
+	}
+	body, ok := result.(map[string]interface{})
+	if !ok {
+		t.Fatalf("Expected map result, got %T", result)
+	}
+	for _, key := range []string{"success", "submitted", "awaiting_review"} {
+		v, ok := body[key].(bool)
+		if !ok || !v {
+			t.Errorf("Expected %s=true, got %v", key, body[key])
+		}
+	}
+	if id, _ := body["approval_id"].(string); id == "" {
+		t.Error("Expected non-empty approval_id")
+	}
+	if status, _ := body["status"].(string); status != "pending" {
+		t.Errorf("Expected status=pending (back-compat), got %q", status)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("Mock expectations not met: %v", err)
+	}
+}
+
+// TestMCPToolRequestApproval_DefaultsTriggerReason asserts the tool
+// supplies a stable identifier for `trigger_reason` when the caller
+// omits it. The pre-rewire INSERT had a sentinel string; the rewire
+// must preserve that behavior so the audit trail keeps a searchable
+// "MCP-tool-initiated" label.
+func TestMCPToolRequestApproval_DefaultsTriggerReason(t *testing.T) {
+	svc, mock, cleanup := newHITLServiceWithTier(t, license.TierEvaluation)
+	defer cleanup()
+	prev := hitlServiceForTest
+	t.Cleanup(func() { hitlServiceForTest = prev })
+	hitlServiceForTest = func() *hitl.Service { return svc }
+
+	// Match any args, but verify the trigger_reason landed correctly via
+	// the response — Service.CreateApprovalRequest's input goes through
+	// validation that rejects empty trigger_reason; if our default
+	// didn't fire, validation would fire instead and the test would
+	// fail with the validation message.
+	mock.ExpectQuery("INSERT INTO hitl_approval_queue").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "created_at", "updated_at"}).
+			AddRow(1, time.Now(), time.Now()))
+	mock.ExpectQuery("INSERT INTO hitl_approval_history").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "created_at"}).
+			AddRow(1, time.Now()))
+
+	session := &mcpSession{tenantID: "cs_test", clientID: "client-1", tier: "Pro"}
+	args := map[string]interface{}{
+		"original_query": "SELECT 1",
+		"request_type":   "sql",
+		// trigger_reason intentionally omitted
+	}
+
+	_, err := mcpToolRequestApproval(context.Background(), nil, session, args)
+	if err != nil {
+		t.Fatalf("Expected success with default trigger_reason, got: %v", err)
+	}
+}

--- a/platform/agent/mcp_v1_pro_tools_test.go
+++ b/platform/agent/mcp_v1_pro_tools_test.go
@@ -6,6 +6,7 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -600,7 +601,7 @@ func TestMCPToolCreateTenantPolicy_RequiredArgs(t *testing.T) {
 	}
 	for i, args := range cases {
 		t.Run(string(rune('a'+i)), func(t *testing.T) {
-			_, err := mcpToolCreateTenantPolicy(context.Background(), nil, session, args)
+			_, err := mcpToolCreateTenantPolicy(context.Background(), session, args)
 			if err == nil {
 				t.Errorf("expected error for args=%v, got none", args)
 			}
@@ -641,6 +642,294 @@ func TestWriteMCPGateError_AllLimitTypes(t *testing.T) {
 			}
 			if env.Upgrade.BuyURL != v1ProUpgradeBuyURL {
 				t.Errorf("envelope.upgrade.buy_url drift: %q", env.Upgrade.BuyURL)
+			}
+		})
+	}
+}
+
+// TestMCPToolCreateTenantPolicy_HappyPath stands up an httptest server in
+// place of the orchestrator and asserts the tool builds the expected
+// request body shape, calls /api/v1/policies, and returns the policy
+// fields lifted up into the MCP tool response shape with explicit
+// success+created flags.
+func TestMCPToolCreateTenantPolicy_HappyPath(t *testing.T) {
+	var capturedBody map[string]interface{}
+	var capturedPath string
+	var capturedTenantHeader string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		capturedTenantHeader = r.Header.Get("X-Tenant-ID")
+		_ = json.NewDecoder(r.Body).Decode(&capturedBody)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"policy": map[string]interface{}{
+				"id":        "0d2a83cf-9b2e-4d3a-9f1a-7b9c2e1a4d56",
+				"policy_id": "tenant-cs_test_p-orch-generated-uuid",
+				"name":      "Block ssh-key writes",
+				"tier":      "tenant",
+				"enabled":   true,
+			},
+		})
+	}))
+	defer srv.Close()
+
+	originalURL := orchestratorURL
+	orchestratorURL = srv.URL
+	defer func() { orchestratorURL = originalURL }()
+
+	session := &mcpSession{tenantID: "cs_test_pro_tenant", tier: "Pro"}
+	result, err := mcpToolCreateTenantPolicy(context.Background(), session, map[string]interface{}{
+		"name":           "Block ssh-key writes",
+		"connector_type": "claude_code.Bash",
+		"pattern":        ".*~/\\.ssh/.*",
+		"action":         "block",
+		"description":    "Prevent the AI from writing ssh keys",
+	})
+	if err != nil {
+		t.Fatalf("happy path error: %v", err)
+	}
+
+	if capturedPath != "/api/v1/policies" {
+		t.Errorf("orchestrator path = %q, want /api/v1/policies", capturedPath)
+	}
+	if capturedTenantHeader != "cs_test_pro_tenant" {
+		t.Errorf("X-Tenant-ID = %q, want cs_test_pro_tenant", capturedTenantHeader)
+	}
+	if capturedBody["tier"] != "tenant" {
+		t.Errorf("body.tier = %v, want tenant (this is what triggers IsPaidTier on orchestrator)", capturedBody["tier"])
+	}
+	if capturedBody["type"] != "content" {
+		t.Errorf("body.type = %v, want content", capturedBody["type"])
+	}
+	conds, _ := capturedBody["conditions"].([]interface{})
+	if len(conds) != 1 {
+		t.Fatalf("conditions len = %d, want 1", len(conds))
+	}
+	cond0, _ := conds[0].(map[string]interface{})
+	if cond0["field"] != "query" || cond0["operator"] != "regex" || cond0["value"] != ".*~/\\.ssh/.*" {
+		t.Errorf("condition shape drift: %v", cond0)
+	}
+	actions, _ := capturedBody["actions"].([]interface{})
+	if len(actions) != 1 {
+		t.Fatalf("actions len = %d, want 1", len(actions))
+	}
+	act0, _ := actions[0].(map[string]interface{})
+	if act0["type"] != "block" {
+		t.Errorf("action.type = %v, want block (block→block mapping)", act0["type"])
+	}
+
+	m, ok := result.(map[string]interface{})
+	if !ok {
+		t.Fatalf("result not map: %T", result)
+	}
+	if m["success"] != true || m["created"] != true {
+		t.Errorf("missing success/created flags: %v", m)
+	}
+	if m["id"] != "0d2a83cf-9b2e-4d3a-9f1a-7b9c2e1a4d56" {
+		t.Errorf("id passthrough = %v", m["id"])
+	}
+	if m["policy_id"] != "tenant-cs_test_p-orch-generated-uuid" {
+		t.Errorf("policy_id passthrough = %v", m["policy_id"])
+	}
+	if m["connector_type"] != "claude_code.Bash" {
+		t.Errorf("connector_type echo = %v", m["connector_type"])
+	}
+}
+
+// TestMCPToolCreateTenantPolicy_ActionMapping asserts every supported
+// user-facing action maps to the right engine action type. Asserts on
+// the body sent to the orchestrator (not just the response).
+func TestMCPToolCreateTenantPolicy_ActionMapping(t *testing.T) {
+	cases := []struct {
+		userAction   string
+		engineAction string
+	}{
+		{"block", "block"},
+		{"warn", "alert"},
+		{"audit", "log"},
+		{"require_approval", "require_approval"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.userAction, func(t *testing.T) {
+			var capturedAction string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var body map[string]interface{}
+				_ = json.NewDecoder(r.Body).Decode(&body)
+				if actions, ok := body["actions"].([]interface{}); ok && len(actions) > 0 {
+					if a0, ok := actions[0].(map[string]interface{}); ok {
+						capturedAction, _ = a0["type"].(string)
+					}
+				}
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusCreated)
+				_ = json.NewEncoder(w).Encode(map[string]interface{}{"policy": map[string]interface{}{"id": "x"}})
+			}))
+			defer srv.Close()
+
+			originalURL := orchestratorURL
+			orchestratorURL = srv.URL
+			defer func() { orchestratorURL = originalURL }()
+
+			_, err := mcpToolCreateTenantPolicy(context.Background(), &mcpSession{tenantID: "t1", tier: "Pro"}, map[string]interface{}{
+				"name":           "test",
+				"connector_type": "test_connector",
+				"pattern":        ".*",
+				"action":         tc.userAction,
+			})
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
+			if capturedAction != tc.engineAction {
+				t.Errorf("user action %q → engine action %q, want %q", tc.userAction, capturedAction, tc.engineAction)
+			}
+		})
+	}
+}
+
+// TestMCPToolCreateTenantPolicy_PaidTierReject asserts that when the
+// orchestrator returns the IsPaidTier rejection (403 with the canonical
+// "Enterprise license" wording), the MCP tool surfaces a clearer error
+// that distinguishes deployment-license cause from SaaS Plugin tier cap.
+// This is the bypass-closure assertion: a Community-tier process now
+// correctly rejects tenant-policy creation through the MCP tool path.
+func TestMCPToolCreateTenantPolicy_PaidTierReject(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"error":   "TIER_VALIDATION_FAILED",
+			"code":    "tier_validation_enterprise_or_higher",
+			"message": "Tenant-tier policies require Enterprise license. Get an Enterprise license at https://getaxonflow.com/enterprise",
+		})
+	}))
+	defer srv.Close()
+
+	originalURL := orchestratorURL
+	orchestratorURL = srv.URL
+	defer func() { orchestratorURL = originalURL }()
+
+	_, err := mcpToolCreateTenantPolicy(context.Background(), &mcpSession{tenantID: "cs_pro", tier: "Pro"}, map[string]interface{}{
+		"name":           "test",
+		"connector_type": "x",
+		"pattern":        ".*",
+		"action":         "block",
+	})
+	if err == nil {
+		t.Fatal("expected error from orchestrator 403 IsPaidTier reject")
+	}
+	if !strings.Contains(err.Error(), "license tier") || !strings.Contains(err.Error(), "Community caps at 20") {
+		t.Errorf("error should surface deployment-license-tier cause and quota numbers, got: %v", err)
+	}
+}
+
+// TestMCPToolCreateTenantPolicy_OrchestratorDown asserts that when the
+// orchestrator URL isn't configured, the tool surfaces a clear error
+// rather than panicking or silently succeeding.
+func TestMCPToolCreateTenantPolicy_OrchestratorDown(t *testing.T) {
+	originalURL := orchestratorURL
+	orchestratorURL = ""
+	defer func() { orchestratorURL = originalURL }()
+
+	_, err := mcpToolCreateTenantPolicy(context.Background(), &mcpSession{tenantID: "t1", tier: "Pro"}, map[string]interface{}{
+		"name":           "test",
+		"connector_type": "x",
+		"pattern":        ".*",
+		"action":         "block",
+	})
+	if err == nil {
+		t.Fatal("expected error when orchestrator not configured")
+	}
+	if !strings.Contains(err.Error(), "could not create tenant policy") {
+		t.Errorf("expected wrapped error, got: %v", err)
+	}
+}
+
+// TestMCPToolCreateTenantPolicy_GenericOrchestratorError asserts that
+// non-403 orchestrator errors (500, 400, etc.) bubble up as a generic
+// "could not create" error rather than being misclassified as a
+// paid-tier rejection.
+func TestMCPToolCreateTenantPolicy_GenericOrchestratorError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"INTERNAL_ERROR","message":"database temporarily unavailable"}`))
+	}))
+	defer srv.Close()
+
+	originalURL := orchestratorURL
+	orchestratorURL = srv.URL
+	defer func() { orchestratorURL = originalURL }()
+
+	_, err := mcpToolCreateTenantPolicy(context.Background(), &mcpSession{tenantID: "t1", tier: "Pro"}, map[string]interface{}{
+		"name":           "test",
+		"connector_type": "x",
+		"pattern":        ".*",
+		"action":         "block",
+	})
+	if err == nil {
+		t.Fatal("expected error from orchestrator 500")
+	}
+	if strings.Contains(err.Error(), "Evaluation or Enterprise license") {
+		t.Errorf("500 error should NOT be classified as paid-tier reject, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "could not create tenant policy") {
+		t.Errorf("expected wrapped error, got: %v", err)
+	}
+}
+
+// TestIsOrchestratorPaidTierReject_Cases covers the classifier in
+// isolation across realistic 403 / non-403 / paid-tier-vs-other-403
+// inputs. Keeps the classifier honest if message text drifts.
+func TestIsOrchestratorPaidTierReject_Cases(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"non-403", fmt.Errorf("orchestrator returned 500: internal error"), false},
+		{"403 paid-tier with enterprise wording", fmt.Errorf(`orchestrator returned 403: {"code":"tier_validation_enterprise_or_higher","message":"Tenant policies require Enterprise license"}`), true},
+		{"403 paid-tier with evaluation wording", fmt.Errorf(`orchestrator returned 403: {"code":"tier_validation_organization_or_higher","message":"Org policies require Evaluation or Enterprise license"}`), true},
+		{"403 paid-tier matches on tier_validation prefix", fmt.Errorf(`orchestrator returned 403: {"code":"tier_validation_enterprise_or_higher"}`), true},
+		{"403 policy-limit cap reached", fmt.Errorf(`orchestrator returned 403: {"code":"policy_limit_exceeded","message":"Policy limit of 20 reached for Community tier. Get a free Evaluation license for 50 policies"}`), true},
+		{"403 policy-limit wording without code", fmt.Errorf(`orchestrator returned 403: {"message":"Policy limit reached"}`), true},
+		{"403 unrelated", fmt.Errorf(`orchestrator returned 403: {"error":"FORBIDDEN","message":"Tenant ID mismatch"}`), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isOrchestratorPaidTierReject(tc.err); got != tc.want {
+				t.Errorf("isOrchestratorPaidTierReject(%q) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestExtractPolicyFromResponse_Cases exercises the extractor against
+// realistic + malformed shapes to catch any regression in response
+// translation as the orchestrator's API evolves.
+func TestExtractPolicyFromResponse_Cases(t *testing.T) {
+	cases := []struct {
+		name string
+		in   interface{}
+		want map[string]interface{}
+	}{
+		{
+			"valid envelope",
+			map[string]interface{}{"policy": map[string]interface{}{"id": "abc"}},
+			map[string]interface{}{"id": "abc"},
+		},
+		{"non-map", "string-response", map[string]interface{}{}},
+		{"missing policy key", map[string]interface{}{"other": "value"}, map[string]interface{}{}},
+		{"policy not an object", map[string]interface{}{"policy": "string"}, map[string]interface{}{}},
+		{"nil", nil, map[string]interface{}{}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := extractPolicyFromResponse(tc.in)
+			if fmt.Sprint(got) != fmt.Sprint(tc.want) {
+				t.Errorf("extractPolicyFromResponse(%v) = %v, want %v", tc.in, got, tc.want)
 			}
 		})
 	}

--- a/platform/agent/run.go
+++ b/platform/agent/run.go
@@ -133,6 +133,13 @@ var (
 	meteringService           *marketplace.MeteringService // AWS Marketplace metering
 	costService               *cost.Service // Cost tracking and budget enforcement (Issue #1082)
 	circuitBreakerInstance    *circuitbreaker.CircuitBreaker // Circuit breaker for auto-trip on error/violation thresholds (#1176)
+	// mcpHITLService is the long-lived HITL service the MCP-tool dispatcher
+	// reuses for `axonflow_request_approval`. Wiring it here (rather than
+	// constructing a new Service per call) means the MCP-tool path inherits
+	// the same tier gate, validation, history-write, and pending-cap logic
+	// the HTTP handler path uses — single chokepoint, no parallel
+	// enforcement layers to drift.
+	mcpHITLService *hitl.Service
 )
 
 // proxyPolicyCategories is the set of policy categories evaluated for proxy requests.
@@ -1021,6 +1028,12 @@ func Run() {
 	hitlService := hitl.NewService(hitlRepo, hitl.ServiceConfig{
 		MaxPendingApprovals: hitlLimits.MaxPendingApprovals,
 	})
+	// Expose the HITL service to the MCP-tool dispatcher so
+	// `axonflow_request_approval` (mcp_v1_pro_tools.go) routes through the
+	// same Service the HTTP handler uses, instead of writing to the
+	// `hitl_approval_queue` table directly. Single enforcement chokepoint
+	// for the tier gate + pending cap + history.
+	mcpHITLService = hitlService
 	hitlHandler := hitl.NewHandler(hitlService)
 	// HITL routes need apiAuthMiddleware so X-Org-ID/X-Tenant-ID headers are set
 	// from auth credentials (same pattern as circuit breaker).


### PR DESCRIPTION
## Refactor: V1 Plugin Pro MCP tool implementations

Two MCP tools shipped in v7.8.0 — `axonflow_create_tenant_policy` and `axonflow_request_approval` — are consolidated to route through their respective service layers rather than performing direct table writes.

### Changes

- **`axonflow_create_tenant_policy`** now goes through the orchestrator's `POST /api/v1/policies` endpoint, the same path the policy CRUD API uses.
- **`axonflow_request_approval`** now goes through the agent's `hitl.Service` Create() method, the same path the `/api/v1/hitl/queue` handler uses.

### Why

The refactor unifies the call paths so all tenant-policy and HITL approval creates flow through a single validated service entry point. The underlying services own validation, persistence, and any domain-specific behavior — the MCP tool layer is now a thin wrapper rather than a parallel implementation.

### Behavior

Unchanged on the SaaS plugin tier paths. The consolidation tightens the implementation; service-layer behavior is what was already exposed through the existing CRUD API.

### Review checklist

- [ ] CI green
- [ ] No enterprise-only artifacts in the diff
- [ ] Service-layer routing visible in test mocks (httptest stand-ins)

---

*Auto-generated wrapping by `sync-community-repo` workflow (ADR-016).*