### PR TITLE
chore(ci): suite-gate floor and the gateway-adapters Dockerfile

### DIFF
--- a/.github/scripts/suite-gate.py
+++ b/.github/scripts/suite-gate.py
@@ -23,6 +23,32 @@ OUTCOMES, all three of them stated so none is a fallthrough:
   * every observed suite succeeded or skipped          -> pass
 A `skipped` suite is a pass: a queue build legitimately skips a suite whose
 own job-level conditions exclude it.
+
+THE SANITY FLOOR IS A PROPERTY OF THE TREE, NOT A CONSTANT THAT FITS ONE OF
+THEM. This file SYNCS to the community mirror, and the mirror's tree is not
+this one: the sync strips runtime-e2e/ and every enterprise-only workflow, so
+the mirror carries 2 stack-booting merge_group workflows against this tree's
+76. The enterprise floor of 20 is therefore unreachable on the mirror BY
+CONSTRUCTION, and it failed there exactly that way - "only 2 stack-booting
+workflows declare merge_group (sanity floor 20)" on the v10.4.0 sync PR's
+queue build (getaxonflow/axonflow run 34066582583).
+
+So the floor is chosen from what the CHECKED-OUT TREE CONTAINS, the same
+marker scripts/lint-trap-handlers-exit.sh and
+scripts/lint-hitl-queue-choke-point.sh use, and never from "the count looks
+small" - a gate that decides it must be on the mirror because it found few
+suites is a gate that excuses a broken selector on the tree that has many.
+  * enterprise tree -> MIN_SUITE_RUNS, unchanged at 20.
+  * community tree  -> the count of stack-booting workflows the mirror's own
+    tree carries, and never below 1. That is STRICTER than a constant: every
+    stack-booting workflow that reached the mirror must also declare
+    merge_group, so a selector that matches nothing fails on the floor of 1,
+    a broken `on:` parse fails at 0 < 2, and a mirrored suite that boots a
+    stack outside the queue is named rather than tolerated.
+
+`--check-floor [ROOT]` runs that decision alone, with no API call, and is what
+tests/regression-test-required/suite_gate_floor_is_edition_aware_test.sh
+drives over fixture trees in both directions.
 """
 import glob
 import json
@@ -80,6 +106,58 @@ def suite_workflow_names(workflows_dir=".github/workflows", require_merge_group=
     return names
 
 
+def is_community_tree(root="."):
+    """True for the tree the community sync produces.
+
+    The SAME marker scripts/lint-hitl-queue-choke-point.sh and
+    scripts/lint-trap-handlers-exit.sh use, so the three guards agree on what
+    edition they are standing in: the mirror carries the mirrored lint.yml and
+    NOT sync-community-repo.yml, because the sync excludes its own workflow.
+    Read from what the tree CONTAINS. Never inferred from how many suites were
+    found - that inference is the one a broken selector satisfies.
+    """
+    wf = os.path.join(root, ".github", "workflows")
+    return (os.path.isfile(os.path.join(wf, "lint.yml"))
+            and not os.path.isfile(os.path.join(wf, "sync-community-repo.yml")))
+
+
+def sanity_floor(root="."):
+    """(floor, reason, booting) for this tree. `booting` is None off the mirror.
+
+    See the module header. On the enterprise tree this returns MIN_SUITE_RUNS
+    unchanged, so nothing about the enterprise gate moves.
+    """
+    wf = os.path.join(root, ".github", "workflows")
+    if not is_community_tree(root):
+        return MIN_RUNS, f"the enterprise calibration MIN_SUITE_RUNS={MIN_RUNS}", None
+    booting = suite_workflow_names(wf, require_merge_group=False)
+    return (max(1, len(booting)),
+            f"derived from this community tree, which carries {len(booting)} "
+            f"stack-booting workflow(s) - every one of them must declare merge_group",
+            booting)
+
+
+def floor_holds(root="."):
+    """Apply the sanity floor to ROOT. Prints its own verdict; returns a bool.
+
+    main() calls exactly this, so the regression suite drives the production
+    decision rather than a second copy of it.
+    """
+    wf = os.path.join(root, ".github", "workflows")
+    suites = suite_workflow_names(wf, require_merge_group=True)
+    floor, reason, booting = sanity_floor(root)
+    if len(suites) < floor:
+        print(f"::error::only {len(suites)} stack-booting workflows declare merge_group "
+              f"(sanity floor {floor}, {reason}). "
+              "The selector is broken, not the day quiet.")
+        for n in sorted(set(booting or {}) - set(suites)):
+            print(f"::error::  boots a stack but declares no merge_group: {n}")
+        return False
+    print(f"sanity floor {floor} met by {len(suites)} merge_group suite(s) "
+          f"({reason})")
+    return True
+
+
 def runs_at_sha():
     """EVERY run at this SHA, paginated.
 
@@ -110,9 +188,7 @@ def main():
     # EXPECTED is derived, not guessed: every stack-booting workflow that
     # declares merge_group must produce a completed run for this queue build.
     suites = suite_workflow_names(require_merge_group=True)
-    if len(suites) < MIN_RUNS:
-        print(f"::error::only {len(suites)} stack-booting workflows declare merge_group "
-              f"(sanity floor {MIN_RUNS}). The selector is broken, not the day quiet.")
+    if not floor_holds("."):
         return 1
     print(f"expecting a completed run from each of {len(suites)} merge_group suites "
           f"at {SHA[:9]}")
@@ -161,4 +237,8 @@ def main():
 
 
 if __name__ == "__main__":
+    # `--check-floor [ROOT]`: the sanity-floor decision alone, no API call, so
+    # it can be driven over a fixture tree. Anything else is the real gate.
+    if len(sys.argv) > 1 and sys.argv[1] == "--check-floor":
+        sys.exit(0 if floor_holds(sys.argv[2] if len(sys.argv) > 2 else ".") else 1)
     sys.exit(main())

--- a/.github/workflows/suite-gate.yml
+++ b/.github/workflows/suite-gate.yml
@@ -128,6 +128,20 @@ jobs:
           # than the day quiet. Sufficiency itself is a derived set comparison
           # (every such workflow must produce a completed run; a scoped-out
           # suite still reports completed/skipped, which counts).
+          #
+          # THIS IS THE ENTERPRISE CALIBRATION AND IT APPLIES ONLY HERE. This
+          # workflow and its script both SYNC to the community mirror, whose
+          # tree the sync strips of runtime-e2e/ and every enterprise-only
+          # workflow - 2 stack-booting merge_group workflows there against 76
+          # here. 20 is unreachable on that tree by construction, and it failed
+          # there exactly that way on the v10.4.0 sync PR's queue build
+          # (getaxonflow/axonflow run 34066582583). suite-gate.py therefore
+          # reads the EDITION OFF THE CHECKED-OUT TREE - the same marker
+          # scripts/lint-trap-handlers-exit.sh and
+          # scripts/lint-hitl-queue-choke-point.sh use, never "the count looks
+          # small" - and on the mirror derives the floor from the mirror's own
+          # census instead of from this number. Leaving this value alone is
+          # what keeps the enterprise floor at 20.
           MIN_SUITE_RUNS: '20'
         run: |
           set -euo pipefail

--- a/platform/gateway-adapters/cmd/axonflow-gateway-adapters/Dockerfile
+++ b/platform/gateway-adapters/cmd/axonflow-gateway-adapters/Dockerfile
@@ -48,8 +48,18 @@ COPY platform/go.mod platform/go.sum platform/
 # before any source is copied. Without it the build fails with
 # "reading decision/go.mod: no such file or directory".
 COPY platform/decision/go.mod platform/decision/go.sum platform/decision/
-RUN cd platform && go mod download
 
+# WORKDIR, not `RUN cd platform && ...` (Trivy DS-0013). `cd` in a RUN is scoped
+# to that one shell, so the directory has to be re-entered by every later step
+# that needs it and is invisible to anything reading the image's metadata;
+# WORKDIR sets it for real. The build semantics are unchanged - every command
+# below runs in exactly the directory it ran in before, which is why the
+# working directory is walked back to /go/src/axonflow around the COPY (whose
+# destination is WORKDIR-relative) and around the grpc-health-probe install.
+WORKDIR /go/src/axonflow/platform
+RUN go mod download
+
+WORKDIR /go/src/axonflow
 COPY platform/ platform/
 
 # Static build: CGO disabled, trimmed paths, stripped symbols. The adapter has
@@ -61,10 +71,13 @@ COPY platform/ platform/
 # enterprise-distributed artifact report `community`, so if this image is ever
 # shipped AS Enterprise, add the tag here rather than pinning the constant in
 # telemetry.go. See the comment on gatewayadapters.Edition.
-RUN cd platform && CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+WORKDIR /go/src/axonflow/platform
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
     go build -trimpath -ldflags="-s -w -X axonflow/platform/shared/version.Version=${AXONFLOW_VERSION}" \
     -o /out/axonflow-gateway-adapters \
     ./gateway-adapters/cmd/axonflow-gateway-adapters
+
+WORKDIR /go/src/axonflow
 
 # grpc_health_probe for exec-based health checks (docker HEALTHCHECK below and
 # ECS container healthCheck): the adapter serves standard gRPC health

--- a/tests/regression-test-required/suite_gate_floor_is_edition_aware_test.sh
+++ b/tests/regression-test-required/suite_gate_floor_is_edition_aware_test.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# suite_gate_floor_is_edition_aware_test.sh
+#
+# THE BUG CLASS: A FLOOR CALIBRATED ON ONE TREE, SHIPPED TO TWO.
+#
+# .github/scripts/suite-gate.py refuses to report success unless the tree
+# carries at least MIN_SUITE_RUNS stack-booting workflows declaring
+# merge_group - a real anti-vacuity check, because "no failures found" over an
+# empty selector reads exactly like a green build.
+#
+# That script and its workflow BOTH SYNC to the community mirror, and the
+# mirror is not this tree: the sync strips runtime-e2e/ and every
+# enterprise-only workflow, leaving 2 stack-booting merge_group workflows
+# against this tree's 76. A floor of 20 can never be met there, and it was not:
+# the v10.4.0 sync PR's queue build failed with
+#
+#   only 2 stack-booting workflows declare merge_group (sanity floor 20).
+#   The selector is broken, not the day quiet.
+#
+# (getaxonflow/axonflow run 34066582583, job 101576291763) - a gate reporting a
+# broken selector on a tree whose selector was working perfectly.
+#
+# THE FIX, and what this test pins: the edition is read off what the
+# CHECKED-OUT TREE CONTAINS - the same marker scripts/lint-trap-handlers-exit.sh
+# and scripts/lint-hitl-queue-choke-point.sh use, lint.yml present and
+# sync-community-repo.yml absent - and NEVER from "the count looks small",
+# which is the inference a genuinely broken selector also satisfies. The
+# enterprise floor stays 20; the mirror's is derived from the mirror's own
+# census.
+#
+# BOTH DIRECTIONS, on fixtures, because a floor that only ever passes is not a
+# floor:
+#   1. enterprise tree, 20 suites          -> passes, at floor 20
+#   2. enterprise tree, 19 suites          -> FAILS  (the floor did not move)
+#   3. enterprise tree, selector matched 0 -> FAILS  (the original purpose)
+#   4. community tree, 2 of 2              -> passes (the outage, now green)
+#   5. community tree, 1 of 2              -> FAILS, naming the workflow
+#   6. community tree, selector matched 0  -> FAILS  (floor never below 1)
+#   7. the marker itself separates the two trees, both ways
+#   8. this repository's REAL tree passes its own floor - edition-aware, so
+#      this file is honest on the mirror it syncs to as well.
+#
+# Case 4 is the delete-the-feature control: revert the fix and it goes red.
+# Case 2 is the other one: loosen the enterprise floor and it goes red.
+#
+# Run: bash tests/regression-test-required/suite_gate_floor_is_edition_aware_test.sh
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+GATE="$REPO_ROOT/.github/scripts/suite-gate.py"
+
+PASS=0
+FAIL=0
+ok()  { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+bad() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+[ -f "$GATE" ] || { echo "  FAIL: $GATE is missing; this test cannot vacuously pass"; exit 1; }
+command -v python3 >/dev/null 2>&1 || {
+  echo "  FAIL: python3 is unavailable; a guard that cannot run must not report success"; exit 1; }
+python3 -c 'import yaml' 2>/dev/null || {
+  echo "  FAIL: PyYAML is unavailable; the floor decision cannot be driven, and a guard that cannot run must not pass"; exit 1; }
+
+tmp="$(mktemp -d)" || exit 1
+trap 'rm -rf "$tmp"' EXIT
+
+# ---------------------------------------------------------------------------
+# Fixture builders. A fixture tree is a bare .github/workflows holding only
+# what the decision reads, so nothing else in it can answer for the property
+# under test.
+#
+# `edition` is set by the MARKER FILES, never by the suite count - which is the
+# whole point of the change and has to be built that way here too.
+# ---------------------------------------------------------------------------
+mk_tree() {  # mk_tree <dir> <enterprise|community> <n_booting> <n_of_them_with_merge_group>
+  local dir="$1" edition="$2" n="$3" mg="$4" i
+  mkdir -p "$dir/.github/workflows"
+  # lint.yml is the mirrored-lint half of the marker and is present on both.
+  printf 'name: Lint\non:\n  pull_request:\njobs:\n  lint:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo lint\n' \
+    > "$dir/.github/workflows/lint.yml"
+  if [ "$edition" = enterprise ]; then
+    # The sync excludes its own workflow, so its PRESENCE is the enterprise half.
+    printf 'name: Sync Community Repo\non:\n  workflow_dispatch:\njobs:\n  sync:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo sync\n' \
+      > "$dir/.github/workflows/sync-community-repo.yml"
+  fi
+  for ((i = 1; i <= n; i++)); do
+    {
+      printf 'name: Fixture Suite %02d\non:\n' "$i"
+      if [ "$i" -le "$mg" ]; then printf '  merge_group:\n'; fi
+      printf '  workflow_dispatch:\njobs:\n  suite:\n    runs-on: ubuntu-latest\n    steps:\n      - run: docker compose up -d\n'
+    } > "$dir/.github/workflows/fixture-suite-$(printf '%02d' "$i")-e2e.yml"
+  done
+}
+
+# mk_tree_no_boot: the same tree with steps that boot NOTHING - what a broken
+# BOOTS selector produces, without having to mutate the script to get there.
+mk_tree_no_boot() {  # mk_tree_no_boot <dir> <enterprise|community> <n>
+  local dir="$1" edition="$2" n="$3" i
+  mk_tree "$dir" "$edition" 0 0
+  for ((i = 1; i <= n; i++)); do
+    printf 'name: Fixture Suite %02d\non:\n  merge_group:\njobs:\n  suite:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo nothing boots here\n' "$i" \
+      > "$dir/.github/workflows/fixture-suite-$(printf '%02d' "$i")-e2e.yml"
+  done
+}
+
+# run_floor DIR -> rc, with stdout captured in $OUT
+OUT=""
+run_floor() {
+  OUT="$(python3 "$GATE" --check-floor "$1" 2>&1)"
+  return $?
+}
+
+check() {  # check <label> <expected-rc> <dir> [substring that must appear]
+  local label="$1" want="$2" dir="$3" needle="${4:-}"
+  run_floor "$dir"
+  local rc=$?
+  if [ "$rc" -ne "$want" ]; then
+    bad "$label (expected rc=$want, got rc=$rc)"
+    printf '%s\n' "$OUT" | sed 's/^/        /'
+    return
+  fi
+  if [ -n "$needle" ] && ! printf '%s' "$OUT" | grep -qF -- "$needle"; then
+    bad "$label (rc correct but the verdict never said: $needle)"
+    printf '%s\n' "$OUT" | sed 's/^/        /'
+    return
+  fi
+  ok "$label"
+}
+
+echo "Suite Gate sanity floor: edition-aware, both directions"
+
+# --- 1-3. the enterprise tree: the floor of 20 is exactly where it was -------
+mk_tree "$tmp/ent20" enterprise 20 20
+check "enterprise tree, 20 merge_group suites: passes at floor 20" \
+  0 "$tmp/ent20" "sanity floor 20 met by 20"
+
+mk_tree "$tmp/ent19" enterprise 19 19
+check "enterprise tree, 19 merge_group suites: FAILS - the floor did not move" \
+  1 "$tmp/ent19" "sanity floor 20"
+
+mk_tree_no_boot "$tmp/entzero" enterprise 30
+check "enterprise tree, selector matched nothing: FAILS - the original purpose" \
+  1 "$tmp/entzero" "The selector is broken, not the day quiet."
+
+# --- 4-6. the community mirror: derived from its own census -----------------
+mk_tree "$tmp/com22" community 2 2
+check "community tree, 2 of 2: passes - the floor of 20 no longer reaches it" \
+  0 "$tmp/com22" "sanity floor 2 met by 2"
+
+mk_tree "$tmp/com21" community 2 1
+check "community tree, a mirrored suite drops merge_group: FAILS" \
+  1 "$tmp/com21" "boots a stack but declares no merge_group: Fixture Suite 02"
+
+mk_tree_no_boot "$tmp/comzero" community 3
+check "community tree, selector matched nothing: FAILS - the floor is never below 1" \
+  1 "$tmp/comzero" "sanity floor 1"
+
+# --- 7. the marker itself, both ways ---------------------------------------
+# A tree carrying BOTH marker files is enterprise; the same tree without the
+# sync workflow is community. Nothing but the marker changes between them, so
+# a passing pair here is the marker doing the deciding.
+mk_tree "$tmp/marker" enterprise 2 2
+check "both marker files present -> enterprise, so 2 suites FAIL the floor of 20" \
+  1 "$tmp/marker" "the enterprise calibration MIN_SUITE_RUNS=20"
+rm -f "$tmp/marker/.github/workflows/sync-community-repo.yml"
+check "same tree, sync workflow removed -> community, and the same 2 suites pass" \
+  0 "$tmp/marker" "derived from this community tree"
+
+# --- 8. the real tree, edition-aware -----------------------------------------
+# This file syncs to the mirror, so it must be true on the mirror's own inputs.
+# The assertion is the same either way - the tree passes its own floor - and
+# the REASON it passes is asserted per edition, so a mirror checkout is not
+# quietly accepting the enterprise wording or vice versa.
+if [ -f "$REPO_ROOT/.github/workflows/lint.yml" ] && \
+   [ ! -f "$REPO_ROOT/.github/workflows/sync-community-repo.yml" ]; then
+  check "this COMMUNITY checkout passes its own derived floor" \
+    0 "$REPO_ROOT" "derived from this community tree"
+else
+  check "this ENTERPRISE checkout passes its own floor of 20" \
+    0 "$REPO_ROOT" "the enterprise calibration MIN_SUITE_RUNS=20"
+fi
+
+echo
+echo "  $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1
+exit 0


### PR DESCRIPTION
chore(ci): the Suite Gate floor is derived from this repository's own tree

The suite-gate sanity floor was calibrated to a tree that carries far more
stack-booting suites than this one, so it could never hold here and failed
every queue build with "the selector is broken, not the day quiet". The floor
is now derived from the workflows this repository actually carries, and it is
strict: every stack-booting workflow present must declare merge_group.

Also: the gateway-adapters image builds with WORKDIR rather than `RUN cd`,
which is what the Dockerfile linter asks for and what the build already meant.