### PR TITLE
docs: consolidate product demo links

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,11 +98,11 @@ All policies are configurable. Teams typically start in observe-only mode and en
 
 **[Full Documentation](https://docs.getaxonflow.com)** · **[Getting Started Guide](https://docs.getaxonflow.com/docs/getting-started/)** · **[API Reference](./docs/api/)**
 
-**Community Quickstart Demo (Code + Terminal, 2.5 min):** Governed calls, PII block, Gateway Mode with LangChain/CrewAI, and MAP from YAML — [Watch on YouTube](https://youtu.be/BSqU1z0xxCo)
+**Product demos (Platform + Fraud & Risk):** See runtime enforcement, HITL approvals, audit evidence, cost visibility, and agentic payment controls: [Watch the demos](https://getaxonflow.com/demo/?utm_source=github&utm_medium=readme&utm_campaign=product_demo&utm_content=axonflow)
 
-**Runtime Control Demo (Portal + Workflow, 2.5 min):** Want the product/runtime view? See approvals, retry safety, execution state, and the audit viewer in action — [Watch on YouTube](https://youtu.be/sRTv2uF0sxY)
+**Community Quickstart walkthrough (2.5 min):** See governed calls, PII blocking, Gateway Mode with LangChain/CrewAI, and MAP from YAML: [Watch on YouTube](https://youtu.be/BSqU1z0xxCo)
 
-**Architecture deep dive (12 min):** How the control plane works, policy enforcement flow, and multi-agent planning — [Watch on YouTube](https://youtu.be/Q2CZ1qnquhg)
+**Architecture deep dive (12 min):** How the control plane works, policy enforcement flow, and multi-agent planning: [Watch on YouTube](https://youtu.be/Q2CZ1qnquhg)
 
 ---
 
@@ -143,7 +143,7 @@ This creates a WCP workflow, runs step-level gate checks, records a step ledger,
 
 ## Quick Start
 
-If you want to see how this looks before setting it up, here's a short demo: [Community Quickstart walkthrough (2.5 min)](https://youtu.be/BSqU1z0xxCo)
+If you want to see how this looks before setting it up, watch the [Community Quickstart walkthrough (2.5 min)](https://youtu.be/BSqU1z0xxCo).
 
 **Prerequisites:** [Docker Desktop](https://docs.docker.com/get-docker/) installed and running.
 


### PR DESCRIPTION
## Summary
- make the new product demo page the canonical destination for broad product and Fraud & Risk demos
- retain the Community Quickstart as a specifically labeled technical walkthrough for PII blocking, Gateway Mode, and MAP
- keep the architecture deep dive as a direct video

## Follow-up
After this merges, run pull-from-community in the enterprise repository so the README stays synchronized.

## Verification
- git diff --check
- residual demo-link scan
- YouTube public metadata verification