### PR TITLE
docs(readme): correct the Community Quickstart video runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ All policies are configurable. Teams typically start in observe-only mode and en
 
 **Product demos (Platform + Fraud & Risk):** See runtime enforcement, HITL approvals, audit evidence, cost visibility, and agentic payment controls: [Watch the demos](https://getaxonflow.com/demo/?utm_source=github&utm_medium=readme&utm_campaign=product_demo&utm_content=axonflow)
 
-**Community Quickstart walkthrough (2.5 min):** See governed calls, PII blocking, Gateway Mode with LangChain/CrewAI, and MAP from YAML: [Watch on YouTube](https://youtu.be/BSqU1z0xxCo)
+**Community Quickstart walkthrough (2 min):** See governed calls, PII blocking, Gateway Mode with LangChain/CrewAI, and MAP from YAML: [Watch on YouTube](https://youtu.be/BSqU1z0xxCo)
 
 **Architecture deep dive (12 min):** How the control plane works, policy enforcement flow, and multi-agent planning: [Watch on YouTube](https://youtu.be/Q2CZ1qnquhg)
 
@@ -143,7 +143,7 @@ This creates a WCP workflow, runs step-level gate checks, records a step ledger,
 
 ## Quick Start
 
-If you want to see how this looks before setting it up, watch the [Community Quickstart walkthrough (2.5 min)](https://youtu.be/BSqU1z0xxCo).
+If you want to see how this looks before setting it up, watch the [Community Quickstart walkthrough (2 min)](https://youtu.be/BSqU1z0xxCo).
 
 **Prerequisites:** [Docker Desktop](https://docs.docker.com/get-docker/) installed and running.
 


### PR DESCRIPTION
One factual correction to a demo video label on this README. Prose only, no code, no behaviour change.

## The Community Quickstart runtime was never right

The video at <https://youtu.be/BSqU1z0xxCo> is **2:05**, not 2.5 min. Both README lines that carry the label are corrected (the callout at line 103 and the pointer at line 146).

```diff
-**Community Quickstart walkthrough (2.5 min):** See governed calls, PII blocking, ...
+**Community Quickstart walkthrough (2 min):** See governed calls, PII blocking, ...

-... watch the [Community Quickstart walkthrough (2.5 min)](https://youtu.be/BSqU1z0xxCo).
+... watch the [Community Quickstart walkthrough (2 min)](https://youtu.be/BSqU1z0xxCo).
```

## Runtime verification

Fetched the YouTube watch page directly rather than taking the figure on trust:

```
$ curl -s "https://www.youtube.com/watch?v=BSqU1z0xxCo" | grep -o '.\{140\}"lengthSeconds":"[0-9]*"'
tAudioTrackIndex":0}},"videoDetails":{"videoId":"BSqU1z0xxCo","title":"AxonFlow - Execution
Control for Production LLM and Agent Workflows","lengthSeconds":"125"

$ curl -s "https://www.youtube.com/watch?v=BSqU1z0xxCo" | grep -o '"approxDurationMs":"[0-9]*"' | sort -u
"approxDurationMs":"125440"
"approxDurationMs":"125461"
"approxDurationMs":"125480"
```

**125 seconds = 2:05.** Two independent fields in the player response agree: `videoDetails.lengthSeconds` is `125`, and the per stream `approxDurationMs` values are all ~125.4 s. The page's own chapter list ends at `01:46 - Why AxonFlow (wrap-up)`, which is consistent with a 2:05 runtime.

(The `playerMicroformatRenderer` reports `126`; that field ceiling-rounds. `videoDetails` is the authoritative figure.)

## Not changed

The Banking workflow video (<https://youtu.be/sRTv2uF0sxY>) genuinely is 2.5 min: its `lengthSeconds` is `151`, i.e. 2:31. It is not referenced in this README, but noting it so the `2.5 min` string is not swept globally by a later pass.

The sibling repos also carry a "Three short videos covering different angles of the platform:" line that a recent link sweep left under-counting. This README uses a different prose format and has no such count line, so that half of the correction does not apply here.

## Mirror lockstep

`getaxonflow/axonflow` is the public mirror of `getaxonflow/axonflow-enterprise`, and these two READMEs are byte-identical. They were identical before this change (`md5 5704e0f1...`) and are identical after it (`md5 b5bb27fd...`). The matching change is filed as an ordinary PR in the other repo so the two land in lockstep. **No sync workflow was run** (`sync-community-repo.yml` and `pull-from-community.yml` are both `workflow_dispatch` only, so an ordinary PR cannot trigger either).
