### PR TITLE
chore: bump example SDK/plugin pins + list Claude Desktop plugin in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 It operates inside the execution path between your workflow logic and model or tool calls. Gateways can help at the request boundary and observability tools can tell you what happened later. AxonFlow records why an action was allowed, blocked, paused, or resumed while the workflow is running.
 
-It runs self-hosted (Docker or Kubernetes), with SDKs for **Python**, **TypeScript**, **Go**, **Java**, and **Rust** (preview), plus governance plugins for **OpenClaw**, **Claude Code**, **Cursor**, **Codex**, **Google ADK**, **n8n**, and **LiteLLM**.
+It runs self-hosted (Docker or Kubernetes), with SDKs for **Python**, **TypeScript**, **Go**, **Java**, and **Rust** (preview), plus governance plugins for **OpenClaw**, **Claude Code**, **Claude Desktop**, **Cursor**, **Codex**, **Google ADK**, **n8n**, and **LiteLLM**.
 
 > **Upgrade strongly recommended.** AxonFlow ships substantial monthly security and quality hardening; staying on the latest major is the security-supported release line. [Latest release](https://github.com/getaxonflow/axonflow/releases/latest) · [Security advisories](https://github.com/getaxonflow/axonflow/security/advisories)
 
@@ -261,7 +261,7 @@ All features—policy enforcement, audit logging, MCP connectors, WCP workflows�
 
 AxonFlow ships official plugins for AI agent runtimes, coding assistants, and developer tools. All plugins enforce the same policy surface and share a single audit trail via your self-hosted AxonFlow stack.
 
-**OpenClaw** ships a source-available governance policy bundle covering shell injection, secret exfiltration, PII redaction, and tool-result risk classification. The same policy set ports across all four plugins below; the install path is the only thing that changes.
+**OpenClaw** ships a source-available governance policy bundle covering shell injection, secret exfiltration, PII redaction, and tool-result risk classification. The same policy set ports across all four hook plugins below (OpenClaw, Claude Code, Cursor, Codex); the install path is the only thing that changes. Claude Desktop has no hooks, so it applies the same policies at the MCP-proxy layer (a different interception point — see its row below).
 
 | Plugin | Platform | Install | Docs | Repo |
 |--------|----------|---------|------|------|
@@ -269,6 +269,7 @@ AxonFlow ships official plugins for AI agent runtimes, coding assistants, and de
 | **Claude Code** | Claude Code CLI | Marketplace or manual hooks | [Docs](https://docs.getaxonflow.com/docs/integration/claude-code/) | [GitHub](https://github.com/getaxonflow/axonflow-claude-plugin) |
 | **Cursor** | Cursor IDE | Pre-/post-tool hooks | [Docs](https://docs.getaxonflow.com/docs/integration/cursor/) | [GitHub](https://github.com/getaxonflow/axonflow-cursor-plugin) |
 | **Codex** | OpenAI Codex CLI | Bash hooks and advisory skills | [Docs](https://docs.getaxonflow.com/docs/integration/codex/) | [GitHub](https://github.com/getaxonflow/axonflow-codex-plugin) |
+| **Claude Desktop** | Claude Desktop app (Chat/Cowork/Code) | One-click `.mcpb` Desktop Extension (MCP governance proxy — no hooks) | [Docs](https://docs.getaxonflow.com/docs/integration/claude-desktop/) | [GitHub](https://github.com/getaxonflow/axonflow-claude-desktop-plugin) |
 | **Google ADK** | Google Agent Development Kit | `pip install axonflow-google-adk-plugin` | [Docs](https://docs.getaxonflow.com/docs/integration/google-adk/) | [GitHub](https://github.com/getaxonflow/axonflow-google-adk-plugin) |
 | **n8n** | n8n workflow automation | `npm install @axonflow/n8n-nodes-axonflow` | [Docs](https://docs.getaxonflow.com/docs/integration/n8n/) | [GitHub](https://github.com/getaxonflow/axonflow-n8n-node) |
 | **LiteLLM** | LiteLLM Python SDK | `pip install axonflow-litellm` | [Docs](https://docs.getaxonflow.com/docs/integration/litellm/) | [GitHub](https://github.com/getaxonflow/axonflow-litellm) |

--- a/examples/README.md
+++ b/examples/README.md
@@ -138,11 +138,11 @@ All examples use the latest SDK versions:
 
 | SDK | Package | Version |
 |-----|---------|---------|
-| Python | `axonflow` | >=8.3.0 |
-| TypeScript | `@axonflow/sdk` | >=8.3.0 |
-| Go | `github.com/getaxonflow/axonflow-sdk-go/v8` | v8.3.0 |
-| Java | `com.getaxonflow:axonflow-sdk` | 8.3.0 |
-| Rust _(preview)_ | `axonflow-sdk-rust` | 0.5.0 |
+| Python | `axonflow` | >=8.5.0 |
+| TypeScript | `@axonflow/sdk` | >=8.5.0 |
+| Go | `github.com/getaxonflow/axonflow-sdk-go/v8` | v8.5.0 |
+| Java | `com.getaxonflow:axonflow-sdk` | 8.5.0 |
+| Rust _(preview)_ | `axonflow-sdk-rust` | 0.7.0 |
 
 ## Environment Configuration
 

--- a/examples/audit-logging/go/go.mod
+++ b/examples/audit-logging/go/go.mod
@@ -3,6 +3,6 @@ module github.com/getaxonflow/axonflow/examples/audit-logging/go
 go 1.21
 
 require (
-	github.com/getaxonflow/axonflow-sdk-go/v8 v8.3.0
+	github.com/getaxonflow/axonflow-sdk-go/v8 v8.5.0
 	github.com/sashabaranov/go-openai v1.17.9
 )

--- a/examples/audit-logging/java/pom.xml
+++ b/examples/audit-logging/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>8.3.0</version>
+            <version>8.5.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/audit-logging/python/requirements.txt
+++ b/examples/audit-logging/python/requirements.txt
@@ -1,3 +1,3 @@
-axonflow>=8.3.0
+axonflow>=8.5.0
 python-dotenv>=1.0.0
 openai>=1.0.0

--- a/examples/audit-logging/typescript/package.json
+++ b/examples/audit-logging/typescript/package.json
@@ -7,7 +7,7 @@
     "start": "ts-node index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^8.3.0",
+    "@axonflow/sdk": "^8.5.0",
     "dotenv": "^16.6.1",
     "openai": "^4.104.0"
   },

--- a/examples/code-governance/go/go.mod
+++ b/examples/code-governance/go/go.mod
@@ -2,4 +2,4 @@ module github.com/axonflow/examples/code-governance
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v8 v8.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v8 v8.5.0

--- a/examples/code-governance/java/pom.xml
+++ b/examples/code-governance/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>8.3.0</version>
+            <version>8.5.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/code-governance/python/requirements.txt
+++ b/examples/code-governance/python/requirements.txt
@@ -1,2 +1,2 @@
-axonflow>=8.3.0
+axonflow>=8.5.0
 python-dotenv>=1.0.0

--- a/examples/code-governance/typescript/package.json
+++ b/examples/code-governance/typescript/package.json
@@ -9,7 +9,7 @@
     "start:built": "node dist/index.js"
   },
   "dependencies": {
-    "@axonflow/sdk": "^8.3.0",
+    "@axonflow/sdk": "^8.5.0",
     "dotenv": "^16.3.1"
   },
   "devDependencies": {

--- a/examples/cost-controls/enforcement/go/go.mod
+++ b/examples/cost-controls/enforcement/go/go.mod
@@ -2,4 +2,4 @@ module cost-controls-enforcement
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v8 v8.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v8 v8.5.0

--- a/examples/cost-controls/enforcement/java/pom.xml
+++ b/examples/cost-controls/enforcement/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>8.3.0</version>
+            <version>8.5.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/cost-controls/enforcement/python/main.py
+++ b/examples/cost-controls/enforcement/python/main.py
@@ -29,7 +29,7 @@ try:
     from axonflow.exceptions import BudgetExceededError
 except ImportError:
     print("ERROR: axonflow not installed")
-    print("Install with: pip install axonflow>=8.3.0")
+    print("Install with: pip install axonflow>=8.5.0")
     print("Or for local development: pip install -e ../../../../axonflow-sdk-python")
     sys.exit(1)
 

--- a/examples/cost-controls/enforcement/python/requirements.txt
+++ b/examples/cost-controls/enforcement/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=8.3.0
+axonflow>=8.5.0

--- a/examples/cost-controls/enforcement/typescript/package.json
+++ b/examples/cost-controls/enforcement/typescript/package.json
@@ -9,7 +9,7 @@
     "test": "npm run start"
   },
   "dependencies": {
-    "@axonflow/sdk": "^8.3.0"
+    "@axonflow/sdk": "^8.5.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/examples/cost-controls/go/go.mod
+++ b/examples/cost-controls/go/go.mod
@@ -2,4 +2,4 @@ module github.com/getaxonflow/axonflow/examples/cost-controls/go
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v8 v8.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v8 v8.5.0

--- a/examples/cost-controls/java/pom.xml
+++ b/examples/cost-controls/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>8.3.0</version>
+            <version>8.5.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/cost-controls/python/requirements.txt
+++ b/examples/cost-controls/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=8.3.0
+axonflow>=8.5.0

--- a/examples/cost-controls/typescript/package.json
+++ b/examples/cost-controls/typescript/package.json
@@ -8,7 +8,7 @@
     "start": "npx tsx src/index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^8.3.0"
+    "@axonflow/sdk": "^8.5.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/examples/cost-estimation/go/go.mod
+++ b/examples/cost-estimation/go/go.mod
@@ -2,4 +2,4 @@ module cost-estimation
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v8 v8.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v8 v8.5.0

--- a/examples/cost-estimation/java/pom.xml
+++ b/examples/cost-estimation/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>8.3.0</version>
+            <version>8.5.0</version>
         </dependency>
         <!-- Override transitive jackson for GHSA-72hv-8253-57qq -->
         <dependency>

--- a/examples/cost-estimation/python/requirements.txt
+++ b/examples/cost-estimation/python/requirements.txt
@@ -1,3 +1,3 @@
-axonflow>=8.3.0
+axonflow>=8.5.0
 python-dotenv>=1.0.0
 requests>=2.31.0

--- a/examples/cost-estimation/typescript/package.json
+++ b/examples/cost-estimation/typescript/package.json
@@ -8,7 +8,7 @@
     "start": "npx tsx index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^8.3.0",
+    "@axonflow/sdk": "^8.5.0",
     "dotenv": "^16.3.1"
   },
   "devDependencies": {

--- a/examples/demo/requirements.txt
+++ b/examples/demo/requirements.txt
@@ -1,5 +1,5 @@
 # Core SDK
-axonflow>=8.3.0
+axonflow>=8.5.0
 
 # HTTP client
 httpx>=0.24.0

--- a/examples/dynamic-policies/compliance/go/go.mod
+++ b/examples/dynamic-policies/compliance/go/go.mod
@@ -2,4 +2,4 @@ module compliance-example
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v8 v8.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v8 v8.5.0

--- a/examples/dynamic-policies/compliance/java/pom.xml
+++ b/examples/dynamic-policies/compliance/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>8.3.0</version>
+            <version>8.5.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/dynamic-policies/compliance/typescript/package.json
+++ b/examples/dynamic-policies/compliance/typescript/package.json
@@ -6,7 +6,7 @@
     "start": "npx ts-node --esm index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^8.3.0"
+    "@axonflow/sdk": "^8.5.0"
   },
   "devDependencies": {
     "ts-node": "^10.9.2",

--- a/examples/dynamic-policies/go/go.mod
+++ b/examples/dynamic-policies/go/go.mod
@@ -2,4 +2,4 @@ module github.com/getaxonflow/axonflow/examples/dynamic-policies/go
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v8 v8.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v8 v8.5.0

--- a/examples/dynamic-policies/java/pom.xml
+++ b/examples/dynamic-policies/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>8.3.0</version>
+            <version>8.5.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/dynamic-policies/typescript/package.json
+++ b/examples/dynamic-policies/typescript/package.json
@@ -6,6 +6,6 @@
     "start": "npx tsx index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^8.3.0"
+    "@axonflow/sdk": "^8.5.0"
   }
 }

--- a/examples/evaluation-tier/go/go.mod
+++ b/examples/evaluation-tier/go/go.mod
@@ -2,4 +2,4 @@ module github.com/getaxonflow/axonflow/examples/evaluation-tier/go
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v8 v8.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v8 v8.5.0

--- a/examples/evaluation-tier/java/pom.xml
+++ b/examples/evaluation-tier/java/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <axonflow.version>8.3.0</axonflow.version>
+        <axonflow.version>8.5.0</axonflow.version>
     </properties>
 
     <dependencyManagement>

--- a/examples/evaluation-tier/python/requirements.txt
+++ b/examples/evaluation-tier/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=8.3.0
+axonflow>=8.5.0

--- a/examples/evaluation-tier/typescript/package.json
+++ b/examples/evaluation-tier/typescript/package.json
@@ -7,7 +7,7 @@
     "test": "npx ts-node test_tier_limits.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^8.3.0"
+    "@axonflow/sdk": "^8.5.0"
   },
   "devDependencies": {
     "ts-node": "^10.9.2",

--- a/examples/execution-replay/go/go.mod
+++ b/examples/execution-replay/go/go.mod
@@ -2,4 +2,4 @@ module github.com/getaxonflow/axonflow/examples/execution-replay/go
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v8 v8.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v8 v8.5.0

--- a/examples/execution-replay/java/pom.xml
+++ b/examples/execution-replay/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>8.3.0</version>
+            <version>8.5.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/execution-replay/python/requirements.txt
+++ b/examples/execution-replay/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=8.3.0
+axonflow>=8.5.0

--- a/examples/execution-replay/typescript/package.json
+++ b/examples/execution-replay/typescript/package.json
@@ -9,7 +9,7 @@
     "dev": "ts-node src/index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^8.3.0"
+    "@axonflow/sdk": "^8.5.0"
   },
   "devDependencies": {
     "@types/node": "^20.10.0",

--- a/examples/execution-tracking/go/go.mod
+++ b/examples/execution-tracking/go/go.mod
@@ -2,4 +2,4 @@ module github.com/getaxonflow/axonflow-enterprise/examples/execution-tracking
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v8 v8.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v8 v8.5.0

--- a/examples/execution-tracking/java/pom.xml
+++ b/examples/execution-tracking/java/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <axonflow.sdk.version>8.3.0</axonflow.sdk.version>
+        <axonflow.sdk.version>8.5.0</axonflow.sdk.version>
     </properties>
 
     <dependencyManagement>

--- a/examples/execution-tracking/python/requirements.txt
+++ b/examples/execution-tracking/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=8.3.0
+axonflow>=8.5.0

--- a/examples/execution-tracking/typescript/package.json
+++ b/examples/execution-tracking/typescript/package.json
@@ -8,7 +8,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@axonflow/sdk": "^8.3.0"
+    "@axonflow/sdk": "^8.5.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/examples/gateway-policy-config/go/go.mod
+++ b/examples/gateway-policy-config/go/go.mod
@@ -2,4 +2,4 @@ module examples/gateway-policy-config/go
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v8 v8.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v8 v8.5.0

--- a/examples/gateway-policy-config/java/pom.xml
+++ b/examples/gateway-policy-config/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>8.3.0</version>
+            <version>8.5.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/gateway-policy-config/python/requirements.txt
+++ b/examples/gateway-policy-config/python/requirements.txt
@@ -1,2 +1,2 @@
-axonflow>=8.3.0
+axonflow>=8.5.0
 python-dotenv>=1.0.0

--- a/examples/gateway-policy-config/typescript/package.json
+++ b/examples/gateway-policy-config/typescript/package.json
@@ -7,7 +7,7 @@
     "start": "ts-node index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^8.3.0",
+    "@axonflow/sdk": "^8.5.0",
     "dotenv": "^16.3.1"
   },
   "devDependencies": {

--- a/examples/health-check/go/go.mod
+++ b/examples/health-check/go/go.mod
@@ -2,4 +2,4 @@ module health-check
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v8 v8.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v8 v8.5.0

--- a/examples/health-check/java/pom.xml
+++ b/examples/health-check/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>8.3.0</version>
+            <version>8.5.0</version>
         </dependency>
         <!-- Override transitive jackson for GHSA-72hv-8253-57qq -->
         <dependency>

--- a/examples/health-check/python/requirements.txt
+++ b/examples/health-check/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=8.3.0
+axonflow>=8.5.0

--- a/examples/health-check/typescript/package.json
+++ b/examples/health-check/typescript/package.json
@@ -6,6 +6,6 @@
     "start": "npx tsx index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^8.3.0"
+    "@axonflow/sdk": "^8.5.0"
   }
 }

--- a/examples/hello-world/go/go.mod
+++ b/examples/hello-world/go/go.mod
@@ -2,4 +2,4 @@ module github.com/axonflow/examples/hello-world
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v8 v8.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v8 v8.5.0

--- a/examples/hello-world/java/pom.xml
+++ b/examples/hello-world/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>8.3.0</version>
+            <version>8.5.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/hello-world/python/requirements.txt
+++ b/examples/hello-world/python/requirements.txt
@@ -1,5 +1,5 @@
 # AxonFlow SDK
-axonflow>=8.3.0
+axonflow>=8.5.0
 
 # Environment management
 python-dotenv>=1.0.0

--- a/examples/hello-world/rust/Cargo.toml
+++ b/examples/hello-world/rust/Cargo.toml
@@ -9,6 +9,6 @@ name = "axonflow-hello-world-rust"
 path = "main.rs"
 
 [dependencies]
-axonflow-sdk-rust = "0.5"
+axonflow-sdk-rust = "0.7.0"
 tokio = { version = "1", features = ["full"] }
 serde_json = "1"

--- a/examples/hello-world/typescript/package.json
+++ b/examples/hello-world/typescript/package.json
@@ -13,7 +13,7 @@
   "author": "AxonFlow",
   "license": "MIT",
   "dependencies": {
-    "@axonflow/sdk": "^8.3.0",
+    "@axonflow/sdk": "^8.5.0",
     "dotenv": "^16.3.0"
   },
   "devDependencies": {

--- a/examples/hitl-queue/go/go.mod
+++ b/examples/hitl-queue/go/go.mod
@@ -2,4 +2,4 @@ module github.com/axonflow/examples/hitl-queue
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v8 v8.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v8 v8.5.0

--- a/examples/hitl-queue/java/pom.xml
+++ b/examples/hitl-queue/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>8.3.0</version>
+            <version>8.5.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/hitl-queue/python/requirements.txt
+++ b/examples/hitl-queue/python/requirements.txt
@@ -1,2 +1,2 @@
-axonflow>=8.3.0
+axonflow>=8.5.0
 python-dotenv>=1.0.0

--- a/examples/hitl-queue/typescript/package.json
+++ b/examples/hitl-queue/typescript/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^8.3.0",
+    "@axonflow/sdk": "^8.5.0",
     "dotenv": "^16.3.1"
   },
   "devDependencies": {

--- a/examples/hitl/go/go.mod
+++ b/examples/hitl/go/go.mod
@@ -2,4 +2,4 @@ module axonflow-hitl-example
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v8 v8.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v8 v8.5.0

--- a/examples/hitl/java/pom.xml
+++ b/examples/hitl/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>8.3.0</version>
+            <version>8.5.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/hitl/python/requirements.txt
+++ b/examples/hitl/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=8.3.0
+axonflow>=8.5.0

--- a/examples/hitl/typescript/package.json
+++ b/examples/hitl/typescript/package.json
@@ -7,7 +7,7 @@
     "example": "npx ts-node --esm require-approval-policy.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^8.3.0"
+    "@axonflow/sdk": "^8.5.0"
   },
   "devDependencies": {
     "ts-node": "^10.9.2",

--- a/examples/integrations/autogen/java/pom.xml
+++ b/examples/integrations/autogen/java/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>8.3.0</version>
+            <version>8.5.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/integrations/autogen/requirements.txt
+++ b/examples/integrations/autogen/requirements.txt
@@ -1,3 +1,3 @@
 pyautogen>=0.2.0
-axonflow>=8.3.0
+axonflow>=8.5.0
 python-dotenv>=1.0.0

--- a/examples/integrations/computer-use/python/requirements.txt
+++ b/examples/integrations/computer-use/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=8.3.0
+axonflow>=8.5.0

--- a/examples/integrations/crewai/requirements.txt
+++ b/examples/integrations/crewai/requirements.txt
@@ -1,5 +1,5 @@
 # AxonFlow SDK
-axonflow>=8.3.0
+axonflow>=8.5.0
 
 # CrewAI
 crewai>=0.5.0

--- a/examples/integrations/dspy/go/go.mod
+++ b/examples/integrations/dspy/go/go.mod
@@ -2,4 +2,4 @@ module dspy-axonflow-example
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v8 v8.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v8 v8.5.0

--- a/examples/integrations/dspy/python/requirements.txt
+++ b/examples/integrations/dspy/python/requirements.txt
@@ -1,2 +1,2 @@
-axonflow>=8.3.0
+axonflow>=8.5.0
 python-dotenv>=1.0.0

--- a/examples/integrations/gateway-mode/go/go.mod
+++ b/examples/integrations/gateway-mode/go/go.mod
@@ -3,6 +3,6 @@ module github.com/getaxonflow/axonflow/examples/integrations/gateway-mode/go
 go 1.21
 
 require (
-	github.com/getaxonflow/axonflow-sdk-go/v8 v8.3.0
+	github.com/getaxonflow/axonflow-sdk-go/v8 v8.5.0
 	github.com/sashabaranov/go-openai v1.17.9
 )

--- a/examples/integrations/gateway-mode/java/pom.xml
+++ b/examples/integrations/gateway-mode/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>8.3.0</version>
+            <version>8.5.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/integrations/gateway-mode/python/requirements.txt
+++ b/examples/integrations/gateway-mode/python/requirements.txt
@@ -1,5 +1,5 @@
 # AxonFlow SDK
-axonflow>=8.3.0
+axonflow>=8.5.0
 
 # LLM Providers
 openai>=1.6.0

--- a/examples/integrations/gateway-mode/typescript/package.json
+++ b/examples/integrations/gateway-mode/typescript/package.json
@@ -14,7 +14,7 @@
   "author": "AxonFlow",
   "license": "MIT",
   "dependencies": {
-    "@axonflow/sdk": "^8.3.0",
+    "@axonflow/sdk": "^8.5.0",
     "dotenv": "^16.3.0",
     "openai": "^4.20.0",
     "@anthropic-ai/sdk": "^0.32.0"

--- a/examples/integrations/governed-tools/go/go.mod
+++ b/examples/integrations/governed-tools/go/go.mod
@@ -2,4 +2,4 @@ module github.com/axonflow/examples/governed-tools
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v8 v8.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v8 v8.5.0

--- a/examples/integrations/governed-tools/java/pom.xml
+++ b/examples/integrations/governed-tools/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>8.3.0</version>
+            <version>8.5.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/integrations/governed-tools/python/requirements.txt
+++ b/examples/integrations/governed-tools/python/requirements.txt
@@ -1,2 +1,2 @@
-axonflow>=8.3.0
+axonflow>=8.5.0
 langchain-core>=0.3.0

--- a/examples/integrations/governed-tools/typescript/package.json
+++ b/examples/integrations/governed-tools/typescript/package.json
@@ -13,7 +13,7 @@
   "author": "AxonFlow",
   "license": "MIT",
   "dependencies": {
-    "@axonflow/sdk": "^8.3.0"
+    "@axonflow/sdk": "^8.5.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/examples/integrations/langchain/requirements.txt
+++ b/examples/integrations/langchain/requirements.txt
@@ -1,5 +1,5 @@
 # AxonFlow SDK
-axonflow>=8.3.0
+axonflow>=8.5.0
 
 # LangChain
 langchain>=0.1.0

--- a/examples/integrations/langgraph/go/go.mod
+++ b/examples/integrations/langgraph/go/go.mod
@@ -2,4 +2,4 @@ module langgraph-axonflow-example
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v8 v8.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v8 v8.5.0

--- a/examples/integrations/langgraph/python/requirements.txt
+++ b/examples/integrations/langgraph/python/requirements.txt
@@ -1,2 +1,2 @@
-axonflow>=8.3.0
+axonflow>=8.5.0
 python-dotenv>=1.0.0

--- a/examples/integrations/langgraph/typescript/package.json
+++ b/examples/integrations/langgraph/typescript/package.json
@@ -9,7 +9,7 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
-    "@axonflow/sdk": "^8.3.0"
+    "@axonflow/sdk": "^8.5.0"
   },
   "devDependencies": {
     "@types/node": "^20.10.0",

--- a/examples/integrations/proxy-mode/go/go.mod
+++ b/examples/integrations/proxy-mode/go/go.mod
@@ -2,4 +2,4 @@ module github.com/getaxonflow/axonflow/examples/integrations/proxy-mode/go
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v8 v8.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v8 v8.5.0

--- a/examples/integrations/proxy-mode/java/pom.xml
+++ b/examples/integrations/proxy-mode/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>8.3.0</version>
+            <version>8.5.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/integrations/proxy-mode/python/requirements.txt
+++ b/examples/integrations/proxy-mode/python/requirements.txt
@@ -1,5 +1,5 @@
 # AxonFlow SDK
-axonflow>=8.3.0
+axonflow>=8.5.0
 
 # Environment management
 python-dotenv>=1.0.0

--- a/examples/integrations/proxy-mode/typescript/package.json
+++ b/examples/integrations/proxy-mode/typescript/package.json
@@ -10,7 +10,7 @@
     "dev": "ts-node src/index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^8.3.0",
+    "@axonflow/sdk": "^8.5.0",
     "dotenv": "^16.6.1"
   },
   "devDependencies": {

--- a/examples/integrations/semantic-kernel/java/pom.xml
+++ b/examples/integrations/semantic-kernel/java/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>8.3.0</version>
+            <version>8.5.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/integrations/semantic-kernel/typescript/package.json
+++ b/examples/integrations/semantic-kernel/typescript/package.json
@@ -9,7 +9,7 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
-    "@axonflow/sdk": "^8.3.0"
+    "@axonflow/sdk": "^8.5.0"
   },
   "devDependencies": {
     "@types/node": "^20.10.0",

--- a/examples/integrations/spring-boot/pom.xml
+++ b/examples/integrations/spring-boot/pom.xml
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>8.3.0</version>
+            <version>8.5.0</version>
         </dependency>
 
         <!-- OpenAI for Gateway Mode demo -->

--- a/examples/interceptors/go/go.mod
+++ b/examples/interceptors/go/go.mod
@@ -2,4 +2,4 @@ module github.com/getaxonflow/axonflow/examples/interceptors/go
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v8 v8.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v8 v8.5.0

--- a/examples/interceptors/java/pom.xml
+++ b/examples/interceptors/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>8.3.0</version>
+            <version>8.5.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/interceptors/python/requirements.txt
+++ b/examples/interceptors/python/requirements.txt
@@ -1,2 +1,2 @@
-axonflow>=8.3.0
+axonflow>=8.5.0
 openai>=1.0.0

--- a/examples/interceptors/rust/Cargo.toml
+++ b/examples/interceptors/rust/Cargo.toml
@@ -9,6 +9,6 @@ name = "axonflow-interceptors-rust"
 path = "main.rs"
 
 [dependencies]
-axonflow-sdk-rust = "0.5"
+axonflow-sdk-rust = "0.7.0"
 tokio = { version = "1", features = ["full"] }
 async-trait = "0.1"

--- a/examples/interceptors/typescript/package.json
+++ b/examples/interceptors/typescript/package.json
@@ -7,7 +7,7 @@
     "start": "ts-node src/index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^8.3.0",
+    "@axonflow/sdk": "^8.5.0",
     "dotenv": "^16.3.1",
     "openai": "^4.20.0"
   },

--- a/examples/llm-providers/azure-openai/pii-detection/python/requirements.txt
+++ b/examples/llm-providers/azure-openai/pii-detection/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=8.3.0
+axonflow>=8.5.0

--- a/examples/llm-providers/azure-openai/proxy-mode/go/go.mod
+++ b/examples/llm-providers/azure-openai/proxy-mode/go/go.mod
@@ -2,4 +2,4 @@ module github.com/getaxonflow/axonflow/examples/llm-providers/azure-openai/proxy
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v8 v8.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v8 v8.5.0

--- a/examples/llm-providers/azure-openai/sqli-scanning/typescript/package.json
+++ b/examples/llm-providers/azure-openai/sqli-scanning/typescript/package.json
@@ -8,7 +8,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^8.3.0"
+    "@axonflow/sdk": "^8.5.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/examples/llm-providers/mistral/hello-world/go/go.mod
+++ b/examples/llm-providers/mistral/hello-world/go/go.mod
@@ -2,4 +2,4 @@ module mistral-hello-world
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v8 v8.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v8 v8.5.0

--- a/examples/llm-providers/mistral/hello-world/java/pom.xml
+++ b/examples/llm-providers/mistral/hello-world/java/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>8.3.0</version>
+            <version>8.5.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>

--- a/examples/llm-providers/mistral/hello-world/python/main.py
+++ b/examples/llm-providers/mistral/hello-world/python/main.py
@@ -5,7 +5,7 @@ Demonstrates Gateway Mode and Proxy Mode with Mistral through AxonFlow.
 
 Prerequisites:
     docker compose up -d
-    pip install axonflow>=8.3.0
+    pip install axonflow>=8.5.0
     export AXONFLOW_CLIENT_SECRET=your-secret
 
 Usage:

--- a/examples/llm-providers/mistral/hello-world/python/requirements.txt
+++ b/examples/llm-providers/mistral/hello-world/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=8.3.0
+axonflow>=8.5.0

--- a/examples/llm-providers/mistral/hello-world/typescript/package.json
+++ b/examples/llm-providers/mistral/hello-world/typescript/package.json
@@ -7,7 +7,7 @@
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^8.3.0"
+    "@axonflow/sdk": "^8.5.0"
   },
   "devDependencies": {
     "tsx": "^4.7.0",

--- a/examples/llm-routing/e2e-tests/go/go.mod
+++ b/examples/llm-routing/e2e-tests/go/go.mod
@@ -2,4 +2,4 @@ module llm-provider-tests
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v8 v8.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v8 v8.5.0

--- a/examples/llm-routing/e2e-tests/java/pom.xml
+++ b/examples/llm-routing/e2e-tests/java/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>8.3.0</version>
+            <version>8.5.0</version>
         </dependency>
         <!-- Override transitive jackson for GHSA-72hv-8253-57qq -->
         <dependency>

--- a/examples/llm-routing/e2e-tests/python/requirements.txt
+++ b/examples/llm-routing/e2e-tests/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=8.3.0
+axonflow>=8.5.0

--- a/examples/llm-routing/e2e-tests/typescript/package.json
+++ b/examples/llm-routing/e2e-tests/typescript/package.json
@@ -7,7 +7,7 @@
     "test": "ts-node main.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^8.3.0"
+    "@axonflow/sdk": "^8.5.0"
   },
   "devDependencies": {
     "ts-node": "^10.9.0",

--- a/examples/llm-routing/go/go.mod
+++ b/examples/llm-routing/go/go.mod
@@ -2,4 +2,4 @@ module github.com/getaxonflow/axonflow/examples/llm-routing/go
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v8 v8.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v8 v8.5.0

--- a/examples/llm-routing/java/pom.xml
+++ b/examples/llm-routing/java/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>8.3.0</version>
+            <version>8.5.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/llm-routing/python/requirements.txt
+++ b/examples/llm-routing/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=8.3.0
+axonflow>=8.5.0

--- a/examples/llm-routing/typescript/package.json
+++ b/examples/llm-routing/typescript/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx provider-routing.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^8.3.0"
+    "@axonflow/sdk": "^8.5.0"
   },
   "devDependencies": {
     "typescript": "^5.3.0",

--- a/examples/map-confirm-mode/go/go.mod
+++ b/examples/map-confirm-mode/go/go.mod
@@ -2,4 +2,4 @@ module github.com/getaxonflow/axonflow/examples/map-confirm-mode/go
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v8 v8.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v8 v8.5.0

--- a/examples/map-confirm-mode/java/pom.xml
+++ b/examples/map-confirm-mode/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>8.3.0</version>
+            <version>8.5.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/map-confirm-mode/python/requirements.txt
+++ b/examples/map-confirm-mode/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=8.3.0
+axonflow>=8.5.0

--- a/examples/map-confirm-mode/typescript/package.json
+++ b/examples/map-confirm-mode/typescript/package.json
@@ -9,7 +9,7 @@
     "start": "npx tsx src/index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^8.3.0"
+    "@axonflow/sdk": "^8.5.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/examples/map-lifecycle/go/go.mod
+++ b/examples/map-lifecycle/go/go.mod
@@ -2,4 +2,4 @@ module github.com/getaxonflow/axonflow/examples/map-lifecycle/go
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v8 v8.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v8 v8.5.0

--- a/examples/map-lifecycle/java/pom.xml
+++ b/examples/map-lifecycle/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>8.3.0</version>
+            <version>8.5.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/map-lifecycle/python/requirements.txt
+++ b/examples/map-lifecycle/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=8.3.0
+axonflow>=8.5.0

--- a/examples/map-lifecycle/typescript/package.json
+++ b/examples/map-lifecycle/typescript/package.json
@@ -9,7 +9,7 @@
     "start": "npx tsx src/index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^8.3.0"
+    "@axonflow/sdk": "^8.5.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/examples/map/go/go.mod
+++ b/examples/map/go/go.mod
@@ -2,4 +2,4 @@ module github.com/getaxonflow/axonflow/examples/map/go
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v8 v8.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v8 v8.5.0

--- a/examples/map/java/pom.xml
+++ b/examples/map/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>8.3.0</version>
+            <version>8.5.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/map/python/requirements.txt
+++ b/examples/map/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=8.3.0
+axonflow>=8.5.0

--- a/examples/map/rust/Cargo.toml
+++ b/examples/map/rust/Cargo.toml
@@ -9,5 +9,5 @@ name = "axonflow-map-rust"
 path = "main.rs"
 
 [dependencies]
-axonflow-sdk-rust = "0.5"
+axonflow-sdk-rust = "0.7.0"
 tokio = { version = "1", features = ["full"] }

--- a/examples/map/typescript/package.json
+++ b/examples/map/typescript/package.json
@@ -9,7 +9,7 @@
     "start": "npx tsx src/index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^8.3.0"
+    "@axonflow/sdk": "^8.5.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/examples/mcp-audit/go/go.mod
+++ b/examples/mcp-audit/go/go.mod
@@ -2,4 +2,4 @@ module mcp-audit-example
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v8 v8.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v8 v8.5.0

--- a/examples/mcp-audit/java/pom.xml
+++ b/examples/mcp-audit/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>8.3.0</version>
+            <version>8.5.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/mcp-audit/python/requirements.txt
+++ b/examples/mcp-audit/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=8.3.0
+axonflow>=8.5.0

--- a/examples/mcp-audit/typescript/package.json
+++ b/examples/mcp-audit/typescript/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^8.3.0"
+    "@axonflow/sdk": "^8.5.0"
   },
   "devDependencies": {
     "tsx": "^4.7.0",

--- a/examples/mcp-connectors/cloud-storage/go/go.mod
+++ b/examples/mcp-connectors/cloud-storage/go/go.mod
@@ -2,4 +2,4 @@ module github.com/getaxonflow/axonflow/examples/mcp-connectors/cloud-storage/go
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v8 v8.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v8 v8.5.0

--- a/examples/mcp-connectors/cloud-storage/java/pom.xml
+++ b/examples/mcp-connectors/cloud-storage/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>8.3.0</version>
+            <version>8.5.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/mcp-connectors/cloud-storage/python/requirements.txt
+++ b/examples/mcp-connectors/cloud-storage/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=8.3.0
+axonflow>=8.5.0

--- a/examples/mcp-connectors/cloud-storage/typescript/package.json
+++ b/examples/mcp-connectors/cloud-storage/typescript/package.json
@@ -7,7 +7,7 @@
     "start": "ts-node src/index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^8.3.0"
+    "@axonflow/sdk": "^8.5.0"
   },
   "devDependencies": {
     "ts-node": "^10.9.2",

--- a/examples/mcp-connectors/http/go/go.mod
+++ b/examples/mcp-connectors/http/go/go.mod
@@ -2,4 +2,4 @@ module github.com/getaxonflow/axonflow-enterprise/examples/mcp-connectors/http/g
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v8 v8.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v8 v8.5.0

--- a/examples/mcp-connectors/java/pom.xml
+++ b/examples/mcp-connectors/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>8.3.0</version>
+            <version>8.5.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/mcp-connectors/python/requirements.txt
+++ b/examples/mcp-connectors/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=8.3.0
+axonflow>=8.5.0

--- a/examples/mcp-connectors/rust/Cargo.toml
+++ b/examples/mcp-connectors/rust/Cargo.toml
@@ -9,6 +9,6 @@ name = "axonflow-mcp-connectors-rust"
 path = "main.rs"
 
 [dependencies]
-axonflow-sdk-rust = "0.5"
+axonflow-sdk-rust = "0.7.0"
 tokio = { version = "1", features = ["full"] }
 serde_json = "1"

--- a/examples/mcp-policies/check-endpoints/go/go.mod
+++ b/examples/mcp-policies/check-endpoints/go/go.mod
@@ -2,4 +2,4 @@ module mcp-check-endpoints-example
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v8 v8.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v8 v8.5.0

--- a/examples/mcp-policies/check-endpoints/java/pom.xml
+++ b/examples/mcp-policies/check-endpoints/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>8.3.0</version>
+            <version>8.5.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/mcp-policies/check-endpoints/python/requirements.txt
+++ b/examples/mcp-policies/check-endpoints/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=8.3.0
+axonflow>=8.5.0

--- a/examples/mcp-policies/check-endpoints/typescript/package.json
+++ b/examples/mcp-policies/check-endpoints/typescript/package.json
@@ -7,7 +7,7 @@
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^8.3.0"
+    "@axonflow/sdk": "^8.5.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/examples/mcp-policies/go/go.mod
+++ b/examples/mcp-policies/go/go.mod
@@ -2,4 +2,4 @@ module mcp-policies-example
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v8 v8.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v8 v8.5.0

--- a/examples/mcp-policies/java/pom.xml
+++ b/examples/mcp-policies/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>8.3.0</version>
+            <version>8.5.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/mcp-policies/pii-redaction/go/go.mod
+++ b/examples/mcp-policies/pii-redaction/go/go.mod
@@ -2,4 +2,4 @@ module mcp-pii-redaction-example
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v8 v8.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v8 v8.5.0

--- a/examples/mcp-policies/pii-redaction/java/pom.xml
+++ b/examples/mcp-policies/pii-redaction/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>8.3.0</version>
+            <version>8.5.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/mcp-policies/pii-redaction/python/requirements.txt
+++ b/examples/mcp-policies/pii-redaction/python/requirements.txt
@@ -1,2 +1,2 @@
-axonflow>=8.3.0
+axonflow>=8.5.0
 python-dotenv>=1.0.0

--- a/examples/mcp-policies/pii-redaction/typescript/package.json
+++ b/examples/mcp-policies/pii-redaction/typescript/package.json
@@ -7,7 +7,7 @@
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^8.3.0"
+    "@axonflow/sdk": "^8.5.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/examples/mcp-policies/python/requirements.txt
+++ b/examples/mcp-policies/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=8.3.0
+axonflow>=8.5.0

--- a/examples/mcp-policies/typescript/package.json
+++ b/examples/mcp-policies/typescript/package.json
@@ -7,7 +7,7 @@
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^8.3.0"
+    "@axonflow/sdk": "^8.5.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/examples/media-governance-policies/go/go.mod
+++ b/examples/media-governance-policies/go/go.mod
@@ -2,4 +2,4 @@ module github.com/axonflow/examples/media-governance-policies
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v8 v8.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v8 v8.5.0

--- a/examples/media-governance-policies/java/pom.xml
+++ b/examples/media-governance-policies/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>8.3.0</version>
+            <version>8.5.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/media-governance-policies/python/requirements.txt
+++ b/examples/media-governance-policies/python/requirements.txt
@@ -1,2 +1,2 @@
-axonflow>=8.3.0
+axonflow>=8.5.0
 python-dotenv>=1.0.0

--- a/examples/media-governance-policies/typescript/package.json
+++ b/examples/media-governance-policies/typescript/package.json
@@ -7,7 +7,7 @@
     "start": "ts-node main.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^8.3.0",
+    "@axonflow/sdk": "^8.5.0",
     "dotenv": "^16.3.1"
   },
   "devDependencies": {

--- a/examples/media-governance/go/go.mod
+++ b/examples/media-governance/go/go.mod
@@ -2,4 +2,4 @@ module github.com/axonflow/examples/media-governance
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v8 v8.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v8 v8.5.0

--- a/examples/media-governance/java/pom.xml
+++ b/examples/media-governance/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>8.3.0</version>
+            <version>8.5.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/media-governance/python/requirements.txt
+++ b/examples/media-governance/python/requirements.txt
@@ -1,2 +1,2 @@
-axonflow>=8.3.0
+axonflow>=8.5.0
 python-dotenv>=1.0.0

--- a/examples/media-governance/typescript/package.json
+++ b/examples/media-governance/typescript/package.json
@@ -7,7 +7,7 @@
     "start": "ts-node index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^8.3.0",
+    "@axonflow/sdk": "^8.5.0",
     "dotenv": "^16.3.1"
   },
   "devDependencies": {

--- a/examples/pii-detection/go/go.mod
+++ b/examples/pii-detection/go/go.mod
@@ -2,4 +2,4 @@ module github.com/getaxonflow/axonflow/examples/pii-detection/go
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v8 v8.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v8 v8.5.0

--- a/examples/pii-detection/java/pom.xml
+++ b/examples/pii-detection/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>8.3.0</version>
+            <version>8.5.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/pii-detection/python/requirements.txt
+++ b/examples/pii-detection/python/requirements.txt
@@ -1,2 +1,2 @@
-axonflow>=8.3.0
+axonflow>=8.5.0
 python-dotenv>=1.0.0

--- a/examples/pii-detection/typescript/package.json
+++ b/examples/pii-detection/typescript/package.json
@@ -7,7 +7,7 @@
     "start": "ts-node index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^8.3.0",
+    "@axonflow/sdk": "^8.5.0",
     "dotenv": "^16.3.1"
   },
   "devDependencies": {

--- a/examples/policies/crud/requirements.txt
+++ b/examples/policies/crud/requirements.txt
@@ -1,5 +1,5 @@
 # AxonFlow SDK
-axonflow>=8.3.0
+axonflow>=8.5.0
 
 # HTTP client for direct API calls
 httpx>=0.25.0

--- a/examples/policies/go/README.md
+++ b/examples/policies/go/README.md
@@ -12,7 +12,7 @@ Examples demonstrating policy CRUD operations using the AxonFlow Go SDK.
 
 ```bash
 # Install SDK
-go get github.com/getaxonflow/axonflow-sdk-go/v8@v8.3.0
+go get github.com/getaxonflow/axonflow-sdk-go/v8@v8.5.0
 ```
 
 ## Environment Variables

--- a/examples/policies/go/create-custom-policy/go.mod
+++ b/examples/policies/go/create-custom-policy/go.mod
@@ -2,4 +2,4 @@ module github.com/getaxonflow/axonflow-enterprise/examples/policies/go
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v8 v8.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v8 v8.5.0

--- a/examples/policies/go/list-and-filter/go.mod
+++ b/examples/policies/go/list-and-filter/go.mod
@@ -2,4 +2,4 @@ module github.com/getaxonflow/axonflow-enterprise/examples/policies/go
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v8 v8.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v8 v8.5.0

--- a/examples/policies/go/test-pattern/go.mod
+++ b/examples/policies/go/test-pattern/go.mod
@@ -2,4 +2,4 @@ module github.com/getaxonflow/axonflow-enterprise/examples/policies/go
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v8 v8.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v8 v8.5.0

--- a/examples/policies/java/pom.xml
+++ b/examples/policies/java/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>8.3.0</version>
+            <version>8.5.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/policies/python/requirements.txt
+++ b/examples/policies/python/requirements.txt
@@ -1,5 +1,5 @@
 # AxonFlow SDK (from feature branch)
-axonflow>=8.3.0
+axonflow>=8.5.0
 
 # For loading environment variables
 python-dotenv>=1.0.0

--- a/examples/policies/typescript/package.json
+++ b/examples/policies/typescript/package.json
@@ -10,7 +10,7 @@
     "all": "npm run create && npm run list && npm run test-pattern"
   },
   "dependencies": {
-    "@axonflow/sdk": "^8.3.0"
+    "@axonflow/sdk": "^8.5.0"
   },
   "devDependencies": {
     "tsx": "^4.7.0",

--- a/examples/policy-configuration/go/go.mod
+++ b/examples/policy-configuration/go/go.mod
@@ -2,4 +2,4 @@ module examples/policy-configuration/go
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v8 v8.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v8 v8.5.0

--- a/examples/policy-configuration/java/pom.xml
+++ b/examples/policy-configuration/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>8.3.0</version>
+            <version>8.5.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/policy-configuration/python/requirements.txt
+++ b/examples/policy-configuration/python/requirements.txt
@@ -1,2 +1,2 @@
-axonflow>=8.3.0
+axonflow>=8.5.0
 python-dotenv>=1.0.0

--- a/examples/policy-configuration/typescript/package.json
+++ b/examples/policy-configuration/typescript/package.json
@@ -7,7 +7,7 @@
     "start": "ts-node index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^8.3.0",
+    "@axonflow/sdk": "^8.5.0",
     "dotenv": "^16.3.1"
   },
   "devDependencies": {

--- a/examples/retry-semantics/go/go.mod
+++ b/examples/retry-semantics/go/go.mod
@@ -2,6 +2,6 @@ module github.com/getaxonflow/axonflow-enterprise/examples/retry-semantics/go
 
 go 1.23.0
 
-require github.com/getaxonflow/axonflow-sdk-go/v8 v8.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v8 v8.5.0
 
 replace github.com/getaxonflow/axonflow-sdk-go/v8 => /Users/saurabhjain/Development/axonflow-sdk-go

--- a/examples/retry-semantics/java/pom.xml
+++ b/examples/retry-semantics/java/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>8.3.0</version>
+            <version>8.5.0</version>
         </dependency>
     </dependencies>
 </project>

--- a/examples/risk-tiered-approvals/go/go.mod
+++ b/examples/risk-tiered-approvals/go/go.mod
@@ -2,4 +2,4 @@ module github.com/axonflow/examples/risk-tiered-approvals
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v8 v8.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v8 v8.5.0

--- a/examples/sdk-audit/go/go.mod
+++ b/examples/sdk-audit/go/go.mod
@@ -2,4 +2,4 @@ module github.com/axonflow/examples/sdk-audit
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v8 v8.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v8 v8.5.0

--- a/examples/sdk-audit/java/pom.xml
+++ b/examples/sdk-audit/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>8.3.0</version>
+            <version>8.5.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/sdk-audit/python/requirements.txt
+++ b/examples/sdk-audit/python/requirements.txt
@@ -1,2 +1,2 @@
-axonflow>=8.3.0
+axonflow>=8.5.0
 python-dotenv>=1.0.0

--- a/examples/sdk-audit/typescript/package.json
+++ b/examples/sdk-audit/typescript/package.json
@@ -13,7 +13,7 @@
   "author": "AxonFlow",
   "license": "MIT",
   "dependencies": {
-    "@axonflow/sdk": "^8.3.0",
+    "@axonflow/sdk": "^8.5.0",
     "dotenv": "^16.3.0"
   },
   "devDependencies": {

--- a/examples/singapore-pii/go/go.mod
+++ b/examples/singapore-pii/go/go.mod
@@ -2,4 +2,4 @@ module singapore-pii-example
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v8 v8.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v8 v8.5.0

--- a/examples/singapore-pii/java/pom.xml
+++ b/examples/singapore-pii/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>8.3.0</version>
+            <version>8.5.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/singapore-pii/python/requirements.txt
+++ b/examples/singapore-pii/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=8.3.0
+axonflow>=8.5.0

--- a/examples/singapore-pii/typescript/package.json
+++ b/examples/singapore-pii/typescript/package.json
@@ -8,7 +8,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@axonflow/sdk": "^8.3.0"
+    "@axonflow/sdk": "^8.5.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/examples/sqli-detection/go/go.mod
+++ b/examples/sqli-detection/go/go.mod
@@ -2,4 +2,4 @@ module github.com/getaxonflow/axonflow/examples/sqli-detection/go
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v8 v8.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v8 v8.5.0

--- a/examples/sqli-detection/java/pom.xml
+++ b/examples/sqli-detection/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>8.3.0</version>
+            <version>8.5.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/sqli-detection/python/requirements.txt
+++ b/examples/sqli-detection/python/requirements.txt
@@ -1,2 +1,2 @@
-axonflow>=8.3.0
+axonflow>=8.5.0
 python-dotenv>=1.0.0

--- a/examples/sqli-detection/typescript/package.json
+++ b/examples/sqli-detection/typescript/package.json
@@ -7,7 +7,7 @@
     "start": "ts-node index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^8.3.0",
+    "@axonflow/sdk": "^8.5.0",
     "dotenv": "^16.3.1"
   },
   "devDependencies": {

--- a/examples/static-policies/go/go.mod
+++ b/examples/static-policies/go/go.mod
@@ -2,4 +2,4 @@ module static-policies-example
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v8 v8.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v8 v8.5.0

--- a/examples/static-policies/java/pom.xml
+++ b/examples/static-policies/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>8.3.0</version>
+            <version>8.5.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/static-policies/python/requirements.txt
+++ b/examples/static-policies/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=8.3.0
+axonflow>=8.5.0

--- a/examples/static-policies/typescript/package.json
+++ b/examples/static-policies/typescript/package.json
@@ -7,7 +7,7 @@
     "start": "npx ts-node index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^8.3.0"
+    "@axonflow/sdk": "^8.5.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/examples/support-demo/backend/go.mod
+++ b/examples/support-demo/backend/go.mod
@@ -3,7 +3,7 @@ module axonflow-support-demo
 go 1.21
 
 require (
-	github.com/getaxonflow/axonflow-sdk-go/v8 v8.3.0
+	github.com/getaxonflow/axonflow-sdk-go/v8 v8.5.0
 	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/gorilla/mux v1.8.1
 	github.com/lib/pq v1.10.9

--- a/examples/version-check/go/go.mod
+++ b/examples/version-check/go/go.mod
@@ -2,4 +2,4 @@ module version-check-example
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v8 v8.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v8 v8.5.0

--- a/examples/version-check/java/pom.xml
+++ b/examples/version-check/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>8.3.0</version>
+            <version>8.5.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/examples/version-check/python/requirements.txt
+++ b/examples/version-check/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=8.3.0
+axonflow>=8.5.0

--- a/examples/version-check/typescript/package.json
+++ b/examples/version-check/typescript/package.json
@@ -7,7 +7,7 @@
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^8.3.0"
+    "@axonflow/sdk": "^8.5.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/examples/wcp-retry-idempotency/community/go/go.mod
+++ b/examples/wcp-retry-idempotency/community/go/go.mod
@@ -2,4 +2,4 @@ module github.com/getaxonflow/axonflow-enterprise/examples/wcp-retry-idempotency
 
 go 1.23
 
-require github.com/getaxonflow/axonflow-sdk-go/v8 v8.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v8 v8.5.0

--- a/examples/wcp-retry-idempotency/community/java/pom.xml
+++ b/examples/wcp-retry-idempotency/community/java/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>8.3.0</version>
+            <version>8.5.0</version>
         </dependency>
     </dependencies>
 

--- a/examples/wcp-retry-idempotency/evaluation/go/go.mod
+++ b/examples/wcp-retry-idempotency/evaluation/go/go.mod
@@ -2,4 +2,4 @@ module github.com/getaxonflow/axonflow-enterprise/examples/wcp-retry-idempotency
 
 go 1.23
 
-require github.com/getaxonflow/axonflow-sdk-go/v8 v8.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v8 v8.5.0

--- a/examples/wcp-retry-idempotency/evaluation/java/pom.xml
+++ b/examples/wcp-retry-idempotency/evaluation/java/pom.xml
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>8.3.0</version>
+            <version>8.5.0</version>
         </dependency>
     </dependencies>
 

--- a/examples/webhooks/go/go.mod
+++ b/examples/webhooks/go/go.mod
@@ -2,4 +2,4 @@ module webhooks
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v8 v8.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v8 v8.5.0

--- a/examples/webhooks/java/pom.xml
+++ b/examples/webhooks/java/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>8.3.0</version>
+            <version>8.5.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/webhooks/python/requirements.txt
+++ b/examples/webhooks/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=8.3.0
+axonflow>=8.5.0

--- a/examples/webhooks/typescript/package.json
+++ b/examples/webhooks/typescript/package.json
@@ -7,7 +7,7 @@
     "start": "npx ts-node src/index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^8.3.0",
+    "@axonflow/sdk": "^8.5.0",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.0"
   }

--- a/examples/workflow-control/go/go.mod
+++ b/examples/workflow-control/go/go.mod
@@ -2,4 +2,4 @@ module workflow-control
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v8 v8.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v8 v8.5.0

--- a/examples/workflow-control/java/pom.xml
+++ b/examples/workflow-control/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>8.3.0</version>
+            <version>8.5.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/workflow-control/python/requirements.txt
+++ b/examples/workflow-control/python/requirements.txt
@@ -1,3 +1,3 @@
-axonflow>=8.3.0
+axonflow>=8.5.0
 python-dotenv>=1.0.0
 langgraph>=0.2.0

--- a/examples/workflow-control/typescript/package.json
+++ b/examples/workflow-control/typescript/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^8.3.0",
+    "@axonflow/sdk": "^8.5.0",
     "dotenv": "^16.3.1"
   },
   "devDependencies": {

--- a/examples/workflow-fail/go/go.mod
+++ b/examples/workflow-fail/go/go.mod
@@ -2,4 +2,4 @@ module workflow-fail
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v8 v8.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v8 v8.5.0

--- a/examples/workflow-fail/java/pom.xml
+++ b/examples/workflow-fail/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>8.3.0</version>
+            <version>8.5.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/workflow-fail/python/requirements.txt
+++ b/examples/workflow-fail/python/requirements.txt
@@ -1,2 +1,2 @@
-axonflow>=8.3.0
+axonflow>=8.5.0
 python-dotenv>=1.0.0

--- a/examples/workflow-fail/typescript/package.json
+++ b/examples/workflow-fail/typescript/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx index.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^8.3.0",
+    "@axonflow/sdk": "^8.5.0",
     "dotenv": "^16.3.1"
   },
   "devDependencies": {

--- a/examples/workflow-policy/go/go.mod
+++ b/examples/workflow-policy/go/go.mod
@@ -2,4 +2,4 @@ module workflow-policy-example
 
 go 1.21
 
-require github.com/getaxonflow/axonflow-sdk-go/v8 v8.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v8 v8.5.0

--- a/examples/workflow-policy/java/pom.xml
+++ b/examples/workflow-policy/java/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>8.3.0</version>
+            <version>8.5.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/workflow-policy/python/requirements.txt
+++ b/examples/workflow-policy/python/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=8.3.0
+axonflow>=8.5.0

--- a/examples/workflow-policy/typescript/package.json
+++ b/examples/workflow-policy/typescript/package.json
@@ -7,7 +7,7 @@
     "start": "npx tsx main.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^8.3.0"
+    "@axonflow/sdk": "^8.5.0"
   },
   "devDependencies": {
     "tsx": "^4.0.0",

--- a/examples/workflows/01-simple-sequential/go.mod
+++ b/examples/workflows/01-simple-sequential/go.mod
@@ -2,4 +2,4 @@ module github.com/getaxonflow/axonflow/examples/workflows/01-simple-sequential
 
 go 1.23
 
-require github.com/getaxonflow/axonflow-sdk-go/v8 v8.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v8 v8.5.0

--- a/examples/workflows/01-simple-sequential/package.json
+++ b/examples/workflows/01-simple-sequential/package.json
@@ -7,7 +7,7 @@
     "start": "npx ts-node main.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^8.3.0"
+    "@axonflow/sdk": "^8.5.0"
   },
   "devDependencies": {
     "ts-node": "^10.9.2",

--- a/examples/workflows/01-simple-sequential/pom.xml
+++ b/examples/workflows/01-simple-sequential/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>8.3.0</version>
+            <version>8.5.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/workflows/01-simple-sequential/requirements.txt
+++ b/examples/workflows/01-simple-sequential/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=8.3.0
+axonflow>=8.5.0

--- a/examples/workflows/02-parallel-execution/go.mod
+++ b/examples/workflows/02-parallel-execution/go.mod
@@ -2,4 +2,4 @@ module github.com/getaxonflow/axonflow/examples/workflows/02-parallel-execution
 
 go 1.23
 
-require github.com/getaxonflow/axonflow-sdk-go/v8 v8.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v8 v8.5.0

--- a/examples/workflows/02-parallel-execution/package.json
+++ b/examples/workflows/02-parallel-execution/package.json
@@ -7,7 +7,7 @@
     "start": "npx ts-node main.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^8.3.0"
+    "@axonflow/sdk": "^8.5.0"
   },
   "devDependencies": {
     "ts-node": "^10.9.2",

--- a/examples/workflows/02-parallel-execution/pom.xml
+++ b/examples/workflows/02-parallel-execution/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>8.3.0</version>
+            <version>8.5.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/workflows/02-parallel-execution/requirements.txt
+++ b/examples/workflows/02-parallel-execution/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=8.3.0
+axonflow>=8.5.0

--- a/examples/workflows/03-conditional-logic/go.mod
+++ b/examples/workflows/03-conditional-logic/go.mod
@@ -2,4 +2,4 @@ module github.com/getaxonflow/axonflow/examples/workflows/03-conditional-logic
 
 go 1.23
 
-require github.com/getaxonflow/axonflow-sdk-go/v8 v8.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v8 v8.5.0

--- a/examples/workflows/03-conditional-logic/package.json
+++ b/examples/workflows/03-conditional-logic/package.json
@@ -7,7 +7,7 @@
     "start": "npx ts-node main.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^8.3.0"
+    "@axonflow/sdk": "^8.5.0"
   },
   "devDependencies": {
     "ts-node": "^10.9.2",

--- a/examples/workflows/03-conditional-logic/pom.xml
+++ b/examples/workflows/03-conditional-logic/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>8.3.0</version>
+            <version>8.5.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/workflows/03-conditional-logic/requirements.txt
+++ b/examples/workflows/03-conditional-logic/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=8.3.0
+axonflow>=8.5.0

--- a/examples/workflows/04-travel-booking-fallbacks/go.mod
+++ b/examples/workflows/04-travel-booking-fallbacks/go.mod
@@ -2,4 +2,4 @@ module github.com/getaxonflow/axonflow/examples/workflows/04-travel-booking-fall
 
 go 1.23
 
-require github.com/getaxonflow/axonflow-sdk-go/v8 v8.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v8 v8.5.0

--- a/examples/workflows/04-travel-booking-fallbacks/package.json
+++ b/examples/workflows/04-travel-booking-fallbacks/package.json
@@ -7,7 +7,7 @@
     "start": "npx ts-node main.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^8.3.0"
+    "@axonflow/sdk": "^8.5.0"
   },
   "devDependencies": {
     "ts-node": "^10.9.2",

--- a/examples/workflows/04-travel-booking-fallbacks/pom.xml
+++ b/examples/workflows/04-travel-booking-fallbacks/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>8.3.0</version>
+            <version>8.5.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/workflows/04-travel-booking-fallbacks/requirements.txt
+++ b/examples/workflows/04-travel-booking-fallbacks/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=8.3.0
+axonflow>=8.5.0

--- a/examples/workflows/05-data-pipeline/go.mod
+++ b/examples/workflows/05-data-pipeline/go.mod
@@ -2,4 +2,4 @@ module github.com/getaxonflow/axonflow/examples/workflows/05-data-pipeline
 
 go 1.23
 
-require github.com/getaxonflow/axonflow-sdk-go/v8 v8.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v8 v8.5.0

--- a/examples/workflows/05-data-pipeline/package.json
+++ b/examples/workflows/05-data-pipeline/package.json
@@ -7,7 +7,7 @@
     "start": "npx ts-node main.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^8.3.0"
+    "@axonflow/sdk": "^8.5.0"
   },
   "devDependencies": {
     "ts-node": "^10.9.2",

--- a/examples/workflows/05-data-pipeline/pom.xml
+++ b/examples/workflows/05-data-pipeline/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>8.3.0</version>
+            <version>8.5.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/workflows/05-data-pipeline/requirements.txt
+++ b/examples/workflows/05-data-pipeline/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=8.3.0
+axonflow>=8.5.0

--- a/examples/workflows/06-multi-step-approval/go.mod
+++ b/examples/workflows/06-multi-step-approval/go.mod
@@ -2,4 +2,4 @@ module github.com/getaxonflow/axonflow/examples/workflows/06-multi-step-approval
 
 go 1.23
 
-require github.com/getaxonflow/axonflow-sdk-go/v8 v8.3.0
+require github.com/getaxonflow/axonflow-sdk-go/v8 v8.5.0

--- a/examples/workflows/06-multi-step-approval/package.json
+++ b/examples/workflows/06-multi-step-approval/package.json
@@ -7,7 +7,7 @@
     "start": "npx ts-node main.ts"
   },
   "dependencies": {
-    "@axonflow/sdk": "^8.3.0"
+    "@axonflow/sdk": "^8.5.0"
   },
   "devDependencies": {
     "ts-node": "^10.9.2",

--- a/examples/workflows/06-multi-step-approval/pom.xml
+++ b/examples/workflows/06-multi-step-approval/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>com.getaxonflow</groupId>
             <artifactId>axonflow-sdk</artifactId>
-            <version>8.3.0</version>
+            <version>8.5.0</version>
         </dependency>
         <!-- Override transitive jackson-core for CVE fix -->
         <dependency>

--- a/examples/workflows/06-multi-step-approval/requirements.txt
+++ b/examples/workflows/06-multi-step-approval/requirements.txt
@@ -1,1 +1,1 @@
-axonflow>=8.3.0
+axonflow>=8.5.0

--- a/platform/agent/capabilities.go
+++ b/platform/agent/capabilities.go
@@ -94,10 +94,10 @@ func getSDKCompatibility() SDKCompatInfo {
 		// Latest tag this platform was tested against. Kept in lockstep
 		// with each SDK's release-train tag.
 		RecommendedSDKVersion: map[string]string{
-			"python":     "8.4.0",
-			"typescript": "8.4.0",
-			"go":         "8.4.0",
-			"java":       "8.4.0",
+			"python":     "8.5.0",
+			"typescript": "8.5.0",
+			"go":         "8.5.0",
+			"java":       "8.5.0",
 		},
 	}
 }
@@ -138,13 +138,14 @@ func getPluginCompatibility() PluginCompatInfo {
 		// 1.5.3 ships the headersHelper ${CLAUDE_PLUGIN_ROOT} fix so the
 		// plugins send Basic auth correctly against self-hosted/Enterprise.
 		// codex stays 1.5.2 (its v8.5.2 fix was documentation-only; no codex
-		// 1.5.3 was cut); openclaw stays 2.6.1. Plugin tags are live on their
-		// registries (openclaw 2.6.1 on npm, claude/cursor 1.5.3 + codex
-		// 1.5.2 on ClawHub) — plugins below the recommended version receive
-		// an actionable upgrade-warning header on every governed call; the
-		// MinPluginVersion floor stays 1.4.0 / 2.4.0.
+		// 1.5.3 was cut); openclaw bumped 2.6.1 -> 2.6.5 to track its latest
+		// published release (the prior value lagged the registry). Plugin tags
+		// are live on their registries (openclaw 2.6.5 on npm, claude/cursor
+		// 1.5.3 + codex 1.5.2 on ClawHub) — plugins below the recommended
+		// version receive an actionable upgrade-warning header on every
+		// governed call; the MinPluginVersion floor stays 1.4.0 / 2.4.0.
 		RecommendedPluginVersion: map[string]string{
-			"openclaw":    "2.6.1",
+			"openclaw":    "2.6.5",
 			"claude-code": "1.5.3",
 			"cursor":      "1.5.3",
 			"codex":       "1.5.2",

--- a/platform/orchestrator/capabilities.go
+++ b/platform/orchestrator/capabilities.go
@@ -89,10 +89,10 @@ func getSDKCompatibility() SDKCompatInfo {
 		// Latest tag this platform was tested against. Kept in lockstep
 		// with each SDK's release-train tag.
 		RecommendedSDKVersion: map[string]string{
-			"python":     "8.4.0",
-			"typescript": "8.4.0",
-			"go":         "8.4.0",
-			"java":       "8.4.0",
+			"python":     "8.5.0",
+			"typescript": "8.5.0",
+			"go":         "8.5.0",
+			"java":       "8.5.0",
 		},
 	}
 }
@@ -127,11 +127,13 @@ func getPluginCompatibility() PluginCompatInfo {
 		// (#2308) did NOT change the plugin recommended-version. Bumped
 		// claude-code + cursor to 1.5.3 during the v8.5.2 release-train
 		// (headersHelper ${CLAUDE_PLUGIN_ROOT} Basic-auth fix); codex stays
-		// 1.5.2 (v8.5.2 fix was docs-only, no codex 1.5.3); openclaw stays
-		// 2.6.1; MinPluginVersion floor stays 1.4.0 / 2.4.0. Mirrors
+		// 1.5.2 (v8.5.2 fix was docs-only, no codex 1.5.3); openclaw bumped
+		// 2.6.1 -> 2.6.5 to track its latest published release (prior value
+		// lagged the registry; openclaw 2.6.5 is live on npm).
+		// MinPluginVersion floor stays 1.4.0 / 2.4.0. Mirrors
 		// platform/agent/capabilities.go.
 		RecommendedPluginVersion: map[string]string{
-			"openclaw":    "2.6.1",
+			"openclaw":    "2.6.5",
 			"claude-code": "1.5.3",
 			"cursor":      "1.5.3",
 			"codex":       "1.5.2",

--- a/platform/orchestrator/capabilities_test.go
+++ b/platform/orchestrator/capabilities_test.go
@@ -28,10 +28,10 @@ func TestSDKCompatibilityPinnedToReleaseTrain(t *testing.T) {
 		"java":       "8.0.0",
 	}
 	wantRecommended := map[string]string{
-		"python":     "8.4.0",
-		"typescript": "8.4.0",
-		"go":         "8.4.0",
-		"java":       "8.4.0",
+		"python":     "8.5.0",
+		"typescript": "8.5.0",
+		"go":         "8.5.0",
+		"java":       "8.5.0",
 	}
 
 	for lang, want := range wantMin {
@@ -65,7 +65,7 @@ func TestPluginCompatibilityPinnedToReleaseTrain(t *testing.T) {
 		"codex":       "1.4.0",
 	}
 	wantRecommended := map[string]string{
-		"openclaw":    "2.6.1",
+		"openclaw":    "2.6.5",
 		"claude-code": "1.5.3",
 		"cursor":      "1.5.3",
 		"codex":       "1.5.2",


### PR DESCRIPTION
Follow-on community sync after the v8.6.0 release sync. Examples and docs only — no platform/ or policy-engine changes.

- Examples: bump the pinned AxonFlow SDK to 8.5.0 and the openclaw plugin to 2.6.5 across the example projects (Go, Python, TypeScript, Java dependency manifests).
- README: add the Claude Desktop governance plugin to the integrations list.