### PR TITLE
fix(agent): HITL require_approval sentinel in pre-check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ Additive minor release. Decision Mode brings the Policy Decision Point / Policy 
 
 - **Integration package stubs.** `examples/integrations/google-adk-plugin/` and `examples/integrations/n8n-axonflow-node/` replaced with stub READMEs pointing to their standalone repos.
 
+### Fixed
+
+- **HITL `require_approval` policies now correctly return the `require_approval` sentinel in Gateway Mode pre-check.** When a custom policy with `action=require_approval` matched, the pre-check response returned the policy description as `block_reason` instead of the `require_approval` sentinel string that SDKs and plugins check to trigger the HITL approval flow. The approval flow silently did not activate. Now `require_approval` policies return `block_reason="require_approval"` so SDK-side HITL detection works correctly.
+
 ## [8.1.0] - 2026-05-23 — HITL outbound webhook callback + HTTP Idempotency-Key dedup
 
 Minor release on top of v8.0.1. Two additive features that close gaps surfaced during the Google ADK plugin + n8n community node R3 — workflow tools that pause on a webhook can now resume without a polling sidecar, and `Retry on Fail` retries no longer double-create approval rows or double-record audit entries.

--- a/platform/agent/gateway_handlers.go
+++ b/platform/agent/gateway_handlers.go
@@ -648,11 +648,19 @@ func handlePolicyPreCheck(w http.ResponseWriter, r *http.Request) {
 		response.Policies = append(response.Policies, "hitl_enterprise")
 	}
 
-	if policyResult.Blocked {
+	if requiresHITL {
+		// HITL takes precedence over block — the request needs human approval,
+		// not an outright deny. SDKs check for the exact "require_approval"
+		// sentinel to trigger the HITL polling flow.
+		response.BlockReason = "require_approval"
+		log.Printf("⏸️ [Pre-check] HITL required (Enterprise) - awaiting human approval (contextID=%s)", contextID)
+	} else if policyResult.Blocked {
 		response.BlockReason = policyResult.Reason
 		log.Printf("⛔ [Pre-check] Request blocked: %s", policyResult.Reason)
+	}
 
-		// Record policy violation for auto-trip threshold tracking (#1176)
+	// Record policy violation for auto-trip threshold tracking
+	if policyResult.Blocked || requiresHITL {
 		if circuitBreakerInstance != nil {
 			for _, policyID := range policyResult.TriggeredPolicies {
 				if err := circuitBreakerInstance.RecordPolicyViolation(ctx, client.OrgID, client.TenantID, client.ID, policyID); err != nil {
@@ -660,12 +668,9 @@ func handlePolicyPreCheck(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 		}
-	} else if requiresHITL {
-		// Issue #1081: HITL required (Enterprise only) - block with require_approval reason
-		// This enables EU AI Act Article 14, RBI, SEBI, and other compliance frameworks
-		response.BlockReason = "require_approval"
-		log.Printf("⏸️ [Pre-check] HITL required (Enterprise) - awaiting human approval (contextID=%s)", contextID)
-	} else if requiresRedaction {
+	}
+
+	if !policyResult.Blocked && !requiresHITL && requiresRedaction {
 		log.Printf("⚠️ [Pre-check] Request approved with redaction required: %s", policyResult.Reason)
 	} else {
 		// Fetch data from MCP connectors if data sources specified

--- a/platform/agent/gateway_handlers_test.go
+++ b/platform/agent/gateway_handlers_test.go
@@ -3571,4 +3571,33 @@ func TestConvertSharedResultToStatic_RequireApproval(t *testing.T) {
 	}
 }
 
+// TestConvertSharedResultToStatic_RequireApprovalWithBlocked tests that
+// RequiresApproval is set correctly even when the shared engine also sets
+// Blocked=true (the shared engine sets Blocked=true for require_approval
+// policies because the request IS blocked pending human approval).
+func TestConvertSharedResultToStatic_RequireApprovalWithBlocked(t *testing.T) {
+	sharedResult := &sharedpolicy.RequestResult{
+		Blocked:           true,
+		BlockReason:       "Policy description text",
+		PoliciesEvaluated: 1,
+		MatchedPolicies: []sharedpolicy.PolicyMatch{
+			{
+				PolicyID: "custom_hitl_policy",
+				Action:   sharedpolicy.ActionRequireApproval,
+				Category: sharedpolicy.CategorySensitiveData,
+				Severity: sharedpolicy.SeverityHigh,
+			},
+		},
+	}
+
+	result := convertSharedResultToStatic(sharedResult)
+
+	if !result.RequiresApproval {
+		t.Error("Expected RequiresApproval=true even when Blocked=true")
+	}
+	if !result.Blocked {
+		t.Error("Expected Blocked=true (request is blocked pending approval)")
+	}
+}
+
 // TestIsPIICategory tests the PII category detection helper


### PR DESCRIPTION
## Summary

Fix for the HITL require_approval policy pre-check response. When a
custom policy with action=require_approval matched, the Gateway Mode
pre-check handler returned the policy description string as block_reason
instead of the "require_approval" sentinel. SDKs and plugins that check
for this sentinel to trigger the approval flow never saw it, so HITL
silently did not activate.

The handler now checks require_approval before blocked so the sentinel
takes precedence.

CHANGELOG v8.2.0 entry updated with the fix.

### Review Checklist
- [ ] No enterprise-only content leaked
- [ ] Fix is in gateway_handlers.go (community code)
- [ ] Unit test + runtime-e2e included